### PR TITLE
Add public sharing for STT / TTS / LLM test / benchmark / simulation runs

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -2406,14 +2406,26 @@ def update_job_visibility(
         return cursor.rowcount > 0
 
 
-def get_job_by_share_token(share_token: str) -> Optional[Dict[str, Any]]:
-    """Get a job by its share_token."""
+def get_job_by_share_token(
+    share_token: str, job_type: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Get a job by its share_token, optionally restricted to a specific job type.
+
+    Always filters to is_public = 1. Pass job_type (e.g. 'stt-eval', 'tts-eval')
+    to prevent tokens from one resource kind being accepted by a different endpoint.
+    """
     with get_db_connection() as conn:
         cursor = conn.cursor()
-        cursor.execute(
-            "SELECT * FROM jobs WHERE share_token = ? AND is_public = 1",
-            (share_token,),
-        )
+        if job_type:
+            cursor.execute(
+                "SELECT * FROM jobs WHERE share_token = ? AND is_public = 1 AND type = ?",
+                (share_token, job_type),
+            )
+        else:
+            cursor.execute(
+                "SELECT * FROM jobs WHERE share_token = ? AND is_public = 1",
+                (share_token,),
+            )
         row = cursor.fetchone()
         if row:
             return _parse_job_row(row)
@@ -2692,14 +2704,27 @@ def update_agent_test_job_visibility(
         return cursor.rowcount > 0
 
 
-def get_agent_test_job_by_share_token(share_token: str) -> Optional[Dict[str, Any]]:
-    """Get an agent test job by its share_token."""
+def get_agent_test_job_by_share_token(
+    share_token: str, job_type: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Get an agent test job by its share_token, optionally restricted to a specific type.
+
+    Always filters to is_public = 1. Pass job_type (e.g. 'llm-unit-test',
+    'llm-benchmark') to prevent test-run tokens from resolving on the benchmark
+    endpoint and vice versa.
+    """
     with get_db_connection() as conn:
         cursor = conn.cursor()
-        cursor.execute(
-            "SELECT * FROM agent_test_jobs WHERE share_token = ? AND is_public = 1",
-            (share_token,),
-        )
+        if job_type:
+            cursor.execute(
+                "SELECT * FROM agent_test_jobs WHERE share_token = ? AND is_public = 1 AND type = ?",
+                (share_token, job_type),
+            )
+        else:
+            cursor.execute(
+                "SELECT * FROM agent_test_jobs WHERE share_token = ? AND is_public = 1",
+                (share_token,),
+            )
         row = cursor.fetchone()
         if row:
             return _parse_agent_test_job_row(row)

--- a/src/db.py
+++ b/src/db.py
@@ -407,6 +407,21 @@ def init_db():
         except sqlite3.OperationalError:
             pass
 
+        # Add is_public and share_token columns for public sharing feature
+        for table in ("jobs", "agent_test_jobs", "simulation_jobs"):
+            try:
+                cursor.execute(
+                    f"ALTER TABLE {table} ADD COLUMN is_public INTEGER NOT NULL DEFAULT 0"
+                )
+            except sqlite3.OperationalError:
+                pass
+            try:
+                cursor.execute(
+                    f"ALTER TABLE {table} ADD COLUMN share_token TEXT DEFAULT NULL"
+                )
+            except sqlite3.OperationalError:
+                pass
+
         conn.commit()
 
         # Create default user if not exists and update existing rows with NULL user_id
@@ -2377,6 +2392,34 @@ def update_job(
         return updated
 
 
+def update_job_visibility(
+    job_uuid: str, is_public: bool, share_token: Optional[str]
+) -> bool:
+    """Update is_public and share_token for a job. Returns True if the job was found."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE jobs SET is_public = ?, share_token = ?, updated_at = CURRENT_TIMESTAMP WHERE uuid = ?",
+            (1 if is_public else 0, share_token, job_uuid),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def get_job_by_share_token(share_token: str) -> Optional[Dict[str, Any]]:
+    """Get a job by its share_token."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM jobs WHERE share_token = ? AND is_public = 1",
+            (share_token,),
+        )
+        row = cursor.fetchone()
+        if row:
+            return _parse_job_row(row)
+        return None
+
+
 def delete_job(job_uuid: str) -> bool:
     """Delete a job. Returns True if the job was found and deleted."""
     with get_db_connection() as conn:
@@ -2479,6 +2522,43 @@ def get_all_agent_test_jobs(job_type: Optional[str] = None) -> List[Dict[str, An
             )
         else:
             cursor.execute("SELECT * FROM agent_test_jobs ORDER BY created_at DESC")
+        rows = cursor.fetchall()
+        return [_parse_agent_test_job_row(row) for row in rows]
+
+
+def get_agent_test_jobs_for_user(
+    user_id: str, job_type: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Get all agent test jobs belonging to a user (across all their agents).
+
+    Joins agent_test_jobs with agents so that each returned dict includes
+    ``agent_name`` and ``agent_id`` alongside the normal job fields.
+    Results are ordered newest-updated-first.
+    """
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        if job_type:
+            cursor.execute(
+                """
+                SELECT atj.*, a.name AS agent_name, a.uuid AS agent_id
+                FROM agent_test_jobs atj
+                JOIN agents a ON atj.agent_id = a.uuid
+                WHERE a.user_id = ? AND a.deleted_at IS NULL AND atj.type = ?
+                ORDER BY atj.updated_at DESC
+                """,
+                (user_id, job_type),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT atj.*, a.name AS agent_name, a.uuid AS agent_id
+                FROM agent_test_jobs atj
+                JOIN agents a ON atj.agent_id = a.uuid
+                WHERE a.user_id = ? AND a.deleted_at IS NULL
+                ORDER BY atj.updated_at DESC
+                """,
+                (user_id,),
+            )
         rows = cursor.fetchall()
         return [_parse_agent_test_job_row(row) for row in rows]
 
@@ -2596,6 +2676,34 @@ def update_agent_test_job(
         if updated:
             logger.info(f"Updated agent test job with UUID: {job_uuid}")
         return updated
+
+
+def update_agent_test_job_visibility(
+    job_uuid: str, is_public: bool, share_token: Optional[str]
+) -> bool:
+    """Update is_public and share_token for an agent test job. Returns True if found."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE agent_test_jobs SET is_public = ?, share_token = ?, updated_at = CURRENT_TIMESTAMP WHERE uuid = ?",
+            (1 if is_public else 0, share_token, job_uuid),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def get_agent_test_job_by_share_token(share_token: str) -> Optional[Dict[str, Any]]:
+    """Get an agent test job by its share_token."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM agent_test_jobs WHERE share_token = ? AND is_public = 1",
+            (share_token,),
+        )
+        row = cursor.fetchone()
+        if row:
+            return _parse_agent_test_job_row(row)
+        return None
 
 
 def delete_agent_test_job(job_uuid: str) -> bool:
@@ -2838,6 +2946,34 @@ def update_simulation_job(
         if updated:
             logger.info(f"Updated simulation job with UUID: {job_uuid}")
         return updated
+
+
+def update_simulation_job_visibility(
+    job_uuid: str, is_public: bool, share_token: Optional[str]
+) -> bool:
+    """Update is_public and share_token for a simulation job. Returns True if found."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE simulation_jobs SET is_public = ?, share_token = ?, updated_at = CURRENT_TIMESTAMP WHERE uuid = ?",
+            (1 if is_public else 0, share_token, job_uuid),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def get_simulation_job_by_share_token(share_token: str) -> Optional[Dict[str, Any]]:
+    """Get a simulation job by its share_token."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM simulation_jobs WHERE share_token = ? AND is_public = 1",
+            (share_token,),
+        )
+        row = cursor.fetchone()
+        if row:
+            return _parse_simulation_job_row(row)
+        return None
 
 
 def delete_simulation_job(job_uuid: str) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -49,6 +49,7 @@ from routers.simulations import router as simulations_router
 from routers.jobs import router as jobs_router
 from routers.datasets import router as datasets_router
 from routers.user_limits import router as user_limits_router
+from routers.public import router as public_router
 from utils import (
     generate_presigned_upload_url,
     get_s3_output_config,
@@ -129,6 +130,8 @@ app.include_router(simulations_router)
 app.include_router(jobs_router)
 app.include_router(datasets_router)
 app.include_router(user_limits_router)
+# Public (no-auth) sharing endpoints — must be registered without any auth dependency
+app.include_router(public_router)
 
 # Configure CORS allowed origins from environment variable
 # CORS_ALLOWED_ORIGINS can be comma-separated list (e.g., "http://localhost:3000,https://app.example.com")

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -28,7 +28,9 @@ from db import (
     create_agent_test_job,
     get_agent_test_job,
     update_agent_test_job,
+    update_agent_test_job_visibility,
     get_agent_test_jobs_for_agent,
+    get_agent_test_jobs_for_user,
     delete_agent_test_job,
 )
 from auth_utils import get_current_user_id
@@ -200,6 +202,8 @@ class TestRunStatusResponse(BaseModel):
     results: Optional[List[TestCaseResult]] = None
     results_s3_prefix: Optional[str] = None
     error: bool = False
+    is_public: bool = False
+    share_token: Optional[str] = None
 
 
 class AgentTestRunListItem(BaseModel):
@@ -219,10 +223,22 @@ class AgentTestRunListItem(BaseModel):
     # Common fields
     results_s3_prefix: Optional[str] = None
     error: bool = False
+    is_public: bool = False
+    share_token: Optional[str] = None
 
 
 class AgentTestRunsResponse(BaseModel):
     runs: List[AgentTestRunListItem]
+
+
+class GlobalTestRunListItem(AgentTestRunListItem):
+    """AgentTestRunListItem extended with agent identity for the global view."""
+    agent_id: str
+    agent_name: str
+
+
+class GlobalTestRunsResponse(BaseModel):
+    runs: List[GlobalTestRunListItem]
 
 
 @router.post("", response_model=AgentTestsCreateResponse)
@@ -330,10 +346,80 @@ async def get_agent_test_runs(agent_uuid: str):
             # Common fields
             results_s3_prefix=job_results.get("results_s3_prefix"),
             error=bool(job_results.get("error")),
+            is_public=bool(job.get("is_public")),
+            share_token=job.get("share_token"),
         )
         runs.append(run_item)
 
     return AgentTestRunsResponse(runs=runs)
+
+
+@router.get("/runs", response_model=GlobalTestRunsResponse)
+async def get_all_test_runs_for_user(
+    user_id: str = Depends(get_current_user_id),
+    type: Optional[str] = None,
+):
+    """
+    Get all test runs (unit tests and benchmarks) across every agent owned by
+    the authenticated user.
+
+    Optional query param:
+      ?type=llm-unit-test   — return only unit-test runs
+      ?type=llm-benchmark   — return only benchmark runs
+
+    Results are ordered newest-updated-first. Each item includes ``agent_id``
+    and ``agent_name`` so the frontend can group or label by agent.
+    """
+    jobs = get_agent_test_jobs_for_user(user_id, job_type=type)
+
+    # Per-agent counters for naming ("Run 1", "Benchmark 2", …).
+    # We need ascending order to assign names correctly, then flip back.
+    jobs_asc = sorted(jobs, key=lambda j: j.get("created_at", ""))
+    agent_unit_counts: Dict[str, int] = {}
+    agent_benchmark_counts: Dict[str, int] = {}
+    name_map: Dict[str, str] = {}  # job uuid → display name
+
+    for job in jobs_asc:
+        agent_id = job.get("agent_id", "")
+        job_type = job.get("type", "")
+        if job_type == "llm-unit-test":
+            agent_unit_counts[agent_id] = agent_unit_counts.get(agent_id, 0) + 1
+            name_map[job["uuid"]] = f"Run {agent_unit_counts[agent_id]}"
+        elif job_type == "llm-benchmark":
+            agent_benchmark_counts[agent_id] = agent_benchmark_counts.get(agent_id, 0) + 1
+            name_map[job["uuid"]] = f"Benchmark {agent_benchmark_counts[agent_id]}"
+        else:
+            name_map[job["uuid"]] = "Job"
+
+    runs = []
+    for job in jobs:  # already newest-first
+        job_results = job.get("results") or {}
+        run_item = GlobalTestRunListItem(
+            uuid=job["uuid"],
+            name=name_map[job["uuid"]],
+            status=job["status"],
+            type=job.get("type", ""),
+            updated_at=job.get("updated_at", job.get("created_at", "")),
+            # Unit test fields
+            total_tests=job_results.get("total_tests"),
+            passed=job_results.get("passed"),
+            failed=job_results.get("failed"),
+            results=job_results.get("test_results"),
+            # Benchmark fields
+            model_results=job_results.get("model_results"),
+            leaderboard_summary=job_results.get("leaderboard_summary"),
+            # Common fields
+            results_s3_prefix=job_results.get("results_s3_prefix"),
+            error=bool(job_results.get("error")),
+            is_public=bool(job.get("is_public")),
+            share_token=job.get("share_token"),
+            # Agent identity (global-only fields)
+            agent_id=job.get("agent_id", ""),
+            agent_name=job.get("agent_name", ""),
+        )
+        runs.append(run_item)
+
+    return GlobalTestRunsResponse(runs=runs)
 
 
 @router.get("/test/{test_uuid}/agents", response_model=List[AgentResponse])
@@ -1006,6 +1092,43 @@ async def run_agent_test(agent_uuid: str, request: RunTestRequest):
     return TaskCreateResponse(task_id=job_id, status=initial_status)
 
 
+class VisibilityRequest(BaseModel):
+    is_public: bool
+
+
+class VisibilityResponse(BaseModel):
+    is_public: bool
+    share_token: str | None = None
+
+
+@router.patch("/run/{task_id}/visibility", response_model=VisibilityResponse)
+async def update_test_run_visibility(
+    task_id: str,
+    body: VisibilityRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Toggle public sharing for an agent test run."""
+    job = get_agent_test_job(task_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    agent_id = job.get("agent_id")
+    if not agent_id:
+        raise HTTPException(status_code=404, detail="Task not found")
+    agent = get_agent(agent_id)
+    if not agent or agent.get("user_id") != user_id:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if body.is_public:
+        import uuid as _uuid
+        share_token = job.get("share_token") or str(_uuid.uuid4())
+    else:
+        share_token = None
+
+    update_agent_test_job_visibility(task_id, body.is_public, share_token)
+    return VisibilityResponse(is_public=body.is_public, share_token=share_token)
+
+
 @router.get("/run/{task_id}", response_model=TestRunStatusResponse)
 async def get_agent_test_run_status(task_id: str):
     """
@@ -1047,6 +1170,8 @@ async def get_agent_test_run_status(task_id: str):
         results=results.get("test_results"),
         results_s3_prefix=results.get("results_s3_prefix"),
         error=bool(results.get("error")),
+        is_public=bool(job.get("is_public")),
+        share_token=job.get("share_token"),
     )
 
 
@@ -1074,6 +1199,8 @@ class BenchmarkStatusResponse(BaseModel):
     leaderboard_summary: Optional[List[Dict[str, Any]]] = None
     results_s3_prefix: Optional[str] = None
     error: bool = False
+    is_public: bool = False
+    share_token: Optional[str] = None
 
 
 def _update_benchmark_intermediate_results(
@@ -1606,6 +1733,34 @@ async def run_agent_benchmark(agent_uuid: str, request: BenchmarkRequest):
     return TaskCreateResponse(task_id=job_id, status=initial_status)
 
 
+@router.patch("/benchmark/{task_id}/visibility", response_model=VisibilityResponse)
+async def update_benchmark_visibility(
+    task_id: str,
+    body: VisibilityRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Toggle public sharing for a benchmark run."""
+    job = get_agent_test_job(task_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    agent_id = job.get("agent_id")
+    if not agent_id:
+        raise HTTPException(status_code=404, detail="Task not found")
+    agent = get_agent(agent_id)
+    if not agent or agent.get("user_id") != user_id:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if body.is_public:
+        import uuid as _uuid
+        share_token = job.get("share_token") or str(_uuid.uuid4())
+    else:
+        share_token = None
+
+    update_agent_test_job_visibility(task_id, body.is_public, share_token)
+    return VisibilityResponse(is_public=body.is_public, share_token=share_token)
+
+
 @router.get("/benchmark/{task_id}", response_model=BenchmarkStatusResponse)
 async def get_benchmark_status(task_id: str):
     """
@@ -1645,6 +1800,8 @@ async def get_benchmark_status(task_id: str):
         leaderboard_summary=results.get("leaderboard_summary"),
         results_s3_prefix=results.get("results_s3_prefix"),
         error=bool(results.get("error")),
+        is_public=bool(job.get("is_public")),
+        share_token=job.get("share_token"),
     )
 
 

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -189,7 +189,7 @@ async def get_public_stt(share_token: str):
     No authentication required — accessible to anyone with the share_token.
     Returns 404 if the token is unknown or the run has been made private again.
     """
-    job = get_job_by_share_token(share_token)
+    job = get_job_by_share_token(share_token, job_type="stt-eval")
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
 
@@ -224,7 +224,7 @@ async def get_public_tts(share_token: str):
     No authentication required — accessible to anyone with the share_token.
     Returns 404 if the token is unknown or the run has been made private again.
     """
-    job = get_job_by_share_token(share_token)
+    job = get_job_by_share_token(share_token, job_type="tts-eval")
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
 
@@ -264,7 +264,7 @@ async def get_public_test_run(share_token: str):
     No authentication required — accessible to anyone with the share_token.
     Returns 404 if the token is unknown or the run has been made private again.
     """
-    job = get_agent_test_job_by_share_token(share_token)
+    job = get_agent_test_job_by_share_token(share_token, job_type="llm-unit-test")
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
 
@@ -290,7 +290,7 @@ async def get_public_benchmark(share_token: str):
     No authentication required — accessible to anyone with the share_token.
     Returns 404 if the token is unknown or the run has been made private again.
     """
-    job = get_agent_test_job_by_share_token(share_token)
+    job = get_agent_test_job_by_share_token(share_token, job_type="llm-benchmark")
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
 

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -1,0 +1,343 @@
+"""
+Public read-only endpoints for shared eval/run results.
+
+These routes bypass authentication entirely — they are excluded from the
+auth middleware by design so that anyone with a valid share_token can view
+the results without logging in.
+
+URL scheme:
+  GET /public/stt/{share_token}
+  GET /public/tts/{share_token}
+  GET /public/test-run/{share_token}
+  GET /public/benchmark/{share_token}
+  GET /public/simulation-run/{share_token}
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from db import (
+    get_job_by_share_token,
+    get_agent_test_job_by_share_token,
+    get_simulation_job_by_share_token,
+    get_simulation_jobs_for_simulation,
+)
+from utils import (
+    TaskStatus,
+    ProviderResult,
+    generate_presigned_download_url,
+    get_s3_output_config,
+    normalize_metrics,
+)
+# Re-use the audio URL helper from simulations (no circular import risk)
+from routers.simulations import _get_audio_urls_from_s3_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/public", tags=["public"])
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+class PublicSTTResponse(BaseModel):
+    task_id: str
+    status: str
+    language: Optional[str] = None
+    dataset_id: Optional[str] = None
+    dataset_name: Optional[str] = None
+    provider_results: Optional[List[ProviderResult]] = None
+    leaderboard_summary: Optional[List[Dict[str, Any]]] = None
+    error: Optional[str] = None
+
+
+class PublicTTSResponse(BaseModel):
+    task_id: str
+    status: str
+    language: Optional[str] = None
+    dataset_id: Optional[str] = None
+    dataset_name: Optional[str] = None
+    provider_results: Optional[List[ProviderResult]] = None
+    leaderboard_summary: Optional[List[Dict[str, Any]]] = None
+    error: Optional[str] = None
+
+
+class PublicTestRunResponse(BaseModel):
+    task_id: str
+    status: str
+    total_tests: Optional[int] = None
+    passed: Optional[int] = None
+    failed: Optional[int] = None
+    results: Optional[List[Dict[str, Any]]] = None
+    error: bool = False
+
+
+class PublicBenchmarkResponse(BaseModel):
+    task_id: str
+    status: str
+    model_results: Optional[List[Dict[str, Any]]] = None
+    leaderboard_summary: Optional[List[Dict[str, Any]]] = None
+    error: bool = False
+
+
+class PublicSimulationRunResponse(BaseModel):
+    task_id: str
+    name: str
+    status: str
+    type: str
+    updated_at: str
+    total_simulations: Optional[int] = None
+    metrics: Optional[Dict[str, Any]] = None
+    simulation_results: Optional[List[Dict[str, Any]]] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_tts_provider_results_with_presigned_urls(
+    provider_results: List[Dict[str, Any]],
+    status: str,
+) -> List[Dict[str, Any]]:
+    """
+    For DONE/FAILED TTS jobs regenerate presigned download URLs for audio
+    entries whose audio_path is an S3 key rather than an http URL.
+    Mirrors the logic in routers/tts.py::get_tts_evaluation_status.
+    """
+    if status not in (TaskStatus.DONE.value, TaskStatus.FAILED.value):
+        return provider_results
+
+    for provider_result in provider_results:
+        if provider_result.get("results"):
+            for result_row in provider_result["results"]:
+                if "audio_path" in result_row and result_row["audio_path"]:
+                    audio_s3_key = result_row["audio_path"]
+                    if audio_s3_key.startswith("http") or audio_s3_key.startswith("s3://"):
+                        continue
+                    presigned_url = generate_presigned_download_url(audio_s3_key)
+                    if presigned_url:
+                        result_row["audio_path"] = presigned_url
+
+    return provider_results
+
+
+def _build_simulation_results_with_presigned_urls(
+    job: Dict[str, Any],
+    simulation_results: List[Dict[str, Any]],
+    status: str,
+) -> List[Dict[str, Any]]:
+    """
+    For DONE voice simulations regenerate presigned audio URLs on-the-fly.
+    Mirrors the logic in routers/simulations.py::get_simulation_run_status.
+    """
+    if job.get("type") != "voice" or not simulation_results:
+        return simulation_results
+
+    if status == TaskStatus.DONE.value:
+        try:
+            s3_bucket = get_s3_output_config()
+            for sim_result in simulation_results:
+                audios_s3_key_prefix = sim_result.get("audios_s3_path")
+                if audios_s3_key_prefix:
+                    audio_urls = _get_audio_urls_from_s3_key(
+                        audios_s3_key_prefix,
+                        s3_bucket,
+                        transcript=sim_result.get("transcript"),
+                    )
+                    sim_result["audio_urls"] = audio_urls
+
+                conversation_wav_s3_key = sim_result.get("conversation_wav_s3_key")
+                if conversation_wav_s3_key:
+                    conversation_wav_url = generate_presigned_download_url(
+                        conversation_wav_s3_key, bucket=s3_bucket
+                    )
+                    sim_result["conversation_wav_url"] = conversation_wav_url or ""
+                else:
+                    sim_result["conversation_wav_url"] = ""
+        except Exception as exc:
+            logger.warning(f"Failed to generate audio URLs for public endpoint: {exc}")
+
+    return simulation_results
+
+
+def _get_simulation_run_name(job: Dict[str, Any]) -> str:
+    """Return 'Run N' by looking at the job's position among sibling jobs."""
+    simulation_id = job.get("simulation_id")
+    if not simulation_id:
+        return "Run 1"
+    all_jobs = get_simulation_jobs_for_simulation(simulation_id)
+    sorted_jobs = sorted(all_jobs, key=lambda j: j.get("created_at", ""))
+    for idx, j in enumerate(sorted_jobs, start=1):
+        if j["uuid"] == job["uuid"]:
+            return f"Run {idx}"
+    return "Run 1"
+
+
+# ---------------------------------------------------------------------------
+# Public GET endpoints (no auth)
+# ---------------------------------------------------------------------------
+
+@router.get("/stt/{share_token}", response_model=PublicSTTResponse)
+async def get_public_stt(share_token: str):
+    """
+    Return a publicly shared STT evaluation result.
+    No authentication required — accessible to anyone with the share_token.
+    Returns 404 if the token is unknown or the run has been made private again.
+    """
+    job = get_job_by_share_token(share_token)
+    if not job:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    task_id = job["uuid"]
+    status = job["status"]
+    results = job.get("results") or {}
+    details = job.get("details") or {}
+
+    provider_results = results.get("provider_results") or []
+
+    # Normalize metrics format for backward compatibility (list -> dict)
+    for pr in provider_results:
+        if pr.get("metrics"):
+            pr["metrics"] = normalize_metrics(pr["metrics"])
+
+    return PublicSTTResponse(
+        task_id=task_id,
+        status=status,
+        language=details.get("language"),
+        dataset_id=details.get("dataset_id"),
+        dataset_name=details.get("dataset_name"),
+        provider_results=provider_results or None,
+        leaderboard_summary=results.get("leaderboard_summary"),
+        error=results.get("error"),
+    )
+
+
+@router.get("/tts/{share_token}", response_model=PublicTTSResponse)
+async def get_public_tts(share_token: str):
+    """
+    Return a publicly shared TTS evaluation result.
+    No authentication required — accessible to anyone with the share_token.
+    Returns 404 if the token is unknown or the run has been made private again.
+    """
+    job = get_job_by_share_token(share_token)
+    if not job:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    task_id = job["uuid"]
+    status = job["status"]
+    results = job.get("results") or {}
+    details = job.get("details") or {}
+
+    provider_results = results.get("provider_results") or []
+
+    # Normalize metrics format for backward compatibility (list -> dict)
+    for pr in provider_results:
+        if pr.get("metrics"):
+            pr["metrics"] = normalize_metrics(pr["metrics"])
+
+    # Regenerate presigned audio URLs for completed/failed jobs
+    provider_results = _build_tts_provider_results_with_presigned_urls(
+        provider_results, status
+    )
+
+    return PublicTTSResponse(
+        task_id=task_id,
+        status=status,
+        language=details.get("language"),
+        dataset_id=details.get("dataset_id"),
+        dataset_name=details.get("dataset_name"),
+        provider_results=provider_results or None,
+        leaderboard_summary=results.get("leaderboard_summary"),
+        error=results.get("error"),
+    )
+
+
+@router.get("/test-run/{share_token}", response_model=PublicTestRunResponse)
+async def get_public_test_run(share_token: str):
+    """
+    Return a publicly shared LLM test run result.
+    No authentication required — accessible to anyone with the share_token.
+    Returns 404 if the token is unknown or the run has been made private again.
+    """
+    job = get_agent_test_job_by_share_token(share_token)
+    if not job:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    task_id = job["uuid"]
+    status = job["status"]
+    results = job.get("results") or {}
+
+    return PublicTestRunResponse(
+        task_id=task_id,
+        status=status,
+        total_tests=results.get("total_tests"),
+        passed=results.get("passed"),
+        failed=results.get("failed"),
+        results=results.get("test_results"),
+        error=bool(results.get("error")),
+    )
+
+
+@router.get("/benchmark/{share_token}", response_model=PublicBenchmarkResponse)
+async def get_public_benchmark(share_token: str):
+    """
+    Return a publicly shared LLM benchmark result.
+    No authentication required — accessible to anyone with the share_token.
+    Returns 404 if the token is unknown or the run has been made private again.
+    """
+    job = get_agent_test_job_by_share_token(share_token)
+    if not job:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    task_id = job["uuid"]
+    status = job["status"]
+    results = job.get("results") or {}
+
+    return PublicBenchmarkResponse(
+        task_id=task_id,
+        status=status,
+        model_results=results.get("model_results"),
+        leaderboard_summary=results.get("leaderboard_summary"),
+        error=bool(results.get("error")),
+    )
+
+
+@router.get("/simulation-run/{share_token}", response_model=PublicSimulationRunResponse)
+async def get_public_simulation_run(share_token: str):
+    """
+    Return a publicly shared simulation run result.
+    No authentication required — accessible to anyone with the share_token.
+    Returns 404 if the token is unknown or the run has been made private again.
+    Presigned audio URLs are regenerated on-the-fly for voice simulations.
+    """
+    job = get_simulation_job_by_share_token(share_token)
+    if not job:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    task_id = job["uuid"]
+    status = job["status"]
+    results = job.get("results") or {}
+
+    simulation_results = results.get("simulation_results") or []
+    simulation_results = _build_simulation_results_with_presigned_urls(
+        job, simulation_results, status
+    )
+
+    run_name = _get_simulation_run_name(job)
+
+    return PublicSimulationRunResponse(
+        task_id=task_id,
+        name=run_name,
+        status=status,
+        type=job["type"],
+        updated_at=job["updated_at"],
+        total_simulations=results.get("total_simulations"),
+        metrics=results.get("metrics"),
+        simulation_results=simulation_results or None,
+        error=results.get("error"),
+    )

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -35,6 +35,7 @@ from db import (
     create_simulation_job,
     get_simulation_job,
     update_simulation_job,
+    update_simulation_job_visibility,
     get_simulation_jobs_for_simulation,
     delete_simulation_job,
 )
@@ -397,6 +398,8 @@ class SimulationRunStatusResponse(BaseModel):
     metrics: Optional[Dict[str, Any]] = None
     simulation_results: Optional[List[SimulationCaseResult]] = None
     error: Optional[str] = None
+    is_public: bool = False
+    share_token: Optional[str] = None
 
 
 class SimulationRunListItem(BaseModel):
@@ -502,6 +505,44 @@ async def list_simulations(user_id: str = Depends(get_current_user_id)):
             )
         )
     return result
+
+
+class VisibilityRequest(BaseModel):
+    is_public: bool
+
+
+class VisibilityResponse(BaseModel):
+    is_public: bool
+    share_token: str | None = None
+
+
+@router.patch("/run/{task_id}/visibility", response_model=VisibilityResponse)
+async def update_simulation_run_visibility(
+    task_id: str,
+    body: VisibilityRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Toggle public sharing for a simulation run."""
+    job = get_simulation_job(task_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    simulation_id = job.get("simulation_id")
+    if simulation_id:
+        simulation = get_simulation(simulation_id)
+        if not simulation or simulation.get("user_id") != user_id:
+            raise HTTPException(status_code=404, detail="Task not found")
+    else:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if body.is_public:
+        import uuid as _uuid
+        share_token = job.get("share_token") or str(_uuid.uuid4())
+    else:
+        share_token = None
+
+    update_simulation_job_visibility(task_id, body.is_public, share_token)
+    return VisibilityResponse(is_public=body.is_public, share_token=share_token)
 
 
 @router.get("/run/{task_id}", response_model=SimulationRunStatusResponse)
@@ -620,6 +661,8 @@ async def get_simulation_run_status(
         metrics=results.get("metrics"),
         simulation_results=simulation_results,
         error=results.get("error"),
+        is_public=bool(job.get("is_public")),
+        share_token=job.get("share_token"),
     )
 
 

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 
-from db import create_job, get_job, update_job
+from db import create_job, get_job, update_job, update_job_visibility
 from dataset_utils import resolve_dataset_inputs
 from auth_utils import get_current_user_id
 from utils import (
@@ -540,6 +540,36 @@ async def evaluate_stt(
     )
 
 
+class VisibilityRequest(BaseModel):
+    is_public: bool
+
+
+class VisibilityResponse(BaseModel):
+    is_public: bool
+    share_token: str | None = None
+
+
+@router.patch("/evaluate/{task_id}/visibility", response_model=VisibilityResponse)
+async def update_stt_visibility(
+    task_id: str,
+    body: VisibilityRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Toggle public sharing for an STT evaluation job."""
+    job = get_job(task_id, user_id=user_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if body.is_public:
+        import uuid as _uuid
+        share_token = job.get("share_token") or str(_uuid.uuid4())
+    else:
+        share_token = None
+
+    update_job_visibility(task_id, body.is_public, share_token)
+    return VisibilityResponse(is_public=body.is_public, share_token=share_token)
+
+
 @router.get("/evaluate/{task_id}", response_model=TaskStatusResponse)
 async def get_evaluation_status(
     task_id: str, user_id: str = Depends(get_current_user_id)
@@ -702,4 +732,6 @@ async def get_evaluation_status(
         provider_results=provider_results,
         leaderboard_summary=results.get("leaderboard_summary"),
         error=results.get("error"),
+        is_public=bool(job.get("is_public")),
+        share_token=job.get("share_token"),
     )

--- a/src/routers/tts.py
+++ b/src/routers/tts.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 
-from db import create_job, get_job, update_job
+from db import create_job, get_job, update_job, update_job_visibility
 from dataset_utils import resolve_dataset_inputs
 from auth_utils import get_current_user_id
 from utils import (
@@ -563,6 +563,36 @@ async def evaluate_tts(
     )
 
 
+class VisibilityRequest(BaseModel):
+    is_public: bool
+
+
+class VisibilityResponse(BaseModel):
+    is_public: bool
+    share_token: str | None = None
+
+
+@router.patch("/evaluate/{task_id}/visibility", response_model=VisibilityResponse)
+async def update_tts_visibility(
+    task_id: str,
+    body: VisibilityRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Toggle public sharing for a TTS evaluation job."""
+    job = get_job(task_id, user_id=user_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if body.is_public:
+        import uuid as _uuid
+        share_token = job.get("share_token") or str(_uuid.uuid4())
+    else:
+        share_token = None
+
+    update_job_visibility(task_id, body.is_public, share_token)
+    return VisibilityResponse(is_public=body.is_public, share_token=share_token)
+
+
 @router.get("/evaluate/{task_id}", response_model=TaskStatusResponse)
 async def get_tts_evaluation_status(
     task_id: str, user_id: str = Depends(get_current_user_id)
@@ -767,4 +797,6 @@ async def get_tts_evaluation_status(
         provider_results=provider_results,
         leaderboard_summary=results.get("leaderboard_summary"),
         error=results.get("error"),
+        is_public=bool(job.get("is_public")),
+        share_token=job.get("share_token"),
     )

--- a/src/utils.py
+++ b/src/utils.py
@@ -114,6 +114,8 @@ class TaskStatusResponse(BaseModel):
     provider_results: Optional[List[ProviderResult]] = None
     leaderboard_summary: Optional[List[Dict[str, Any]]] = None
     error: Optional[str] = None
+    is_public: bool = False
+    share_token: Optional[str] = None
 
 
 def kill_process_group(pid: int, job_id: str) -> bool:


### PR DESCRIPTION
Fix #15 

## Summary

- **Public sharing toggle** — 5 new `PATCH /*/visibility` endpoints (auth required, owner-only) to enable/disable sharing. Enabling generates a stable UUID v4 `share_token`; disabling clears it immediately so old links stop working.
- **Public read endpoints** — 5 new `GET /public/*` endpoints (no auth whatsoever — skips auth middleware entirely) that look up by `share_token` and return the same response shape as the authenticated GET, including regenerated presigned audio URLs for TTS and voice simulations.
- **Sharing state on existing GETs** — all 5 authenticated GET endpoints now return `is_public` and `share_token` so the frontend can render the share toggle in the correct state when an owner visits their result page.
- **Global test runs endpoint** — new `GET /agent-tests/runs` (auth required) returns all unit-test and benchmark runs across every agent owned by the user, with `agent_id` + `agent_name` on each item. Supports `?type=llm-unit-test` / `?type=llm-benchmark` filter.
- **Schema migration** — `is_public` and `share_token` columns added to `jobs`, `agent_test_jobs`, and `simulation_jobs` via safe `ALTER TABLE … IF NOT EXISTS`-style migrations in `init_db()`.

## Changed files

| File | What changed |
|---|---|
| `src/db.py` | Schema migrations + 6 new visibility functions + `get_agent_test_jobs_for_user` |
| `src/utils.py` | `is_public` + `share_token` added to `TaskStatusResponse` |
| `src/routers/stt.py` | `PATCH /stt/evaluate/{taskId}/visibility` + updated GET response |
| `src/routers/tts.py` | `PATCH /tts/evaluate/{taskId}/visibility` + updated GET response |
| `src/routers/agent_tests.py` | 2 PATCH visibility endpoints + updated GET responses + global runs endpoint |
| `src/routers/simulations.py` | `PATCH /simulations/run/{runId}/visibility` + updated GET response |
| `src/routers/public.py` | New — 5 no-auth public GET endpoints |
| `src/main.py` | Register `public_router` |

## Public endpoint URLs

```
GET /public/stt/{share_token}
GET /public/tts/{share_token}
GET /public/test-run/{share_token}
GET /public/benchmark/{share_token}
GET /public/simulation-run/{share_token}
```

## Test plan

- [ ] Toggle sharing on for an STT/TTS/test/benchmark/simulation run and confirm `share_token` is returned
- [ ] Hit the corresponding `/public/*` URL without an auth header — confirm 200 with correct data
- [ ] Disable sharing and confirm the same `/public/*` URL returns 404
- [ ] Confirm audio presigned URLs are present in public TTS and voice simulation responses
- [ ] `GET /agent-tests/runs` returns runs from multiple agents; `?type=llm-unit-test` filters correctly
- [ ] Existing authenticated GET endpoints return `is_public: false, share_token: null` for un-shared runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)