### PR TITLE
Expose reasoning on human_annotations in evaluator-run response

### DIFF
--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -1139,6 +1139,12 @@ def _human_agreement_for_run(
             annotator = (
                 annotators_by_uuid.get(annotator_id) if annotator_id else None
             )
+            raw_value = a.get("value")
+            reasoning = (
+                raw_value.get("reasoning")
+                if isinstance(raw_value, dict)
+                else None
+            )
             annotations_by_evaluator.setdefault(ev_id, []).append(
                 {
                     "annotation_id": a.get("uuid"),
@@ -1147,7 +1153,8 @@ def _human_agreement_for_run(
                         annotator.get("name") if annotator else None
                     ),
                     "job_id": a.get("job_id"),
-                    "value": a.get("value"),
+                    "value": raw_value,
+                    "reasoning": reasoning,
                     "updated_at": a.get("updated_at"),
                 }
             )


### PR DESCRIPTION
## Summary
- Adds a top-level `reasoning` field to each entry in `human_agreement.items[].evaluators[].human_annotations[]` returned by `GET /annotation-tasks/{task_uuid}/evaluator-runs/{job_uuid}`.
- Reasoning is extracted from the stored `value` dict (`{value, reasoning?}`); falls back to `null` when the stored value isn't a dict or has no `reasoning` key.
- `value` itself is unchanged for backwards compatibility.

## Why
Frontend wants to render annotator reasoning next to the agreement cell without having to reach into the raw `value` blob.

## Test plan
- [ ] Hit the endpoint with a job that has human annotations carrying non-empty `reasoning` — verify the field surfaces verbatim.
- [ ] Verify entries with empty / missing reasoning return `null` or `""` as stored, without breaking the response shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)