### PR TITLE
Fix: ensure dataset text field is always treated as string

### DIFF
--- a/src/dataset_utils.py
+++ b/src/dataset_utils.py
@@ -47,7 +47,7 @@ def resolve_dataset_inputs(
         if not items:
             raise HTTPException(status_code=400, detail="Dataset has no items")
 
-        resolved_texts = [i["text"] for i in items]
+        resolved_texts = [str(i["text"]) for i in items]
         resolved_audio = (
             [i["audio_path"] for i in items] if expected_type == "stt" else None
         )

--- a/src/db.py
+++ b/src/db.py
@@ -3187,7 +3187,7 @@ def add_dataset_items(
                     item_uuid,
                     dataset_id,
                     item.get("audio_path"),
-                    item["text"],
+                    str(item["text"]),
                     order_index,
                 ),
             )
@@ -3212,7 +3212,11 @@ def get_dataset_item(item_uuid: str, dataset_id: str) -> Optional[Dict[str, Any]
             (item_uuid, dataset_id),
         )
         row = cursor.fetchone()
-        return dict(row) if row else None
+        if row is None:
+            return None
+        item = dict(row)
+        item["text"] = str(item["text"])
+        return item
 
 
 def get_dataset_items(dataset_id: str) -> List[Dict[str, Any]]:
@@ -3224,7 +3228,10 @@ def get_dataset_items(dataset_id: str) -> List[Dict[str, Any]]:
             (dataset_id,),
         )
         rows = cursor.fetchall()
-        return [dict(row) for row in rows]
+        items = [dict(row) for row in rows]
+        for item in items:
+            item["text"] = str(item["text"])
+        return items
 
 
 def get_dataset_items_by_uuids(item_uuids: List[str]) -> List[Dict[str, Any]]:
@@ -3238,7 +3245,10 @@ def get_dataset_items_by_uuids(item_uuids: List[str]) -> List[Dict[str, Any]]:
             f"SELECT * FROM dataset_items WHERE uuid IN ({placeholders}) AND deleted_at IS NULL ORDER BY order_index ASC",
             item_uuids,
         )
-        return [dict(row) for row in cursor.fetchall()]
+        items = [dict(row) for row in cursor.fetchall()]
+        for item in items:
+            item["text"] = str(item["text"])
+        return items
 
 
 def update_dataset_item(

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -223,7 +223,7 @@ def run_evaluation_task(
                         s3.download_file(bucket, key, str(local_audio_path))
 
                         # Write CSV row
-                        writer.writerow([audio_id, gt_text])
+                        writer.writerow([audio_id, str(gt_text)])
 
                 # Create output directory
                 output_dir = temp_path / "output"

--- a/src/routers/tts.py
+++ b/src/routers/tts.py
@@ -214,7 +214,7 @@ def run_tts_evaluation_task(
                     writer = csv.writer(csvfile)
                     writer.writerow(["id", "text"])
                     for idx, text in enumerate(request.texts):
-                        writer.writerow([idx, text])
+                        writer.writerow([idx, str(text)])
 
                 # Create output directory
                 output_dir = temp_path / "output"


### PR DESCRIPTION
Fixes #22 

## Summary
- When the `text` field in an STT/TTS dataset contains only numbers (e.g., `"12345"`), SQLite's dynamic typing stores and returns it as an integer instead of a string, causing downstream evaluation failures.
- Added `str()` coercion at all DB write and read boundaries for the `text` field in `dataset_items`, in the dataset resolver (`dataset_utils.py`), and in the CSV writers used by STT/TTS evaluation tasks.

## Changes
- **`src/db.py`** — `add_dataset_items`: coerce on insert; `get_dataset_item`, `get_dataset_items`, `get_dataset_items_by_uuids`: coerce on read
- **`src/dataset_utils.py`** — `resolve_dataset_inputs`: coerce resolved texts
- **`src/routers/stt.py`** — coerce ground-truth text when writing eval input CSV
- **`src/routers/tts.py`** — coerce text when writing eval input CSV

## Test plan
- [ ] Create an STT/TTS dataset where the text field is purely numeric (e.g., `"12345"`)
- [ ] Run an evaluation against that dataset
- [ ] Verify the text is treated as a string throughout (no integer coercion errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)