### PR TITLE
Add presigned audio URLs to STT eval results

### DIFF
--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 
 from auth_utils import get_current_user_id
-from utils import generate_presigned_download_url
+from utils import presign_audio_path
 from db import (
     create_dataset,
     get_dataset,
@@ -90,24 +90,10 @@ def _validate_items_for_type(dataset_type: str, items: List[DatasetItemIn]) -> N
             )
 
 
-def _presign_audio_path(audio_path: Optional[str]) -> Optional[str]:
-    """Convert an s3://bucket/key path to a presigned download URL."""
-    if not audio_path:
-        return audio_path
-    if audio_path.startswith("s3://"):
-        parts = audio_path[5:].split("/", 1)
-        bucket = parts[0]
-        key = parts[1] if len(parts) > 1 else ""
-        return generate_presigned_download_url(key, bucket=bucket) or audio_path
-    if audio_path.startswith("http"):
-        return audio_path
-    return generate_presigned_download_url(audio_path) or audio_path
-
-
 def _item_row_to_response(row: dict) -> DatasetItemResponse:
     return DatasetItemResponse(
         uuid=row["uuid"],
-        audio_path=_presign_audio_path(row.get("audio_path")),
+        audio_path=presign_audio_path(row.get("audio_path")),
         text=row["text"],
         order_index=row["order_index"],
         created_at=row["created_at"],

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -31,6 +31,7 @@ from utils import (
     generate_presigned_download_url,
     get_s3_output_config,
     normalize_metrics,
+    presign_audio_path,
 )
 # Re-use the audio URL helper from simulations (no circular import risk)
 from routers.simulations import _get_audio_urls_from_s3_key
@@ -204,6 +205,26 @@ async def get_public_stt(share_token: str):
     for pr in provider_results:
         if pr.get("metrics"):
             pr["metrics"] = normalize_metrics(pr["metrics"])
+
+    # Enrich result rows with presigned audio URLs from the dataset
+    audio_paths = details.get("audio_paths", [])
+    if audio_paths:
+        # Collect IDs actually present in results to avoid unnecessary presigning
+        needed_ids: set[str] = set()
+        for pr in provider_results:
+            for row in pr.get("results") or []:
+                if row.get("id"):
+                    needed_ids.add(row["id"])
+
+        audio_url_map = {}
+        for idx, path in enumerate(audio_paths):
+            audio_id = f"audio_{idx + 1}"
+            if audio_id in needed_ids:
+                audio_url_map[audio_id] = presign_audio_path(path)
+
+        for pr in provider_results:
+            for row in pr.get("results") or []:
+                row["audio_url"] = audio_url_map.get(row.get("id", ""))
 
     return PublicSTTResponse(
         task_id=task_id,

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -724,21 +724,28 @@ async def get_evaluation_status(
         if provider_result.get("metrics"):
             provider_result["metrics"] = normalize_metrics(provider_result["metrics"])
 
-    # Enrich each result row with a presigned audio URL from the dataset
+    # Enrich each result row with a presigned audio URL from the dataset.
+    # Only presign IDs that actually appear in results to avoid unnecessary
+    # S3 calls during early polling when results are still empty.
     audio_paths = details.get("audio_paths", [])
     if audio_paths:
-        # Build mapping: audio_id (e.g. "audio_1") -> presigned URL
-        audio_url_map = {}
-        for idx, path in enumerate(audio_paths):
-            audio_id = f"audio_{idx + 1}"
-            audio_url_map[audio_id] = presign_audio_path(path)
-
+        # Collect IDs actually present in results
+        needed_ids: set[str] = set()
         for provider_result in provider_results:
-            results_list = provider_result.get("results")
-            if results_list:
-                for row in results_list:
-                    row_id = row.get("id", "")
-                    row["audio_url"] = audio_url_map.get(row_id)
+            for row in provider_result.get("results") or []:
+                if row.get("id"):
+                    needed_ids.add(row["id"])
+
+        if needed_ids:
+            audio_url_map = {}
+            for idx, path in enumerate(audio_paths):
+                audio_id = f"audio_{idx + 1}"
+                if audio_id in needed_ids:
+                    audio_url_map[audio_id] = presign_audio_path(path)
+
+            for provider_result in provider_results:
+                for row in provider_result.get("results") or []:
+                    row["audio_url"] = audio_url_map.get(row.get("id", ""))
 
     return TaskStatusResponse(
         task_id=task_id,

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -31,6 +31,7 @@ from utils import (
     capture_exception_to_sentry,
     normalize_metrics,
     read_leaderboard_xlsx,
+    presign_audio_path,
 )
 
 # Job types that share the same queue
@@ -722,6 +723,22 @@ async def get_evaluation_status(
     for provider_result in provider_results:
         if provider_result.get("metrics"):
             provider_result["metrics"] = normalize_metrics(provider_result["metrics"])
+
+    # Enrich each result row with a presigned audio URL from the dataset
+    audio_paths = details.get("audio_paths", [])
+    if audio_paths:
+        # Build mapping: audio_id (e.g. "audio_1") -> presigned URL
+        audio_url_map = {}
+        for idx, path in enumerate(audio_paths):
+            audio_id = f"audio_{idx + 1}"
+            audio_url_map[audio_id] = presign_audio_path(path)
+
+        for provider_result in provider_results:
+            results_list = provider_result.get("results")
+            if results_list:
+                for row in results_list:
+                    row_id = row.get("id", "")
+                    row["audio_url"] = audio_url_map.get(row_id)
 
     return TaskStatusResponse(
         task_id=task_id,

--- a/src/utils.py
+++ b/src/utils.py
@@ -280,6 +280,20 @@ def generate_presigned_download_url(
         return None
 
 
+def presign_audio_path(audio_path: Optional[str]) -> Optional[str]:
+    """Convert an s3://bucket/key path (or plain key) to a presigned download URL."""
+    if not audio_path:
+        return audio_path
+    if audio_path.startswith("s3://"):
+        parts = audio_path[5:].split("/", 1)
+        bucket = parts[0]
+        key = parts[1] if len(parts) > 1 else ""
+        return generate_presigned_download_url(key, bucket=bucket) or audio_path
+    if audio_path.startswith("http"):
+        return audio_path
+    return generate_presigned_download_url(audio_path) or audio_path
+
+
 def generate_presigned_upload_url(
     s3_key: str,
     content_type: str,


### PR DESCRIPTION
Fixes #20 

## Summary
- STT eval status endpoint (`GET /stt/evaluate/{task_id}`) now returns a presigned S3 download URL (`audio_url`) for each audio sample in `provider_results[].results[]`
- Extracted `presign_audio_path()` from `datasets.py` into `utils.py` for shared use across routers
- Frontend can now play back the original audio inline alongside reference text and predicted transcript

## How it works
When polling for eval results, the endpoint maps each `audio_id` (e.g. `audio_1`) back to its original S3 path stored in job details, generates a time-limited presigned URL, and injects it into each result row. No extra DB queries or storage needed.

## Test plan
- [ ] Trigger an STT eval run and poll `GET /stt/evaluate/{task_id}` — verify each result row contains `audio_url` with a valid presigned S3 URL
- [ ] Verify the presigned URL is playable/downloadable
- [ ] Verify existing dataset endpoints still work (presigning unchanged)
- [ ] Verify in-progress eval polling still returns correct intermediate results

🤖 Generated with [Claude Code](https://claude.com/claude-code)