### PR TITLE
Added support for optionally loading human annotations for labelling tasks

### DIFF
--- a/src/annotation_eval_runner.py
+++ b/src/annotation_eval_runner.py
@@ -33,9 +33,11 @@ from db import (
     create_evaluator_runs,
     get_annotation_items_for_task,
     get_annotation_task,
+    get_eval_job_items,
     get_evaluator,
     get_evaluator_version,
     get_job,
+    snapshot_eval_job_items,
     update_job,
 )
 from llm_judge import (
@@ -958,17 +960,41 @@ def _run_job(
         if not task:
             raise RuntimeError(f"Task {task_uuid} disappeared")
 
-        all_items = get_annotation_items_for_task(task_uuid)
-        if not all_items:
-            raise RuntimeError("Task has no items")
-        if item_ids is None:
-            items = all_items
+        # Read the snapshot the submission endpoint wrote into
+        # `annotation_eval_job_items`. This is the exact item set + payloads
+        # the user submitted, frozen against subsequent edits / soft-deletes
+        # on `annotation_items`. Order is preserved by the snapshot's
+        # insertion order so calibrate sees the same sequence on retry.
+        snapshot_items = get_eval_job_items(job_uuid)
+        if snapshot_items:
+            items = snapshot_items
         else:
-            by_id = {it["uuid"]: it for it in all_items}
-            items = [by_id[i] for i in item_ids if i in by_id]
-            if not items:
-                raise RuntimeError(
-                    "None of the requested item_ids are still live on this task"
+            # Backwards-compat: jobs created before snapshotting was added
+            # have no rows in `annotation_eval_job_items`. Fall back to the
+            # live list (old behavior) and write the snapshot now so a later
+            # recovery / re-read goes through the snapshot path. This
+            # branch is also the only path for any in-flight job that
+            # spans the deploy of this change.
+            all_items = get_annotation_items_for_task(task_uuid)
+            if not all_items:
+                raise RuntimeError("Task has no items")
+            if item_ids is None:
+                items = all_items
+            else:
+                by_id = {it["uuid"]: it for it in all_items}
+                items = [by_id[i] for i in item_ids if i in by_id]
+                if not items:
+                    raise RuntimeError(
+                        "None of the requested item_ids are still live on this task"
+                    )
+            try:
+                snapshot_eval_job_items(job_uuid, items)
+            except Exception as e:
+                # Snapshotting is a perf optimisation for next-read; a
+                # failure here shouldn't block the run.
+                logger.warning(
+                    f"[annotation-eval] backfill snapshot failed for "
+                    f"{job_uuid}: {e}"
                 )
 
         task_type = task.get("type", "stt")

--- a/src/db.py
+++ b/src/db.py
@@ -609,6 +609,27 @@ def init_db():
         except sqlite3.OperationalError:
             pass
 
+        # Snapshot of items assigned to an evaluator-run job. Mirrors
+        # `annotation_job_items` but for the generic-`jobs`-table-backed
+        # `annotation-eval` flow, so evaluator runs survive item edits/
+        # soft-deletes after submission. Reading is via
+        # `get_eval_job_items`; the runner reads payloads from here so the
+        # exact bytes v3 scored against are reproducible even after the
+        # source `annotation_items` row is edited or soft-deleted.
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS annotation_eval_job_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id TEXT NOT NULL,
+                item_id TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                UNIQUE(job_id, item_id),
+                FOREIGN KEY (job_id) REFERENCES jobs(uuid),
+                FOREIGN KEY (item_id) REFERENCES annotation_items(uuid)
+            )
+            """
+        )
+
         cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS annotation_job_evaluators (
@@ -6208,6 +6229,64 @@ def get_annotations_for_annotator_overlap_slots(
         return [_parse_annotation_row(r) for r in cursor.fetchall()]
 
 
+def snapshot_eval_job_items(
+    job_uuid: str, items: List[Dict[str, Any]]
+) -> None:
+    """Write `(item_uuid, payload)` rows into `annotation_eval_job_items`
+    for an annotation-eval job. Idempotent: re-snapshotting the same
+    `(job_id, item_id)` is a no-op (UNIQUE constraint with INSERT OR
+    IGNORE), so recovery / retries are safe.
+
+    Caller must pass the items in the order they want preserved — the
+    auto-increment `id` column is what determines the read order in
+    `get_eval_job_items`."""
+    if not items:
+        return
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.executemany(
+            "INSERT OR IGNORE INTO annotation_eval_job_items "
+            "(job_id, item_id, payload) VALUES (?, ?, ?)",
+            [
+                (
+                    job_uuid,
+                    it["uuid"],
+                    json.dumps(it.get("payload")),
+                )
+                for it in items
+            ],
+        )
+        conn.commit()
+
+
+def get_eval_job_items(job_uuid: str) -> List[Dict[str, Any]]:
+    """Read snapshotted items for an annotation-eval job. Order matches
+    submission order (insertion order on `id`). Each row is
+    `{uuid, payload (parsed)}` — no joins to `annotation_items` so the
+    snapshot is independent of post-submit edits / soft-deletes there."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT item_id AS uuid, payload
+              FROM annotation_eval_job_items
+             WHERE job_id = ?
+             ORDER BY id ASC
+            """,
+            (job_uuid,),
+        )
+        out: List[Dict[str, Any]] = []
+        for row in cursor.fetchall():
+            d = dict(row)
+            if d.get("payload"):
+                try:
+                    d["payload"] = json.loads(d["payload"])
+                except (TypeError, ValueError):
+                    pass
+            out.append(d)
+        return out
+
+
 def get_job_items(job_uuid: str) -> List[Dict[str, Any]]:
     """Return the snapshotted items for a job. Read from `annotation_job_items.payload`
     so edits/deletes on the source `annotation_items` row don't affect the
@@ -6351,13 +6430,27 @@ def get_annotations_for_item(item_id: str) -> List[Dict[str, Any]]:
         return [_parse_annotation_row(r) for r in cursor.fetchall()]
 
 
-def get_annotations_for_task(
+def get_annotations_for_slots(
     task_id: str,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
+    item_ids: List[str],
+    evaluator_ids: List[str],
+    include_deleted_items: bool = True,
 ) -> List[Dict[str, Any]]:
-    """All annotations across all NON-DELETED items in a task. Annotations on
-    soft-deleted items are excluded so aggregate agreement metrics drop them."""
+    """All annotations on the given (item × evaluator) slots within a task.
+
+    Avoids the read-everything-then-filter-in-Python pattern when only a
+    specific run's slots are needed (e.g. the run-detail endpoint), which
+    on a large task is dominated by annotation history outside the run.
+
+    `include_deleted_items=True` (default) preserves annotations whose
+    item was soft-deleted after the run's snapshot — matching the
+    eval-run reproducibility contract: what humans said about the row
+    at the time, even if the row was cleaned up later. Soft-deleted
+    JOBS are still excluded (cascade on task delete is intentional)."""
+    if not item_ids or not evaluator_ids:
+        return []
+    item_placeholders = ",".join("?" for _ in item_ids)
+    evaluator_placeholders = ",".join("?" for _ in evaluator_ids)
     query = (
         "SELECT a.*, j.annotator_id AS annotator_id, j.task_id AS task_id "
         "  FROM annotations a "
@@ -6366,8 +6459,48 @@ def get_annotations_for_task(
         " WHERE j.task_id = ? "
         "   AND a.deleted_at IS NULL "
         "   AND j.deleted_at IS NULL "
-        "   AND ai.deleted_at IS NULL "
+        f"  AND a.item_id IN ({item_placeholders}) "
+        f"  AND a.evaluator_id IN ({evaluator_placeholders}) "
     )
+    if not include_deleted_items:
+        query += "   AND ai.deleted_at IS NULL "
+    query += " ORDER BY a.updated_at ASC"
+    params: List[Any] = [task_id, *item_ids, *evaluator_ids]
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(query, params)
+        return [_parse_annotation_row(r) for r in cursor.fetchall()]
+
+
+def get_annotations_for_task(
+    task_id: str,
+    since: Optional[str] = None,
+    until: Optional[str] = None,
+    include_deleted_items: bool = False,
+) -> List[Dict[str, Any]]:
+    """All annotations across all NON-DELETED items in a task. Annotations on
+    soft-deleted items are excluded by default so aggregate agreement metrics
+    drop them.
+
+    `include_deleted_items=True` keeps annotations whose item was soft-deleted
+    after the annotation was written. The run-detail view uses this so an
+    item soft-delete after a run completes doesn't silently shrink the
+    `human_agreement` block under the user — the eval-run pinning contract
+    is "what did v3 score against, vs what humans said about the same row at
+    the time", and that contract has to outlast item soft-delete. Annotations
+    on soft-deleted JOBS are still excluded (cascade on task delete is
+    intentional)."""
+    query = (
+        "SELECT a.*, j.annotator_id AS annotator_id, j.task_id AS task_id "
+        "  FROM annotations a "
+        "  JOIN annotation_jobs j ON j.uuid = a.job_id "
+        "  JOIN annotation_items ai ON ai.uuid = a.item_id "
+        " WHERE j.task_id = ? "
+        "   AND a.deleted_at IS NULL "
+        "   AND j.deleted_at IS NULL "
+    )
+    if not include_deleted_items:
+        query += "   AND ai.deleted_at IS NULL "
     params: List[Any] = [task_id]
     if since:
         query += " AND a.updated_at >= ? "

--- a/src/db.py
+++ b/src/db.py
@@ -5731,6 +5731,24 @@ def soft_delete_annotation_items(
         return cursor.rowcount
 
 
+def soft_delete_annotation_job(job_uuid: str) -> bool:
+    """Soft-delete a single annotation_jobs row. Used by the bulk-upload
+    rollback path when a snapshot mismatch is detected after the job has
+    been created — leaves the row in place but flips it out of every
+    `deleted_at IS NULL` filter so it doesn't appear in lists or feed
+    downstream agreement reads. Returns True iff a live row was
+    transitioned (already-deleted UUIDs return False)."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE annotation_jobs SET deleted_at = CURRENT_TIMESTAMP "
+            "WHERE uuid = ? AND deleted_at IS NULL",
+            (job_uuid,),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
 def get_annotation_items_for_task(task_id: str) -> List[Dict[str, Any]]:
     with get_db_connection() as conn:
         cursor = conn.cursor()

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -874,12 +874,197 @@ async def list_evaluator_run_jobs(
     return [_shape_eval_job_for_response(j) for j in jobs]
 
 
+def _human_agreement_for_run(
+    task_uuid: str, job_runs: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Build the `human_agreement` block returned alongside an evaluator-run
+    job. Restricted to slots (item_id, evaluator_id) actually exercised by
+    THIS job's runs — annotations on items/evaluators not in the run are
+    ignored even if present elsewhere on the task.
+
+    Shape:
+        {
+          "evaluators": [
+            { "evaluator_id": str, "evaluator_version_id": str|None,
+              "agreement": float|None, "pair_count": int, "item_count": int }
+          ],
+          "items": [
+            { "item_id": str, "annotator_count": int,
+              "evaluators": [{evaluator_id, agreement, pair_count}] }
+          ]
+        }
+
+    `evaluators[].agreement` reuses `aggregate_human_evaluator_agreement` —
+    so it agrees with the task-level alignment block by construction.
+    `items[]` only includes items where at least one human annotation exists
+    on an evaluator that this job ran (no humans → no row, by design)."""
+    if not job_runs:
+        return {"evaluators": [], "items": []}
+
+    item_ids_in_run = {r["item_id"] for r in job_runs if r.get("item_id")}
+    evaluator_ids_in_run = list(
+        {r["evaluator_id"] for r in job_runs if r.get("evaluator_id")}
+    )
+    if not item_ids_in_run or not evaluator_ids_in_run:
+        return {"evaluators": [], "items": []}
+
+    # Pull all task annotations once and filter to the items/evaluators in
+    # this run (cheaper than N item-scoped queries, and matches how the
+    # task-level alignment block fetches).
+    all_annotations = get_annotations_for_task(task_uuid)
+    relevant_annotations = [
+        a
+        for a in all_annotations
+        if a.get("item_id") in item_ids_in_run
+        and a.get("evaluator_id") in set(evaluator_ids_in_run)
+    ]
+
+    # Per-evaluator aggregate (across every item this job touched).
+    evaluator_blocks: List[Dict[str, Any]] = []
+    # Pre-compute version pin per evaluator from the run rows so the FE can
+    # show "agreement on evaluator X version Y vs humans" without an extra
+    # lookup. A job runs one version per evaluator by construction.
+    version_by_evaluator: Dict[str, Optional[str]] = {}
+    for r in job_runs:
+        ev_id = r.get("evaluator_id")
+        if ev_id and ev_id not in version_by_evaluator:
+            version_by_evaluator[ev_id] = r.get("evaluator_version_id")
+    for ev_id in evaluator_ids_in_run:
+        agreement, pair_count = aggregate_human_evaluator_agreement(
+            relevant_annotations, job_runs, ev_id
+        )
+        # Items with at least one human annotation on this evaluator.
+        item_count = len(
+            {
+                a["item_id"]
+                for a in relevant_annotations
+                if a.get("evaluator_id") == ev_id
+            }
+        )
+        evaluator_blocks.append(
+            {
+                "evaluator_id": ev_id,
+                "evaluator_version_id": version_by_evaluator.get(ev_id),
+                "agreement": agreement,
+                "pair_count": pair_count,
+                "item_count": item_count,
+            }
+        )
+
+    # Per-item agreement, restricted to items that have at least one human
+    # annotation on an evaluator this job ran. The whole point of this view
+    # is "where do machines and humans disagree on this run" — items with
+    # zero human signal contribute nothing.
+    annotations_by_item: Dict[str, List[Dict[str, Any]]] = {}
+    for a in relevant_annotations:
+        annotations_by_item.setdefault(a["item_id"], []).append(a)
+    runs_by_item: Dict[str, List[Dict[str, Any]]] = {}
+    for r in job_runs:
+        if r.get("item_id"):
+            runs_by_item.setdefault(r["item_id"], []).append(r)
+
+    # Resolve annotator names once for every annotator that contributed to
+    # any of the relevant items, so per-item entries can label each value.
+    annotator_uuids = sorted(
+        {
+            a.get("annotator_id")
+            for a in relevant_annotations
+            if a.get("annotator_id")
+        }
+    )
+    annotators_by_uuid = (
+        get_annotators_by_uuids(annotator_uuids) if annotator_uuids else {}
+    )
+
+    item_blocks: List[Dict[str, Any]] = []
+    for item_id, item_annotations in annotations_by_item.items():
+        per_item = per_item_agreement(
+            item_annotations,
+            runs_by_item.get(item_id, []),
+            evaluator_ids_in_run,
+        )
+        # Drop evaluator slots with zero human pair count so the FE only
+        # renders cells that actually compare to a human.
+        ev_entries = [
+            e for e in per_item.get("evaluators", []) if e.get("pair_count")
+        ]
+        if not ev_entries:
+            continue
+        # Bucket the raw human annotations on this item by evaluator so the
+        # FE can show every annotator's exact value alongside the agreement
+        # number. Annotations are already filtered to the run's slot set,
+        # so every entry here is in scope.
+        annotations_by_evaluator: Dict[str, List[Dict[str, Any]]] = {}
+        for a in item_annotations:
+            ev_id = a.get("evaluator_id")
+            if not ev_id:
+                continue
+            annotator_id = a.get("annotator_id")
+            annotator = (
+                annotators_by_uuid.get(annotator_id) if annotator_id else None
+            )
+            annotations_by_evaluator.setdefault(ev_id, []).append(
+                {
+                    "annotation_id": a.get("uuid"),
+                    "annotator_id": annotator_id,
+                    "annotator_name": (
+                        annotator.get("name") if annotator else None
+                    ),
+                    "job_id": a.get("job_id"),
+                    "value": a.get("value"),
+                    "updated_at": a.get("updated_at"),
+                }
+            )
+        # Sort each evaluator's annotations deterministically (oldest first)
+        # so the FE can render them in submission order.
+        for entries in annotations_by_evaluator.values():
+            entries.sort(key=lambda e: (e.get("updated_at") or "", e.get("annotation_id") or ""))
+        # Inline the raw annotations onto each evaluator block keyed by
+        # evaluator_id, so the agreement cell and the underlying values
+        # render together without an extra join on the FE.
+        for entry in ev_entries:
+            entry["human_annotations"] = annotations_by_evaluator.get(
+                entry["evaluator_id"], []
+            )
+        item_blocks.append(
+            {
+                "item_id": item_id,
+                "annotator_count": len(
+                    {
+                        a.get("annotator_id")
+                        for a in item_annotations
+                        if a.get("annotator_id")
+                    }
+                ),
+                "evaluators": ev_entries,
+            }
+        )
+    # Stable order: items in run-row order so the FE can scroll predictably.
+    item_order = [r["item_id"] for r in job_runs if r.get("item_id")]
+    seen: set = set()
+    ordered_item_ids: List[str] = []
+    for i in item_order:
+        if i not in seen:
+            seen.add(i)
+            ordered_item_ids.append(i)
+    pos = {i: idx for idx, i in enumerate(ordered_item_ids)}
+    item_blocks.sort(key=lambda b: pos.get(b["item_id"], len(pos)))
+
+    return {"evaluators": evaluator_blocks, "items": item_blocks}
+
+
 @router.get("/{task_uuid}/evaluator-runs/{job_uuid}")
 async def get_evaluator_run_job(
     task_uuid: str,
     job_uuid: str,
     user_id: str = Depends(get_current_user_id),
 ):
+    """Single evaluator-run job, with raw runs and human-agreement summary.
+
+    `human_agreement` is computed only on slots (item × evaluator) that this
+    job actually exercised AND that have at least one human annotation —
+    so a fresh task with no humans yet returns empty arrays (not zeros)
+    and the FE can fall back to the regular runs view."""
     _ensure_owned_task(task_uuid, user_id)
     job = get_job(job_uuid, user_id=user_id)
     if (
@@ -889,9 +1074,9 @@ async def get_evaluator_run_job(
     ):
         raise HTTPException(status_code=404, detail="Job not found")
     shaped = _shape_eval_job_for_response(job)
-    shaped["runs"] = _enrich_runs_with_live_evaluator(
-        get_evaluator_runs_for_job(job_uuid)
-    )
+    raw_runs = get_evaluator_runs_for_job(job_uuid)
+    shaped["runs"] = _enrich_runs_with_live_evaluator(raw_runs)
+    shaped["human_agreement"] = _human_agreement_for_run(task_uuid, raw_runs)
     return shaped
 
 

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -272,10 +272,22 @@ class AnnotationItemPayload(BaseModel):
     # task `type`. The backend doesn't validate the shape — frontend +
     # downstream consumers (evaluator runs, agreement, etc.) interpret it.
     payload: Any
+    # Optional human annotations to seed alongside the item. Keys are
+    # evaluator UUIDs that must be currently linked to the task; values
+    # follow the same shape `upsert_annotation` accepts (e.g.
+    # `{"pass": bool, "reasoning": str}` for binary, `{"value": num,
+    # "reasoning": str}` for rating). When any item carries this,
+    # `BulkItemsRequest.annotator_id` is required.
+    annotations: Optional[Dict[str, Any]] = None
 
 
 class BulkItemsRequest(BaseModel):
     items: List[AnnotationItemPayload]
+    # Required only if any item in `items` carries `annotations`. The
+    # annotator must be owned by the requesting user. All seeded
+    # annotations are attributed to one synthesised completed job for
+    # this annotator.
+    annotator_id: Optional[str] = None
 
 
 @router.get("/{task_uuid}/items")
@@ -292,13 +304,113 @@ async def bulk_create_items(
     payload: BulkItemsRequest,
     user_id: str = Depends(get_current_user_id),
 ):
-    """Bulk-insert annotation items. Order of insertion is preserved by `id`."""
+    """Bulk-insert annotation items. Order of insertion is preserved by `id`.
+
+    Optionally seeds human annotations alongside the items: when any item
+    in the request carries `annotations`, `annotator_id` must be supplied
+    and one completed `annotation_jobs` row is synthesised for that
+    annotator covering every newly-inserted item. Annotations are upserted
+    as if the annotator had submitted them through the public form.
+    Annotations are validated against the task's *currently linked*
+    evaluator set; the task type (`stt | llm | simulation | tts`) does
+    not affect the contract — value shape is whatever the evaluator's
+    `output_type` expects (`{pass, reasoning}` for binary,
+    `{value, reasoning}` for rating)."""
     _ensure_owned_task(task_uuid, user_id)
     if not payload.items:
         raise HTTPException(status_code=400, detail="items must be non-empty")
+
+    items_with_annotations = [
+        it for it in payload.items if it.annotations is not None
+    ]
+    if items_with_annotations and not payload.annotator_id:
+        raise HTTPException(
+            status_code=400,
+            detail="annotator_id is required when any item carries `annotations`",
+        )
+
+    annotator: Optional[Dict[str, Any]] = None
+    linked_evaluator_ids: set = set()
+    if items_with_annotations:
+        annotator = get_annotator(payload.annotator_id)
+        if not annotator or annotator.get("user_id") != user_id:
+            # 404 (not 403) — avoid leaking existence
+            raise HTTPException(status_code=404, detail="Annotator not found")
+        linked_evaluator_ids = {
+            e["uuid"] for e in get_evaluators_for_annotation_task(task_uuid)
+        }
+        for idx, it in enumerate(items_with_annotations):
+            if not isinstance(it.annotations, dict):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"items[{idx}].annotations must be an object keyed by evaluator UUID",
+                )
+            unknown = [
+                ev_id
+                for ev_id in it.annotations.keys()
+                if ev_id not in linked_evaluator_ids
+            ]
+            if unknown:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Evaluator(s) not linked to this task: {unknown}. "
+                        f"Link them via POST /annotation-tasks/{task_uuid}/evaluators "
+                        f"before seeding annotations."
+                    ),
+                )
+
     new_uuids = create_annotation_items(
-        task_uuid, [it.dict() for it in payload.items]
+        task_uuid,
+        [{"payload": it.payload} for it in payload.items],
     )
+
+    if items_with_annotations:
+        # One synthesised job covers every newly-inserted item, so the
+        # annotator shows up exactly once in agreement aggregates per
+        # bulk upload (rather than fragmenting across N tiny jobs).
+        # Items without `annotations` are still included in the job's
+        # snapshot — leaving their slots blank, which the auto-complete
+        # check at job-status-time treats the same as a partial form.
+        public_token = secrets.token_urlsafe(24)
+        job_uuid = create_annotation_job(
+            task_id=task_uuid,
+            annotator_id=payload.annotator_id,
+            item_uuids=new_uuids,
+            public_token=public_token,
+            status="pending",
+        )
+        any_annotation_written = False
+        for it, item_uuid in zip(payload.items, new_uuids):
+            if not it.annotations:
+                continue
+            for evaluator_id, value in it.annotations.items():
+                upsert_annotation(
+                    job_id=job_uuid,
+                    item_id=item_uuid,
+                    value=value,
+                    evaluator_id=evaluator_id,
+                )
+                any_annotation_written = True
+        # Mark the synthesised job as completed only when every item in
+        # the job has at least one annotation across the linked evaluator
+        # set — otherwise leave it pending so the auto-complete contract
+        # (every item × every evaluator) stays meaningful.
+        items_fully_annotated = all(
+            it.annotations
+            and linked_evaluator_ids.issubset(set(it.annotations.keys()))
+            for it in payload.items
+        )
+        if any_annotation_written and items_fully_annotated:
+            update_annotation_job_status(
+                job_uuid, status="completed", set_completed_at=True
+            )
+        return {
+            "item_ids": new_uuids,
+            "count": len(new_uuids),
+            "annotation_job_id": job_uuid,
+        }
+
     return {"item_ids": new_uuids, "count": len(new_uuids)}
 
 

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -419,6 +419,32 @@ async def bulk_create_items(
             public_token=public_token,
             status="pending",
         )
+        # Re-validate every requested evaluator_id against the job's own
+        # snapshot, not the pre-creation linked set. Concurrent
+        # link/unlink between the upstream check and `create_annotation_job`
+        # can shift the snapshot under us; without this gate we'd persist
+        # annotations on slots the job doesn't own, polluting downstream
+        # `annotations`-by-task reads. Same contract enforced by the
+        # public-form upsert endpoint in `routers/public.py`.
+        snapshot_evaluator_ids = set(get_evaluator_ids_for_job(job_uuid))
+        snapshot_mismatch: List[str] = []
+        for it in payload.items:
+            if not it.annotations:
+                continue
+            for evaluator_id in it.annotations.keys():
+                if evaluator_id not in snapshot_evaluator_ids:
+                    snapshot_mismatch.append(evaluator_id)
+        if snapshot_mismatch:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Evaluator(s) were unlinked from this task between "
+                    f"validation and job creation: {sorted(set(snapshot_mismatch))}. "
+                    f"Re-link them and retry, or drop them from the request. "
+                    f"(The annotation job {job_uuid} was created but no "
+                    f"annotations have been written.)"
+                ),
+            )
         any_annotation_written = False
         for it, item_uuid in zip(payload.items, new_uuids):
             if not it.annotations:
@@ -431,15 +457,10 @@ async def bulk_create_items(
                     evaluator_id=evaluator_id,
                 )
                 any_annotation_written = True
-        # Mark the synthesised job as completed only when every item in
-        # the job has at least one annotation across the JOB'S SNAPSHOTTED
-        # evaluator set — not the task's currently-linked set, which can
-        # drift between the validation read above and `create_annotation_job`
-        # if another request links/unlinks an evaluator concurrently. The
-        # job's snapshot is the contract every other completion check in
-        # the codebase reads from (see `get_evaluator_ids_for_job` callers
-        # in the public-form auto-complete path).
-        snapshot_evaluator_ids = set(get_evaluator_ids_for_job(job_uuid))
+        # Auto-complete contract: every item × every evaluator IN THE JOB
+        # SNAPSHOT must have a row. Same source of truth as the public-form
+        # auto-complete path (`get_evaluator_ids_for_job`) — see also the
+        # snapshot-mismatch gate above which uses the same set.
         items_fully_annotated = all(
             it.annotations
             and snapshot_evaluator_ids.issubset(set(it.annotations.keys()))

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -17,6 +17,7 @@ from db import (
     get_evaluator,
     get_evaluator_version,
     get_annotations_for_task,
+    get_annotations_for_slots,
     create_annotation_items,
     bulk_update_annotation_items,
     soft_delete_annotation_items,
@@ -35,6 +36,8 @@ from db import (
     get_annotators_by_uuids,
     create_job,
     get_job,
+    snapshot_eval_job_items,
+    get_eval_job_items,
     get_generic_jobs_for_task,
     soft_delete_job,
     update_job,
@@ -274,10 +277,15 @@ class AnnotationItemPayload(BaseModel):
     payload: Any
     # Optional human annotations to seed alongside the item. Keys are
     # evaluator UUIDs that must be currently linked to the task; values
-    # follow the same shape `upsert_annotation` accepts (e.g.
-    # `{"pass": bool, "reasoning": str}` for binary, `{"value": num,
-    # "reasoning": str}` for rating). When any item carries this,
-    # `BulkItemsRequest.annotator_id` is required.
+    # follow the canonical annotation shape used by the public form and
+    # the agreement math: `{"value": <bool|number|string>, "reasoning"?:
+    # str}` for EVERY output_type — binary uses a bool in `value`,
+    # rating uses a number in `value`. The agreement helpers in
+    # `annotation_metrics._scalar` only recognise the keys `value`,
+    # `score`, `rating`, `label`, `binary`; using `pass` (or any other
+    # custom key) stores fine but silently zeroes out of the agreement
+    # aggregates. When any item carries this, `BulkItemsRequest.annotator_id`
+    # is required.
     annotations: Optional[Dict[str, Any]] = None
 
 
@@ -313,9 +321,11 @@ async def bulk_create_items(
     as if the annotator had submitted them through the public form.
     Annotations are validated against the task's *currently linked*
     evaluator set; the task type (`stt | llm | simulation | tts`) does
-    not affect the contract — value shape is whatever the evaluator's
-    `output_type` expects (`{pass, reasoning}` for binary,
-    `{value, reasoning}` for rating)."""
+    not affect the contract. Value shape is uniform across output types:
+    `{"value": <bool|number|string>, "reasoning"?: str}` — binary uses a
+    bool, rating uses a number. This matches what the public form writes
+    via `upsert_annotation`, and is the only shape `annotation_metrics`
+    will count toward agreement aggregates."""
     _ensure_owned_task(task_uuid, user_id)
     if not payload.items:
         raise HTTPException(status_code=400, detail="items must be non-empty")
@@ -359,6 +369,35 @@ async def bulk_create_items(
                         f"before seeding annotations."
                     ),
                 )
+            # Validate the value shape on every entry so a malformed dict
+            # can't slip through and silently zero out of the agreement
+            # aggregates (`annotation_metrics._scalar` only recognises
+            # the keys `value`, `score`, `rating`, `label`, `binary`).
+            # Bulk uploads are the only ingress path that doesn't go
+            # through the public form's typed widget, so the canonical
+            # check lives here.
+            for ev_id, raw in it.annotations.items():
+                if not isinstance(raw, dict):
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"items[{idx}].annotations[{ev_id!r}] must be an object "
+                            f"like {{\"value\": <bool|number|string>, \"reasoning\"?: str}}; "
+                            f"got {type(raw).__name__}"
+                        ),
+                    )
+                if "value" not in raw:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"items[{idx}].annotations[{ev_id!r}] is missing required key "
+                            f"`value`. Use {{\"value\": <bool|number|string>, "
+                            f"\"reasoning\"?: str}} for every output_type — binary uses a "
+                            f"bool in `value`, rating uses a number. (The keys `pass`, "
+                            f"`score`, `rating`, `label`, `binary` will round-trip on "
+                            f"reads but won't count toward agreement aggregates.)"
+                        ),
+                    )
 
     new_uuids = create_annotation_items(
         task_uuid,
@@ -393,12 +432,17 @@ async def bulk_create_items(
                 )
                 any_annotation_written = True
         # Mark the synthesised job as completed only when every item in
-        # the job has at least one annotation across the linked evaluator
-        # set — otherwise leave it pending so the auto-complete contract
-        # (every item × every evaluator) stays meaningful.
+        # the job has at least one annotation across the JOB'S SNAPSHOTTED
+        # evaluator set — not the task's currently-linked set, which can
+        # drift between the validation read above and `create_annotation_job`
+        # if another request links/unlinks an evaluator concurrently. The
+        # job's snapshot is the contract every other completion check in
+        # the codebase reads from (see `get_evaluator_ids_for_job` callers
+        # in the public-form auto-complete path).
+        snapshot_evaluator_ids = set(get_evaluator_ids_for_job(job_uuid))
         items_fully_annotated = all(
             it.annotations
-            and linked_evaluator_ids.issubset(set(it.annotations.keys()))
+            and snapshot_evaluator_ids.issubset(set(it.annotations.keys()))
             for it in payload.items
         )
         if any_annotation_written and items_fully_annotated:
@@ -775,6 +819,12 @@ async def start_evaluator_run(
             "item_ids": item_ids_persisted,
         },
     )
+    # Snapshot the resolved item set onto the job so the runner reads
+    # frozen payloads regardless of any subsequent edit / soft-delete on
+    # the source `annotation_items` row. Order matches submission order
+    # (preserved via the loop above) so reproducibility extends to the
+    # exact byte sequence calibrate sees.
+    snapshot_eval_job_items(job_uuid, items)
 
     if can_start:
         start_annotation_eval_job(
@@ -908,16 +958,20 @@ def _human_agreement_for_run(
     if not item_ids_in_run or not evaluator_ids_in_run:
         return {"evaluators": [], "items": []}
 
-    # Pull all task annotations once and filter to the items/evaluators in
-    # this run (cheaper than N item-scoped queries, and matches how the
-    # task-level alignment block fetches).
-    all_annotations = get_annotations_for_task(task_uuid)
-    relevant_annotations = [
-        a
-        for a in all_annotations
-        if a.get("item_id") in item_ids_in_run
-        and a.get("evaluator_id") in set(evaluator_ids_in_run)
-    ]
+    # Constrain the read to this run's slots at the DB layer rather than
+    # pulling the task's entire annotation history and filtering in
+    # Python — on a large task, the run is a tiny window and the filter
+    # would dominate request latency. `include_deleted_items=True`
+    # preserves annotations on items soft-deleted AFTER this run
+    # completed (the run's `evaluator_runs` rows survive item delete; the
+    # human side has to survive too or the agreement number on the
+    # run-detail view silently shrinks).
+    relevant_annotations = get_annotations_for_slots(
+        task_uuid,
+        item_ids=list(item_ids_in_run),
+        evaluator_ids=evaluator_ids_in_run,
+        include_deleted_items=True,
+    )
 
     # Per-evaluator aggregate (across every item this job touched).
     evaluator_blocks: List[Dict[str, Any]] = []
@@ -1077,6 +1131,11 @@ async def get_evaluator_run_job(
     raw_runs = get_evaluator_runs_for_job(job_uuid)
     shaped["runs"] = _enrich_runs_with_live_evaluator(raw_runs)
     shaped["human_agreement"] = _human_agreement_for_run(task_uuid, raw_runs)
+    # Frozen item snapshot — what calibrate actually saw, regardless of
+    # any post-submit edits / soft-deletes on the source annotation_items.
+    # Empty for legacy jobs created before snapshotting (those will be
+    # backfilled on first run; see annotation_eval_runner._run_job).
+    shaped["items"] = get_eval_job_items(job_uuid)
     return shaped
 
 

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -80,6 +80,33 @@ def _live_version_map(evaluators: List[Dict[str, Any]]) -> Dict[str, Optional[st
     return {e["uuid"]: e.get("live_version_id") for e in evaluators}
 
 
+def _enrich_evaluators_with_live_version(
+    evaluators: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Mutate `evaluators` in place to add live-version fields the FE
+    needs to render the labelling form / display values against the
+    correct rubric: `output_config`, `scale_min`, `scale_max`,
+    `variables`. Mirrors the public-form enrichment in `routers/public.py`
+    so the owner-side and annotator-side responses match. Versions are
+    fetched via a tiny per-call cache so a task with N evaluators that
+    happen to share a live version (rare) doesn't issue N reads."""
+    from llm_judge import _scale_bounds  # local to avoid module-load cycle
+
+    version_cache: Dict[str, Optional[Dict[str, Any]]] = {}
+    for ev in evaluators:
+        live_version_id = ev.get("live_version_id")
+        if live_version_id and live_version_id not in version_cache:
+            version_cache[live_version_id] = get_evaluator_version(live_version_id)
+        version = version_cache.get(live_version_id) if live_version_id else None
+        output_config = version.get("output_config") if version else None
+        scale_min, scale_max = _scale_bounds(output_config)
+        ev["output_config"] = output_config
+        ev["scale_min"] = scale_min
+        ev["scale_max"] = scale_max
+        ev["variables"] = version.get("variables") if version else None
+    return evaluators
+
+
 router = APIRouter(prefix="/annotation-tasks", tags=["annotation-tasks"])
 
 
@@ -185,7 +212,9 @@ async def get_annotation_task_endpoint(
     """Get an annotation task by UUID, including its linked evaluators,
     all items (each annotated with per-item agreement stats), and all jobs."""
     task = _ensure_owned_task(task_uuid, user_id)
-    evaluators = get_evaluators_for_annotation_task(task_uuid)
+    evaluators = _enrich_evaluators_with_live_version(
+        get_evaluators_for_annotation_task(task_uuid)
+    )
     task["evaluators"] = evaluators
     task["jobs"] = get_jobs_for_task_detailed(task_uuid)
 

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -2,7 +2,10 @@ from typing import Optional, List, Dict, Any
 from fastapi import APIRouter, HTTPException, Depends, Query
 from pydantic import BaseModel
 
+import logging
 import secrets
+
+logger = logging.getLogger(__name__)
 
 from db import (
     ANNOTATION_TASK_TYPES,
@@ -21,6 +24,7 @@ from db import (
     create_annotation_items,
     bulk_update_annotation_items,
     soft_delete_annotation_items,
+    soft_delete_annotation_job,
     get_annotation_items_for_task,
     get_annotation_item,
     create_annotation_job,
@@ -464,14 +468,34 @@ async def bulk_create_items(
                 if evaluator_id not in snapshot_evaluator_ids:
                     snapshot_mismatch.append(evaluator_id)
         if snapshot_mismatch:
+            # Roll back the just-created items + job so the request is
+            # atomic from the caller's perspective. Without this, a 409
+            # leaves orphaned items + a dangling pending job, and a
+            # client retry would duplicate items every time. Annotation
+            # rows haven't been written yet (this gate runs before the
+            # upsert loop), so soft-deleting items + job is sufficient.
+            try:
+                soft_delete_annotation_items(task_uuid, new_uuids)
+            except Exception as e:
+                logger.warning(
+                    f"[bulk-create-items] rollback: failed to soft-delete "
+                    f"items {new_uuids} after snapshot mismatch: {e}"
+                )
+            try:
+                soft_delete_annotation_job(job_uuid)
+            except Exception as e:
+                logger.warning(
+                    f"[bulk-create-items] rollback: failed to soft-delete "
+                    f"job {job_uuid} after snapshot mismatch: {e}"
+                )
             raise HTTPException(
                 status_code=409,
                 detail=(
                     f"Evaluator(s) were unlinked from this task between "
                     f"validation and job creation: {sorted(set(snapshot_mismatch))}. "
                     f"Re-link them and retry, or drop them from the request. "
-                    f"(The annotation job {job_uuid} was created but no "
-                    f"annotations have been written.)"
+                    f"(The created items and job have been rolled back; "
+                    f"safe to retry as-is.)"
                 ),
             )
         any_annotation_written = False
@@ -499,6 +523,14 @@ async def bulk_create_items(
             update_annotation_job_status(
                 job_uuid, status="completed", set_completed_at=True
             )
+        elif any_annotation_written:
+            # Partial fill: some slots filled, others left for the
+            # annotator to finish via the public form. Mirror the public
+            # upsert endpoint's "first save flips pending -> in_progress"
+            # transition so status-based consumers (jobs list, dashboards)
+            # don't see a job with real annotation data still labelled
+            # `pending`.
+            update_annotation_job_status(job_uuid, status="in_progress")
         return {
             "item_ids": new_uuids,
             "count": len(new_uuids),


### PR DESCRIPTION
Fixes #33 
Fixes #35 

## Summary

Two related capabilities for the annotation-task flow:

1. **Bulk-upload annotations alongside items.** `POST /annotation-tasks/{uuid}/items` now optionally accepts seeded human annotations per item, attributed to a chosen annotator. Lets the FE turn a CSV with extra evaluator columns into items + annotations in one call.
2. **Human-vs-machine agreement on every evaluator run.** `GET /annotation-tasks/{uuid}/evaluator-runs/{job_uuid}` now returns a `human_agreement` block (per-evaluator aggregate + per-item raw human values) plus an item snapshot, so the FE can show "did v3 agree with humans on the items it ran?" without extra fetches.

Plus the supporting plumbing — item snapshots for eval runs, scoped DB queries, and rollback on race conditions surfaced during code review.

## What changed

### Bulk-upload with seeded annotations (`POST /annotation-tasks/{uuid}/items`)

- Optional `annotator_id` at the top level + optional `annotations: { [evaluatorUuid]: { value, reasoning? } }` per item.
- Synthesises one `annotation_jobs` row per upload so the annotator appears once in agreement aggregates instead of N tiny jobs.
- Validates value shape (`{value, ...}` only — `pass`/`score`/`rating`/`label`/`binary` are silently ignored by `_scalar`, so the endpoint rejects them with a 400).
- Re-validates evaluator IDs against the job's snapshot after creation; on mismatch (concurrent unlink), rolls back items + job and returns 409.
- Auto-completion: full fill → `completed`, partial → `in_progress`, none → `pending`. Mirrors the public-form upsert contract.

### `human_agreement` block on the run-detail endpoint

- Per evaluator: aggregate agreement (`aggregate_human_evaluator_agreement`), pair count, item count, pinned `evaluator_version_id`.
- Per item: raw human annotations (`{annotation_id, annotator_id, annotator_name, job_id, value, updated_at}`) grouped by evaluator, plus the per-item agreement number.
- Restricted to slots actually exercised by the run; items with zero human signal are omitted entirely (so the table only shows actionable rows).
- Reads via new `get_annotations_for_slots(task_id, item_ids, evaluator_ids)` — bounded by the run's footprint instead of the task's history.

### Item snapshots for evaluator runs

- New `annotation_eval_job_items(job_id, item_id, payload)` table, written at submission time.
- Runner reads payloads from the snapshot (falls back to live for legacy in-flight jobs and back-fills the snapshot on the way through).
- Run-detail endpoint exposes the snapshot as `items[]` so the FE can render payloads even after the source item is soft-deleted.
- `get_annotations_for_task` gains `include_deleted_items` so the run-detail view's human side survives item soft-delete; aggregate views (task page, trends) keep dropping deleted items as before.

### `GET /annotation-tasks/{uuid}` enrichment

- Each evaluator now returns `output_config`, `scale_min`, `scale_max`, `variables` from its live version (matching the public form's enrichment) so the FE can render values against the correct rubric without a second roundtrip.

## Files

- `src/db.py` — new tables + helpers: `annotation_eval_job_items`, `snapshot_eval_job_items`, `get_eval_job_items`, `get_annotations_for_slots`, `soft_delete_annotation_job`. `get_annotations_for_task` gains `include_deleted_items`.
- `src/routers/annotation_tasks.py` — bulk-upload extension, `human_agreement` helper, run-detail snapshot wiring, evaluator enrichment helper.
- `src/annotation_eval_runner.py` — runner reads from item snapshot with legacy fallback.

## Test plan

- [ ] Bulk-upload with no `annotations` key behaves exactly as before.
- [ ] Bulk-upload with `annotator_id` + `annotations` creates one job and writes annotations; full fill → `completed`, partial → `in_progress`.
- [ ] Bulk-upload with malformed value (`{pass: true}` or non-dict) → 400 with actionable message.
- [ ] Bulk-upload with evaluator unlinked between validation and job creation → 409 and items + job soft-deleted (no orphans).
- [ ] Run an evaluator on a task with seeded annotations → `human_agreement.evaluators[]` shows non-null agreement; `human_agreement.items[]` shows raw values per annotator.
- [ ] Soft-delete an item after a run completes → run-detail still shows the item via `items[]`, `human_agreement` still includes its annotations; task-page and `/agreement` exclude it as before.
- [ ] `GET /annotation-tasks/{uuid}` returns `output_config`/`scale_min`/`scale_max` per evaluator.
```
