### PR TITLE
Return reasoning field in test/benchmark status API

### DIFF
--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -184,6 +184,7 @@ class TestCaseResult(BaseModel):
 
     name: Optional[str] = None  # Test name, present during in-progress and done states
     passed: Optional[bool] = None  # Only present when done
+    reasoning: Optional[str] = None  # LLM judge reasoning or deterministic diff; null for passing tool call tests
     output: Optional[TestOutput] = None  # Only present when done
     test_case: Optional[Dict[str, Any]] = None  # Only present when done
 
@@ -461,6 +462,7 @@ def _parse_agent_test_results(results_data: Optional[List[dict]]) -> List[dict]:
             {
                 "name": test_case.get("name"),
                 "passed": metrics.get("passed", False),
+                "reasoning": metrics.get("reasoning"),
                 "output": {
                     "response": output_data.get("response"),
                     "tool_calls": output_data.get("tool_calls"),


### PR DESCRIPTION
## Summary
- Adds `reasoning` field to `TestCaseResult` model
- Extracts `metrics.reasoning` in `_parse_agent_test_results` so it flows through to all status API responses

## Details
The `reasoning` field was already being written to `results.json` by calibrate but was never included in the API response. This change passes it through for both single LLM test runs and benchmarks.

| Scenario | `reasoning` value |
|---|---|
| Response eval (pass or fail) | LLM judge explanation |
| Tool call eval — failed | Deterministic diff string |
| Tool call eval — passed | `null` |

## Test plan
- [ ] Run an LLM unit test and confirm `reasoning` appears in the status API response for response-type evals
- [ ] Run a benchmark and confirm `reasoning` appears in `model_results[].test_results[].reasoning`
- [ ] Confirm passing tool call tests return `reasoning: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)