### PR TITLE
Add abort endpoints for STT/TTS, LLM test/benchmark, and evaluator-run jobs

### DIFF
--- a/src/annotation_eval_runner.py
+++ b/src/annotation_eval_runner.py
@@ -110,6 +110,12 @@ SUPPORTED_EVAL_TASK_TYPES = ("stt", "llm", "simulation")
 logger = logging.getLogger(__name__)
 
 
+def _is_job_aborted(job_uuid: str) -> bool:
+    """Check if an annotation-eval job was aborted by the user."""
+    job = get_job(job_uuid)
+    return bool(job and (job.get("details") or {}).get("aborted"))
+
+
 # ---------------------------------------------------------------------------
 # Output parsing — generic eval-only output dir (same layout as STT --eval-only)
 # ---------------------------------------------------------------------------
@@ -779,6 +785,12 @@ class AnnotationEvalTimeoutError(RuntimeError):
     upload partials)."""
 
 
+class AnnotationEvalAbortedError(RuntimeError):
+    """Raised when the polling loop detects a user-requested abort. The outer
+    handler must NOT overwrite the abort state — the abort endpoint is the
+    authoritative writer of the final results/status for an aborted job."""
+
+
 def _run_calibrate_eval_only(
     cmd: List[str],
     cwd: Path,
@@ -823,6 +835,18 @@ def _run_calibrate_eval_only(
                 logger.warning(f"on_started callback raised: {e}")
         last_snapshot: Tuple[int, int] = _output_dir_snapshot(log_dir)
         while proc.poll() is None:
+            if job_uuid is not None and _is_job_aborted(job_uuid):
+                logger.info(
+                    f"[annotation-eval] job {job_uuid} aborted, killing pgid {proc.pid}"
+                )
+                kill_process_group(proc.pid, job_uuid)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+                raise AnnotationEvalAbortedError(
+                    "annotation-eval job aborted by user"
+                )
             time.sleep(heartbeat_seconds)
             if job_uuid is None:
                 continue
@@ -1100,7 +1124,18 @@ def _run_job(
                 },
             )
             logger.info(f"[annotation-eval] job {job_uuid} completed")
+    except AnnotationEvalAbortedError:
+        # User-initiated abort: the abort endpoint already marked the job
+        # done/aborted with the runs collected so far. Don't overwrite that.
+        logger.info(
+            f"[annotation-eval] job {job_uuid} aborted by user; skipping final update"
+        )
     except subprocess.CalledProcessError as e:
+        if _is_job_aborted(job_uuid):
+            logger.info(
+                f"[annotation-eval] job {job_uuid} aborted, skipping error update"
+            )
+            return
         # The calibrate CLI exited non-zero. Surface the actual stderr (or the
         # structured `{"status":"error","error":"..."}` blob if present) so the
         # API caller sees what went wrong, mirroring stt/tts/etc.
@@ -1122,6 +1157,11 @@ def _run_job(
             details=details_patch,
         )
     except Exception as e:
+        if _is_job_aborted(job_uuid):
+            logger.info(
+                f"[annotation-eval] job {job_uuid} aborted, skipping error update"
+            )
+            return
         traceback.print_exc()
         logger.exception(f"[annotation-eval] job {job_uuid} failed: {e}")
         capture_exception_to_sentry(e)

--- a/src/annotation_eval_runner.py
+++ b/src/annotation_eval_runner.py
@@ -885,6 +885,14 @@ def _run_calibrate_eval_only(
                     f"calibrate --eval-only timed out after {timeout_seconds}s "
                     "with no progress"
                 )
+    # Re-check abort after natural subprocess exit: an abort flag set
+    # AFTER `proc.poll()` returned non-None but BEFORE _run_job's parse +
+    # final update_job below would otherwise be silently overwritten by
+    # the success path.
+    if job_uuid is not None and _is_job_aborted(job_uuid):
+        raise AnnotationEvalAbortedError(
+            "annotation-eval job aborted by user (post-exit)"
+        )
     try:
         with open(stdout_path, "r") as f:
             stdout = f.read()
@@ -1109,6 +1117,15 @@ def _run_job(
                     upload_file_to_s3(
                         s3, local_path, s3_bucket, f"{s3_prefix}/{rel}"
                     )
+
+            # Last-chance abort check: parse + create_evaluator_runs + S3
+            # upload above can take seconds-to-minutes; an abort that lands
+            # during that window must not be overwritten by the success
+            # write below.
+            if _is_job_aborted(job_uuid):
+                raise AnnotationEvalAbortedError(
+                    "annotation-eval job aborted by user (pre-final-update)"
+                )
 
             # 7. Mark job completed (status + completed_at on the generic
             # jobs table; metrics + s3_prefix go into details so polling

--- a/src/db.py
+++ b/src/db.py
@@ -4839,8 +4839,12 @@ def update_agent_test_job(
     job_uuid: str,
     status: Optional[str] = None,
     results: Optional[Dict[str, Any]] = None,
+    details: Optional[Dict[str, Any]] = None,
 ) -> bool:
-    """Update an agent test job. Returns True if the job was found and updated."""
+    """Update an agent test job. Returns True if the job was found and updated.
+
+    If details is provided, it will be merged with existing details (not replaced).
+    """
     updates = []
     params = []
 
@@ -4850,6 +4854,20 @@ def update_agent_test_job(
     if results is not None:
         updates.append("results = ?")
         params.append(json.dumps(results))
+
+    if details is not None:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT details FROM agent_test_jobs WHERE uuid = ?", (job_uuid,)
+            )
+            row = cursor.fetchone()
+            if row and row[0]:
+                existing_details = json.loads(row[0])
+                existing_details.update(details)
+                details = existing_details
+        updates.append("details = ?")
+        params.append(json.dumps(details))
 
     if not updates:
         return False

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -1460,7 +1460,10 @@ def run_llm_test_task(
                             prev_completed = completed
                         time.sleep(2)  # Poll every 2 seconds
 
-                    if aborted:
+                    # Re-check abort after natural subprocess exit: an abort
+                    # could arrive between `poll()` returning non-None and
+                    # the final update_agent_test_job below.
+                    if aborted or _is_job_aborted(task_id):
                         logger.info(
                             f"LLM test {task_id} was aborted by user, skipping final processing"
                         )
@@ -1555,6 +1558,15 @@ def run_llm_test_task(
                 config_s3_key = f"{results_prefix}/test_config.json"
                 upload_file_to_s3(s3, config_file, s3_bucket, config_s3_key)
                 logger.info(f"Uploaded config file to S3: {config_s3_key}")
+
+                # Last-chance abort check: parsing + S3 uploads above can
+                # take seconds; an abort that lands during that window
+                # must not be overwritten.
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"LLM test {task_id} aborted before final update, skipping"
+                    )
+                    return
 
                 # Update job with results
                 update_agent_test_job(
@@ -2149,7 +2161,10 @@ def run_benchmark_task(
                             prev_completed = completed
                         time.sleep(2)  # Poll every 2 seconds
 
-                    if aborted:
+                    # Re-check abort after natural subprocess exit: an abort
+                    # could arrive between `poll()` returning non-None and
+                    # the final update_agent_test_job below.
+                    if aborted or _is_job_aborted(task_id):
                         logger.info(
                             f"Benchmark {task_id} was aborted by user, skipping final processing"
                         )
@@ -2328,6 +2343,15 @@ def run_benchmark_task(
                 if not all_succeeded:
                     failed = [r.model for r in model_results if not r.success]
                     error_msg = f"Some models failed: {', '.join(failed)}"
+
+                # Last-chance abort check: parsing + S3 uploads above can
+                # take seconds-to-minutes; an abort that lands during that
+                # window must not be overwritten.
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"Benchmark {task_id} aborted before final update, skipping"
+                    )
+                    return
 
                 # Update job with results
                 update_agent_test_job(

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -2657,7 +2657,6 @@ async def abort_agent_test_job(
         )
 
     details = job.get("details") or {}
-    results = job.get("results") or {}
 
     # Mark aborted FIRST so the polling loop's guard fires immediately.
     update_agent_test_job(job_uuid, details={"aborted": True})
@@ -2669,6 +2668,7 @@ async def abort_agent_test_job(
     # Best-effort: upload whatever partial output the subprocess already
     # wrote to the temp directory before we killed it.
     output_dir_str = details.get("output_dir")
+    uploaded_prefix: Optional[str] = None
     if output_dir_str:
         try:
             output_dir = Path(output_dir_str)
@@ -2676,17 +2676,28 @@ async def abort_agent_test_job(
                 s3 = get_s3_client()
                 s3_bucket = get_s3_output_config()
                 if job.get("type") == "llm-benchmark":
-                    prefix = f"agent-tests/benchmarks/{job_uuid}/outputs"
+                    uploaded_prefix = f"agent-tests/benchmarks/{job_uuid}/outputs"
                 else:
-                    prefix = f"agent-tests/runs/{job_uuid}"
-                upload_directory_tree_to_s3(s3, output_dir, s3_bucket, prefix)
-                results = dict(results)
-                results.setdefault("results_s3_prefix", prefix)
+                    uploaded_prefix = f"agent-tests/runs/{job_uuid}"
+                upload_directory_tree_to_s3(
+                    s3, output_dir, s3_bucket, uploaded_prefix
+                )
         except Exception as exc:
             logger.warning(
                 f"Failed to upload partial outputs for aborted job {job_uuid}: {exc}"
             )
 
+    # Re-read results from the DB right before the final write: the
+    # worker's polling loop may have committed newer
+    # test_results/model_results between our initial snapshot above and
+    # now (kill_process_group sends SIGTERM; the subprocess takes a
+    # moment to actually die, and the polling thread can land one more
+    # `_update_*_intermediate_results` write in that window). Using the
+    # stale snapshot here would overwrite those newer partials.
+    fresh_job = get_agent_test_job(job_uuid) or {}
+    results = dict(fresh_job.get("results") or {})
+    if uploaded_prefix:
+        results.setdefault("results_s3_prefix", uploaded_prefix)
     results["error"] = "user_aborted"
 
     update_agent_test_job(

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -49,6 +49,7 @@ from utils import (
     try_start_queued_agent_test_job,
     register_job_starter,
     is_job_timed_out,
+    kill_process_group,
     capture_exception_to_sentry,
     build_tool_configs,
     upload_directory_tree_to_s3,
@@ -57,6 +58,12 @@ from utils import (
 
 # Job types that share the same queue
 AGENT_TEST_JOB_TYPES = ["llm-unit-test", "llm-benchmark"]
+
+
+def _is_job_aborted(task_id: str) -> bool:
+    """Check if an agent test (LLM unit test or benchmark) job was aborted."""
+    job = get_agent_test_job(task_id)
+    return bool(job and (job.get("details") or {}).get("aborted"))
 
 
 def _start_llm_unit_test_job_from_queue(job: dict) -> bool:
@@ -1413,9 +1420,36 @@ def run_llm_test_task(
                         cwd=str(temp_path),
                     )
 
+                    # Persist pid/pgid so an abort endpoint can kill the
+                    # process group, and so recovery can clean up orphans.
+                    update_agent_test_job(
+                        task_id,
+                        details={
+                            "pid": process.pid,
+                            "pgid": process.pid,
+                            "output_dir": str(output_dir),
+                        },
+                    )
+
                     # Poll for process completion while updating intermediate results
                     prev_completed = 0
+                    aborted = False
                     while process.poll() is None:
+                        if _is_job_aborted(task_id):
+                            logger.info(
+                                f"LLM test {task_id} aborted, killing process group and stopping"
+                            )
+                            kill_process_group(process.pid, task_id)
+                            try:
+                                process.wait(timeout=5)
+                            except subprocess.TimeoutExpired:
+                                process.kill()
+                                try:
+                                    process.wait(timeout=5)
+                                except subprocess.TimeoutExpired:
+                                    pass
+                            aborted = True
+                            break
                         completed = _update_agent_test_intermediate_results(
                             task_id, output_dir, test_names
                         )
@@ -1425,6 +1459,12 @@ def run_llm_test_task(
                             )
                             prev_completed = completed
                         time.sleep(2)  # Poll every 2 seconds
+
+                    if aborted:
+                        logger.info(
+                            f"LLM test {task_id} was aborted by user, skipping final processing"
+                        )
+                        return
 
                     # Final update after process completes
                     _update_agent_test_intermediate_results(
@@ -1535,6 +1575,11 @@ def run_llm_test_task(
                 )
 
             except subprocess.CalledProcessError as e:
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"LLM test {task_id} aborted, skipping error update"
+                    )
+                    return
                 traceback.print_exc()
                 capture_exception_to_sentry(e)
                 # Preserve any existing results from the job
@@ -1564,6 +1609,11 @@ def run_llm_test_task(
                     results=existing_results,
                 )
             except Exception as e:
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"LLM test {task_id} aborted, skipping error update"
+                    )
+                    return
                 traceback.print_exc()
                 capture_exception_to_sentry(e)
                 # Preserve any existing results from the job
@@ -1594,17 +1644,22 @@ def run_llm_test_task(
                 )
 
     except Exception as e:
-        traceback.print_exc()
-        capture_exception_to_sentry(e)
-        # Preserve any existing results from the job
-        existing_job = get_agent_test_job(task_id)
-        existing_results = (existing_job.get("results") or {}) if existing_job else {}
-        existing_results["error"] = f"Task failed: {str(e)}"
-        update_agent_test_job(
-            task_id,
-            status=TaskStatus.FAILED.value,
-            results=existing_results,
-        )
+        if _is_job_aborted(task_id):
+            logger.info(
+                f"LLM test {task_id} aborted, skipping error update"
+            )
+        else:
+            traceback.print_exc()
+            capture_exception_to_sentry(e)
+            # Preserve any existing results from the job
+            existing_job = get_agent_test_job(task_id)
+            existing_results = (existing_job.get("results") or {}) if existing_job else {}
+            existing_results["error"] = f"Task failed: {str(e)}"
+            update_agent_test_job(
+                task_id,
+                status=TaskStatus.FAILED.value,
+                results=existing_results,
+            )
     finally:
         # Try to start the next queued job
         try_start_queued_agent_test_job(AGENT_TEST_JOB_TYPES)
@@ -2056,9 +2111,34 @@ def run_benchmark_task(
                         cwd=str(temp_path),
                     )
 
+                    update_agent_test_job(
+                        task_id,
+                        details={
+                            "pid": process.pid,
+                            "pgid": process.pid,
+                            "output_dir": str(output_dir),
+                        },
+                    )
+
                     # Poll for process completion while updating intermediate results
                     prev_completed = 0
+                    aborted = False
                     while process.poll() is None:
+                        if _is_job_aborted(task_id):
+                            logger.info(
+                                f"Benchmark {task_id} aborted, killing process group and stopping"
+                            )
+                            kill_process_group(process.pid, task_id)
+                            try:
+                                process.wait(timeout=5)
+                            except subprocess.TimeoutExpired:
+                                process.kill()
+                                try:
+                                    process.wait(timeout=5)
+                                except subprocess.TimeoutExpired:
+                                    pass
+                            aborted = True
+                            break
                         completed = _update_benchmark_intermediate_results(
                             task_id, output_dir, models, test_names, cli_models
                         )
@@ -2068,6 +2148,12 @@ def run_benchmark_task(
                             )
                             prev_completed = completed
                         time.sleep(2)  # Poll every 2 seconds
+
+                    if aborted:
+                        logger.info(
+                            f"Benchmark {task_id} was aborted by user, skipping final processing"
+                        )
+                        return
 
                     # Final update after process completes
                     _update_benchmark_intermediate_results(
@@ -2260,6 +2346,11 @@ def run_benchmark_task(
                 )
 
             except subprocess.CalledProcessError as e:
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"Benchmark {task_id} aborted, skipping error update"
+                    )
+                    return
                 traceback.print_exc()
                 capture_exception_to_sentry(e)
                 failed_results: Dict[str, Any] = {
@@ -2280,6 +2371,11 @@ def run_benchmark_task(
                     results=failed_results,
                 )
             except Exception as e:
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"Benchmark {task_id} aborted, skipping error update"
+                    )
+                    return
                 traceback.print_exc()
                 capture_exception_to_sentry(e)
                 # Preserve any existing results from the job
@@ -2306,17 +2402,22 @@ def run_benchmark_task(
                 )
 
     except Exception as e:
-        traceback.print_exc()
-        capture_exception_to_sentry(e)
-        # Preserve any existing results from the job
-        existing_job = get_agent_test_job(task_id)
-        existing_results = (existing_job.get("results") or {}) if existing_job else {}
-        existing_results["error"] = f"Task failed: {str(e)}"
-        update_agent_test_job(
-            task_id,
-            status=TaskStatus.FAILED.value,
-            results=existing_results,
-        )
+        if _is_job_aborted(task_id):
+            logger.info(
+                f"Benchmark {task_id} aborted, skipping error update"
+            )
+        else:
+            traceback.print_exc()
+            capture_exception_to_sentry(e)
+            # Preserve any existing results from the job
+            existing_job = get_agent_test_job(task_id)
+            existing_results = (existing_job.get("results") or {}) if existing_job else {}
+            existing_results["error"] = f"Task failed: {str(e)}"
+            update_agent_test_job(
+                task_id,
+                status=TaskStatus.FAILED.value,
+                results=existing_results,
+            )
     finally:
         # Try to start the next queued job
         try_start_queued_agent_test_job(AGENT_TEST_JOB_TYPES)
@@ -2502,6 +2603,85 @@ async def get_benchmark_status(task_id: str):
         is_public=bool(job.get("is_public")),
         share_token=job.get("share_token"),
     )
+
+
+@router.post("/job/{job_uuid}/abort")
+async def abort_agent_test_job(
+    job_uuid: str, user_id: str = Depends(get_current_user_id)
+):
+    """Abort a running LLM unit test or benchmark job, preserving partial results.
+
+    Kills the running calibrate subprocess and marks the job as done with
+    whatever intermediate results were already written to the DB by the
+    polling loop. Only the owner of the agent can abort their jobs.
+    """
+    job = get_agent_test_job(job_uuid)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # Check ownership via agent
+    agent_id = job.get("agent_id")
+    if not agent_id:
+        raise HTTPException(status_code=404, detail="Job not found")
+    agent = get_agent(agent_id)
+    if not agent or agent.get("user_id") != user_id:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if job.get("status") != TaskStatus.IN_PROGRESS.value:
+        raise HTTPException(
+            status_code=400, detail="Can only abort in-progress jobs"
+        )
+
+    details = job.get("details") or {}
+    results = job.get("results") or {}
+
+    # Mark aborted FIRST so the polling loop's guard fires immediately.
+    update_agent_test_job(job_uuid, details={"aborted": True})
+
+    pid = details.get("pid") or details.get("pgid")
+    if pid:
+        kill_process_group(pid, job_uuid)
+
+    # Best-effort: upload whatever partial output the subprocess already
+    # wrote to the temp directory before we killed it.
+    output_dir_str = details.get("output_dir")
+    if output_dir_str:
+        try:
+            output_dir = Path(output_dir_str)
+            if output_dir.exists():
+                s3 = get_s3_client()
+                s3_bucket = get_s3_output_config()
+                if job.get("type") == "llm-benchmark":
+                    prefix = f"agent-tests/benchmarks/{job_uuid}/outputs"
+                else:
+                    prefix = f"agent-tests/runs/{job_uuid}"
+                upload_directory_tree_to_s3(s3, output_dir, s3_bucket, prefix)
+                results = dict(results)
+                results.setdefault("results_s3_prefix", prefix)
+        except Exception as exc:
+            logger.warning(
+                f"Failed to upload partial outputs for aborted job {job_uuid}: {exc}"
+            )
+
+    results["error"] = "user_aborted"
+
+    update_agent_test_job(
+        job_uuid,
+        status=TaskStatus.DONE.value,
+        results=results,
+    )
+
+    # Drain queue
+    try_start_queued_agent_test_job(AGENT_TEST_JOB_TYPES)
+
+    updated = get_agent_test_job(job_uuid) or {}
+    updated_results = updated.get("results") or {}
+    return {
+        "task_id": job_uuid,
+        "status": TaskStatus.DONE.value,
+        "type": updated.get("type"),
+        "results": updated_results,
+    }
 
 
 @router.delete("/job/{job_uuid}")

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -1513,10 +1513,18 @@ async def abort_evaluator_run_job(
     if pid:
         kill_process_group(pid, job_uuid)
 
+    # Re-read the job before the final write. The runner has its own
+    # abort guards but may have committed `details.{metrics,s3_prefix}`
+    # or partial `results` between our initial read and now; preserve
+    # those by merging rather than overwriting.
+    fresh_job = get_job(job_uuid, user_id=user_id) or {}
+    fresh_results = dict(fresh_job.get("results") or {})
+    fresh_results["error"] = "user_aborted"
+
     update_job(
         job_uuid,
         status=TaskStatus.DONE.value,
-        results={"error": "user_aborted"},
+        results=fresh_results,
         details={"completed_at": _utcnow_str_for_abort()},
     )
 

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -68,6 +68,7 @@ from utils import (
     TaskStatus,
     can_start_job,
     compute_share_token_toggle,
+    kill_process_group,
     try_start_queued_job,
 )
 from auth_utils import get_current_user_id
@@ -1474,6 +1475,71 @@ async def get_evaluator_run_job(
     # backfilled on first run; see annotation_eval_runner._run_job).
     shaped["items"] = get_eval_job_items(job_uuid)
     return shaped
+
+
+@router.post("/{task_uuid}/evaluator-runs/{job_uuid}/abort")
+async def abort_evaluator_run_job(
+    task_uuid: str,
+    job_uuid: str,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Abort a running evaluator-run job, preserving partial evaluator_runs rows.
+
+    Kills the running calibrate subprocess and marks the job as done. Any
+    `evaluator_runs` rows the worker has already inserted up to this point
+    are retained. The runner is responsible for noticing the abort flag
+    (set here before the SIGTERM) and skipping its final overwrite.
+    """
+    _ensure_owned_task(task_uuid, user_id)
+    job = get_job(job_uuid, user_id=user_id)
+    if (
+        not job
+        or job.get("type") != ANNOTATION_EVAL_JOB_TYPE
+        or (job.get("details") or {}).get("task_id") != task_uuid
+    ):
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if job.get("status") != TaskStatus.IN_PROGRESS.value:
+        raise HTTPException(
+            status_code=400, detail="Can only abort in-progress jobs"
+        )
+
+    details = job.get("details") or {}
+
+    # Mark aborted FIRST so the runner's polling guard fires immediately.
+    update_job(job_uuid, details={"aborted": True})
+
+    pid = details.get("pid") or details.get("pgid")
+    if pid:
+        kill_process_group(pid, job_uuid)
+
+    update_job(
+        job_uuid,
+        status=TaskStatus.DONE.value,
+        results={"error": "user_aborted"},
+        details={"completed_at": _utcnow_str_for_abort()},
+    )
+
+    try:
+        try_start_queued_job(EVAL_JOB_TYPES)
+    except Exception:
+        pass
+
+    updated = get_job(job_uuid, user_id=user_id) or {}
+    return {
+        "task_id": job_uuid,
+        "status": TaskStatus.DONE.value,
+        "results": updated.get("results"),
+    }
+
+
+def _utcnow_str_for_abort() -> str:
+    """SQLite CURRENT_TIMESTAMP-style UTC string for the abort path. Kept
+    local to avoid pulling in `annotation_eval_runner._utcnow_str` (private)
+    or adding a tiny new util just for this one call site."""
+    from datetime import datetime as _dt
+
+    return _dt.utcnow().strftime("%Y-%m-%d %H:%M:%S")
 
 
 @router.delete("/{task_uuid}/evaluator-runs/{job_uuid}")

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -454,7 +454,14 @@ def run_evaluation_task(
                             # Process still running, send heartbeat to refresh updated_at
                             update_job(task_id)
 
-                    if aborted:
+                    # Re-check the abort flag after the loop exits: an abort
+                    # request may arrive AFTER the subprocess has exited
+                    # naturally (so we never set `aborted` via the inner
+                    # branch) but BEFORE the worker reaches the final
+                    # update_job below. Without this guard, the normal
+                    # completion path overwrites the abort endpoint's
+                    # status=done / error=user_aborted with success.
+                    if aborted or _is_job_aborted(task_id):
                         logger.info(
                             f"STT eval {task_id} was aborted by user, skipping final processing"
                         )
@@ -583,6 +590,15 @@ def run_evaluation_task(
                 if not all_succeeded:
                     failed = [r.provider for r in provider_results if not r.success]
                     error_msg = f"Some providers failed: {', '.join(failed)}"
+
+                # Last-chance abort check: results parsing + S3 upload above
+                # can take seconds-to-minutes, plenty of room for an abort
+                # request to arrive after the post-loop guard.
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"STT eval {task_id} aborted before final update, skipping"
+                    )
+                    return
 
                 # Update job with results
                 update_job(

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -8,7 +8,7 @@ import traceback
 import threading
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, ConfigDict
@@ -53,6 +53,12 @@ from utils import (
 
 # Job types that share the same queue
 EVAL_JOB_TYPES = ["stt-eval", "tts-eval", "annotation-eval"]
+
+
+def _is_job_aborted(task_id: str) -> bool:
+    """Check if an STT eval job was aborted by the user."""
+    job = get_job(task_id)
+    return bool(job and (job.get("details") or {}).get("aborted"))
 
 
 def _resolve_evaluators_for_job(
@@ -426,11 +432,33 @@ def run_evaluation_task(
                     # Poll for process completion with heartbeat to keep updated_at fresh
                     # This prevents the job from being marked as timed out during long runs
                     HEARTBEAT_INTERVAL = 2  # seconds
+                    aborted = False
                     while process.poll() is None:
+                        if _is_job_aborted(task_id):
+                            logger.info(
+                                f"STT eval {task_id} aborted, killing process group and stopping"
+                            )
+                            kill_process_group(process.pid, task_id)
+                            try:
+                                process.wait(timeout=5)
+                            except subprocess.TimeoutExpired:
+                                process.kill()
+                                try:
+                                    process.wait(timeout=5)
+                                except subprocess.TimeoutExpired:
+                                    pass
+                            aborted = True
+                            break
                         time.sleep(HEARTBEAT_INTERVAL)
                         if process.poll() is None:
                             # Process still running, send heartbeat to refresh updated_at
                             update_job(task_id)
+
+                    if aborted:
+                        logger.info(
+                            f"STT eval {task_id} was aborted by user, skipping final processing"
+                        )
+                        return
 
                 # Read stdout/stderr
                 with open(stdout_path, "r") as f:
@@ -568,6 +596,11 @@ def run_evaluation_task(
                 )
 
             except subprocess.CalledProcessError as e:
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"STT eval {task_id} aborted, skipping error update"
+                    )
+                    return
                 traceback.print_exc()
                 capture_exception_to_sentry(e)
                 error_results = {
@@ -600,6 +633,11 @@ def run_evaluation_task(
                     results=error_results,
                 )
             except Exception as e:
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"STT eval {task_id} aborted, skipping error update"
+                    )
+                    return
                 traceback.print_exc()
                 capture_exception_to_sentry(e)
                 error_results = {
@@ -633,13 +671,18 @@ def run_evaluation_task(
                 )
 
     except Exception as e:
-        traceback.print_exc()
-        capture_exception_to_sentry(e)
-        update_job(
-            task_id,
-            status=TaskStatus.FAILED.value,
-            results={"error": f"Task failed: {str(e)}"},
-        )
+        if _is_job_aborted(task_id):
+            logger.info(
+                f"STT eval {task_id} aborted, skipping error update"
+            )
+        else:
+            traceback.print_exc()
+            capture_exception_to_sentry(e)
+            update_job(
+                task_id,
+                status=TaskStatus.FAILED.value,
+                results={"error": f"Task failed: {str(e)}"},
+            )
     finally:
         # Try to start the next queued job
         try_start_queued_job(EVAL_JOB_TYPES)
@@ -742,6 +785,123 @@ class VisibilityRequest(BaseModel):
 class VisibilityResponse(BaseModel):
     is_public: bool
     share_token: str | None = None
+
+
+@router.post("/evaluate/{task_id}/abort", response_model=TaskStatusResponse)
+async def abort_stt_evaluation(
+    task_id: str, user_id: str = Depends(get_current_user_id)
+):
+    """Abort a running STT evaluation job, preserving partial provider results.
+
+    Kills the running calibrate subprocess, collects whatever each provider
+    managed to write to disk, and saves the partial results with status=done.
+    """
+    job = get_job(task_id, user_id=user_id)
+    if not job or job.get("type") != "stt-eval":
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if job.get("status") != TaskStatus.IN_PROGRESS.value:
+        raise HTTPException(
+            status_code=400, detail="Can only abort in-progress jobs"
+        )
+
+    details = job.get("details") or {}
+    results = job.get("results") or {}
+
+    # Mark aborted FIRST so the polling loop's guard fires immediately.
+    update_job(task_id, details={"aborted": True})
+
+    # Kill running process group
+    pid = details.get("pid") or details.get("pgid")
+    if pid:
+        kill_process_group(pid, task_id)
+
+    # Collect partial results from disk and merge with any existing successful ones
+    requested_providers = details.get("providers", [])
+    output_dir_str = details.get("output_dir")
+    existing_provider_results = results.get("provider_results", []) or []
+    existing_success_map = {
+        pr.get("provider"): pr
+        for pr in existing_provider_results
+        if pr.get("success") is True
+    }
+
+    merged_results: List[Dict[str, Any]] = []
+    if output_dir_str:
+        try:
+            output_dir = Path(output_dir_str)
+            if output_dir.exists():
+                intermediate = _collect_intermediate_results(
+                    output_dir,
+                    requested_providers,
+                    len(details.get("audio_paths") or []),
+                )
+                intermediate_map = {
+                    r.provider: r.model_dump() for r in intermediate
+                }
+                for provider in requested_providers:
+                    if provider in existing_success_map:
+                        merged_results.append(existing_success_map[provider])
+                    elif provider in intermediate_map:
+                        merged_results.append(intermediate_map[provider])
+                    else:
+                        merged_results.append(
+                            {
+                                "provider": provider,
+                                "success": False,
+                                "metrics": None,
+                                "results": None,
+                            }
+                        )
+                # Upload partial outputs to S3 (best effort)
+                try:
+                    s3 = get_s3_client()
+                    s3_bucket = details.get("s3_bucket") or get_s3_output_config()
+                    upload_directory_tree_to_s3(
+                        s3,
+                        output_dir,
+                        s3_bucket,
+                        f"stt/evals/{task_id}/outputs",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        f"Failed to upload partial outputs for aborted STT job {task_id}: {exc}"
+                    )
+        except Exception as exc:
+            logger.warning(
+                f"Failed to collect intermediate results on abort: {exc}"
+            )
+
+    if not merged_results and existing_provider_results:
+        merged_results = existing_provider_results
+
+    results["provider_results"] = merged_results
+    results["error"] = "user_aborted"
+
+    update_job(
+        task_id,
+        status=TaskStatus.DONE.value,
+        results=results,
+    )
+
+    # Drain queue
+    try_start_queued_job(EVAL_JOB_TYPES)
+
+    # Re-read for fresh state
+    updated = get_job(task_id, user_id=user_id) or {}
+    updated_results = updated.get("results") or {}
+    return TaskStatusResponse(
+        task_id=task_id,
+        status=TaskStatus.DONE.value,
+        language=details.get("language"),
+        dataset_id=details.get("dataset_id"),
+        dataset_name=details.get("dataset_name"),
+        provider_results=updated_results.get("provider_results"),
+        leaderboard_summary=updated_results.get("leaderboard_summary"),
+        error=updated_results.get("error"),
+        is_public=bool(updated.get("is_public")),
+        share_token=updated.get("share_token"),
+    )
 
 
 @router.patch("/evaluate/{task_id}/visibility", response_model=VisibilityResponse)

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -822,7 +822,6 @@ async def abort_stt_evaluation(
         )
 
     details = job.get("details") or {}
-    results = job.get("results") or {}
 
     # Mark aborted FIRST so the polling loop's guard fires immediately.
     update_job(task_id, details={"aborted": True})
@@ -832,17 +831,10 @@ async def abort_stt_evaluation(
     if pid:
         kill_process_group(pid, task_id)
 
-    # Collect partial results from disk and merge with any existing successful ones
+    # Collect partial results from disk (best effort) and upload partials.
     requested_providers = details.get("providers", [])
     output_dir_str = details.get("output_dir")
-    existing_provider_results = results.get("provider_results", []) or []
-    existing_success_map = {
-        pr.get("provider"): pr
-        for pr in existing_provider_results
-        if pr.get("success") is True
-    }
-
-    merged_results: List[Dict[str, Any]] = []
+    intermediate_map: Dict[str, Dict[str, Any]] = {}
     if output_dir_str:
         try:
             output_dir = Path(output_dir_str)
@@ -855,21 +847,6 @@ async def abort_stt_evaluation(
                 intermediate_map = {
                     r.provider: r.model_dump() for r in intermediate
                 }
-                for provider in requested_providers:
-                    if provider in existing_success_map:
-                        merged_results.append(existing_success_map[provider])
-                    elif provider in intermediate_map:
-                        merged_results.append(intermediate_map[provider])
-                    else:
-                        merged_results.append(
-                            {
-                                "provider": provider,
-                                "success": False,
-                                "metrics": None,
-                                "results": None,
-                            }
-                        )
-                # Upload partial outputs to S3 (best effort)
                 try:
                     s3 = get_s3_client()
                     s3_bucket = details.get("s3_bucket") or get_s3_output_config()
@@ -887,6 +864,38 @@ async def abort_stt_evaluation(
             logger.warning(
                 f"Failed to collect intermediate results on abort: {exc}"
             )
+
+    # Re-read results from the DB right before the final write. The
+    # worker may have committed a fresher `provider_results` snapshot
+    # between our initial read and now (kill_process_group sends SIGTERM;
+    # the subprocess takes a moment to die, and the polling thread can
+    # land one more write in that window). Using the stale snapshot
+    # would overwrite those newer partials.
+    fresh_job = get_job(task_id, user_id=user_id) or {}
+    results = dict(fresh_job.get("results") or {})
+    existing_provider_results = results.get("provider_results", []) or []
+    existing_success_map = {
+        pr.get("provider"): pr
+        for pr in existing_provider_results
+        if pr.get("success") is True
+    }
+
+    merged_results: List[Dict[str, Any]] = []
+    if intermediate_map or existing_provider_results:
+        for provider in requested_providers:
+            if provider in existing_success_map:
+                merged_results.append(existing_success_map[provider])
+            elif provider in intermediate_map:
+                merged_results.append(intermediate_map[provider])
+            else:
+                merged_results.append(
+                    {
+                        "provider": provider,
+                        "success": False,
+                        "metrics": None,
+                        "results": None,
+                    }
+                )
 
     if not merged_results and existing_provider_results:
         merged_results = existing_provider_results

--- a/src/routers/tts.py
+++ b/src/routers/tts.py
@@ -441,7 +441,10 @@ def run_tts_evaluation_task(
                             # Process still running, send heartbeat to refresh updated_at
                             update_job(task_id)
 
-                    if aborted:
+                    # Re-check abort after natural subprocess exit: an abort
+                    # could arrive between `poll()` returning non-None and
+                    # the final update_job below. See STT for the long form.
+                    if aborted or _is_job_aborted(task_id):
                         logger.info(
                             f"TTS eval {task_id} was aborted by user, skipping final processing"
                         )
@@ -603,6 +606,15 @@ def run_tts_evaluation_task(
                 if not all_succeeded:
                     failed = [r.provider for r in provider_results if not r.success]
                     error_msg = f"Some providers failed: {', '.join(failed)}"
+
+                # Last-chance abort check: results parsing + S3 upload above
+                # can take seconds-to-minutes; an abort that lands during
+                # that window must not be overwritten.
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"TTS eval {task_id} aborted before final update, skipping"
+                    )
+                    return
 
                 # Update job with results
                 update_job(

--- a/src/routers/tts.py
+++ b/src/routers/tts.py
@@ -838,7 +838,6 @@ async def abort_tts_evaluation(
         )
 
     details = job.get("details") or {}
-    results = job.get("results") or {}
 
     # Mark aborted FIRST so the polling loop's guard fires immediately.
     update_job(task_id, details={"aborted": True})
@@ -850,14 +849,7 @@ async def abort_tts_evaluation(
     requested_providers = details.get("providers", [])
     output_dir_str = details.get("output_dir")
     s3_bucket = details.get("s3_bucket") or ""
-    existing_provider_results = results.get("provider_results", []) or []
-    existing_success_map = {
-        pr.get("provider"): pr
-        for pr in existing_provider_results
-        if pr.get("success") is True
-    }
-
-    merged_results: List[Dict[str, Any]] = []
+    intermediate_map: Dict[str, Dict[str, Any]] = {}
     if output_dir_str:
         try:
             output_dir = Path(output_dir_str)
@@ -872,20 +864,6 @@ async def abort_tts_evaluation(
                 intermediate_map = {
                     r.provider: r.model_dump() for r in intermediate
                 }
-                for provider in requested_providers:
-                    if provider in existing_success_map:
-                        merged_results.append(existing_success_map[provider])
-                    elif provider in intermediate_map:
-                        merged_results.append(intermediate_map[provider])
-                    else:
-                        merged_results.append(
-                            {
-                                "provider": provider,
-                                "success": False,
-                                "metrics": None,
-                                "results": None,
-                            }
-                        )
                 try:
                     s3 = get_s3_client()
                     upload_directory_tree_to_s3(
@@ -902,6 +880,36 @@ async def abort_tts_evaluation(
             logger.warning(
                 f"Failed to collect intermediate results on abort: {exc}"
             )
+
+    # Re-read results from the DB right before the final write. The
+    # worker may have committed a fresher `provider_results` snapshot
+    # between our initial read and now — using the stale snapshot would
+    # overwrite those newer partials. See STT abort for the long form.
+    fresh_job = get_job(task_id, user_id=user_id) or {}
+    results = dict(fresh_job.get("results") or {})
+    existing_provider_results = results.get("provider_results", []) or []
+    existing_success_map = {
+        pr.get("provider"): pr
+        for pr in existing_provider_results
+        if pr.get("success") is True
+    }
+
+    merged_results: List[Dict[str, Any]] = []
+    if intermediate_map or existing_provider_results:
+        for provider in requested_providers:
+            if provider in existing_success_map:
+                merged_results.append(existing_success_map[provider])
+            elif provider in intermediate_map:
+                merged_results.append(intermediate_map[provider])
+            else:
+                merged_results.append(
+                    {
+                        "provider": provider,
+                        "success": False,
+                        "metrics": None,
+                        "results": None,
+                    }
+                )
 
     if not merged_results and existing_provider_results:
         merged_results = existing_provider_results

--- a/src/routers/tts.py
+++ b/src/routers/tts.py
@@ -8,7 +8,7 @@ import traceback
 import threading
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, ConfigDict
@@ -54,6 +54,12 @@ from utils import (
 
 # Job types that share the same queue
 EVAL_JOB_TYPES = ["stt-eval", "tts-eval", "annotation-eval"]
+
+
+def _is_job_aborted(task_id: str) -> bool:
+    """Check if a TTS eval job was aborted by the user."""
+    job = get_job(task_id)
+    return bool(job and (job.get("details") or {}).get("aborted"))
 
 
 def _start_tts_job_from_queue(job: dict) -> bool:
@@ -413,11 +419,33 @@ def run_tts_evaluation_task(
                     # Poll for process completion with heartbeat to keep updated_at fresh
                     # This prevents the job from being marked as timed out during long runs
                     HEARTBEAT_INTERVAL = 2  # seconds
+                    aborted = False
                     while process.poll() is None:
+                        if _is_job_aborted(task_id):
+                            logger.info(
+                                f"TTS eval {task_id} aborted, killing process group and stopping"
+                            )
+                            kill_process_group(process.pid, task_id)
+                            try:
+                                process.wait(timeout=5)
+                            except subprocess.TimeoutExpired:
+                                process.kill()
+                                try:
+                                    process.wait(timeout=5)
+                                except subprocess.TimeoutExpired:
+                                    pass
+                            aborted = True
+                            break
                         time.sleep(HEARTBEAT_INTERVAL)
                         if process.poll() is None:
                             # Process still running, send heartbeat to refresh updated_at
                             update_job(task_id)
+
+                    if aborted:
+                        logger.info(
+                            f"TTS eval {task_id} was aborted by user, skipping final processing"
+                        )
+                        return
 
                 # Read stdout/stderr
                 with open(stdout_path, "r") as f:
@@ -588,6 +616,11 @@ def run_tts_evaluation_task(
                 )
 
             except subprocess.CalledProcessError as e:
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"TTS eval {task_id} aborted, skipping error update"
+                    )
+                    return
                 traceback.print_exc()
                 capture_exception_to_sentry(e)
                 error_results = {
@@ -622,6 +655,11 @@ def run_tts_evaluation_task(
                     results=error_results,
                 )
             except Exception as e:
+                if _is_job_aborted(task_id):
+                    logger.info(
+                        f"TTS eval {task_id} aborted, skipping error update"
+                    )
+                    return
                 traceback.print_exc()
                 capture_exception_to_sentry(e)
                 error_results = {
@@ -657,13 +695,18 @@ def run_tts_evaluation_task(
                 )
 
     except Exception as e:
-        traceback.print_exc()
-        capture_exception_to_sentry(e)
-        update_job(
-            task_id,
-            status=TaskStatus.FAILED.value,
-            results={"error": f"Task failed: {str(e)}"},
-        )
+        if _is_job_aborted(task_id):
+            logger.info(
+                f"TTS eval {task_id} aborted, skipping error update"
+            )
+        else:
+            traceback.print_exc()
+            capture_exception_to_sentry(e)
+            update_job(
+                task_id,
+                status=TaskStatus.FAILED.value,
+                results={"error": f"Task failed: {str(e)}"},
+            )
     finally:
         # Try to start the next queued job
         try_start_queued_job(EVAL_JOB_TYPES)
@@ -762,6 +805,120 @@ class VisibilityRequest(BaseModel):
 class VisibilityResponse(BaseModel):
     is_public: bool
     share_token: str | None = None
+
+
+@router.post("/evaluate/{task_id}/abort", response_model=TaskStatusResponse)
+async def abort_tts_evaluation(
+    task_id: str, user_id: str = Depends(get_current_user_id)
+):
+    """Abort a running TTS evaluation job, preserving partial provider results.
+
+    Kills the running calibrate subprocess, collects whatever each provider
+    managed to write to disk, and saves the partial results with status=done.
+    """
+    job = get_job(task_id, user_id=user_id)
+    if not job or job.get("type") != "tts-eval":
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if job.get("status") != TaskStatus.IN_PROGRESS.value:
+        raise HTTPException(
+            status_code=400, detail="Can only abort in-progress jobs"
+        )
+
+    details = job.get("details") or {}
+    results = job.get("results") or {}
+
+    # Mark aborted FIRST so the polling loop's guard fires immediately.
+    update_job(task_id, details={"aborted": True})
+
+    pid = details.get("pid") or details.get("pgid")
+    if pid:
+        kill_process_group(pid, task_id)
+
+    requested_providers = details.get("providers", [])
+    output_dir_str = details.get("output_dir")
+    s3_bucket = details.get("s3_bucket") or ""
+    existing_provider_results = results.get("provider_results", []) or []
+    existing_success_map = {
+        pr.get("provider"): pr
+        for pr in existing_provider_results
+        if pr.get("success") is True
+    }
+
+    merged_results: List[Dict[str, Any]] = []
+    if output_dir_str:
+        try:
+            output_dir = Path(output_dir_str)
+            if output_dir.exists():
+                intermediate = _collect_tts_intermediate_results(
+                    output_dir,
+                    requested_providers,
+                    task_id,
+                    s3_bucket,
+                    len(details.get("texts") or []),
+                )
+                intermediate_map = {
+                    r.provider: r.model_dump() for r in intermediate
+                }
+                for provider in requested_providers:
+                    if provider in existing_success_map:
+                        merged_results.append(existing_success_map[provider])
+                    elif provider in intermediate_map:
+                        merged_results.append(intermediate_map[provider])
+                    else:
+                        merged_results.append(
+                            {
+                                "provider": provider,
+                                "success": False,
+                                "metrics": None,
+                                "results": None,
+                            }
+                        )
+                try:
+                    s3 = get_s3_client()
+                    upload_directory_tree_to_s3(
+                        s3,
+                        output_dir,
+                        s3_bucket or get_s3_output_config(),
+                        f"tts/evals/{task_id}/outputs",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        f"Failed to upload partial outputs for aborted TTS job {task_id}: {exc}"
+                    )
+        except Exception as exc:
+            logger.warning(
+                f"Failed to collect intermediate results on abort: {exc}"
+            )
+
+    if not merged_results and existing_provider_results:
+        merged_results = existing_provider_results
+
+    results["provider_results"] = merged_results
+    results["error"] = "user_aborted"
+
+    update_job(
+        task_id,
+        status=TaskStatus.DONE.value,
+        results=results,
+    )
+
+    try_start_queued_job(EVAL_JOB_TYPES)
+
+    updated = get_job(task_id, user_id=user_id) or {}
+    updated_results = updated.get("results") or {}
+    return TaskStatusResponse(
+        task_id=task_id,
+        status=TaskStatus.DONE.value,
+        language=details.get("language"),
+        dataset_id=details.get("dataset_id"),
+        dataset_name=details.get("dataset_name"),
+        provider_results=updated_results.get("provider_results"),
+        leaderboard_summary=updated_results.get("leaderboard_summary"),
+        error=updated_results.get("error"),
+        is_public=bool(updated.get("is_public")),
+        share_token=updated.get("share_token"),
+    )
 
 
 @router.patch("/evaluate/{task_id}/visibility", response_model=VisibilityResponse)


### PR DESCRIPTION
## Summary

Adds user-abort support to every long-running job type besides simulations (which already had it). Mirrors the existing simulation abort pattern:

- Set `details.aborted = True` on the job.
- SIGTERM → wait → SIGKILL the calibrate process group.
- Preserve whatever partial results landed on disk before the kill.
- Mark the job `DONE` with `results.error = "user_aborted"`.
- Drain the queue so the next queued job starts.

Polling loops and every exception handler in each runner now check the abort flag so they don't overwrite the abort state with their own failure write.

## New endpoints

- `POST /stt/evaluate/{task_id}/abort`
- `POST /tts/evaluate/{task_id}/abort`
- `POST /agent-tests/job/{job_uuid}/abort` — handles both `llm-unit-test` and `llm-benchmark`
- `POST /annotation-tasks/{task_uuid}/evaluator-runs/{job_uuid}/abort`

All return 400 if the job isn't `in_progress`, 404 on missing/not-owned, and the updated job payload (status=`done`) on success.

## Supporting changes

- `update_agent_test_job` now accepts a `details` kwarg with merge semantics (matches `update_job` / `update_simulation_job`). The schema already has the column; this is the first writer. LLM unit-test and benchmark runners now persist `pid` / `pgid` / `output_dir` after `Popen` so the abort path knows which process group to kill.
- `annotation_eval_runner` raises a new `AnnotationEvalAbortedError` from its polling loop when it sees the flag; the outer handler swallows it so the abort endpoint remains the authoritative writer for the final state.

## Reviewer notes

- The CLAUDE.md note "agent_test_jobs has no details column" is now stale — the column has always existed in the schema; this PR is the first code that uses it.
- For LLM tests/benchmarks, intermediate test results are already written to the DB by the polling loop (`_update_agent_test_intermediate_results` / `_update_benchmark_intermediate_results`), so the abort endpoint doesn't need to re-collect them — it just marks DONE and best-effort-uploads the partial output dir to S3.
- For STT/TTS, the abort endpoint reuses the existing `_collect_intermediate_results` / `_collect_tts_intermediate_results` helpers and merges with any provider results already marked `success=True` in the DB (same merge logic the timeout path uses).
- For annotation evaluator-runs, partial `evaluator_runs` rows the worker had already inserted up to abort time are retained as-is.

## Test plan

- [ ] Start an STT eval, hit `POST /stt/evaluate/{id}/abort` mid-run, confirm status flips to `done`, partial provider results visible, no Sentry noise from killed subprocess.
- [ ] Same for TTS.
- [ ] Start an LLM unit test, abort mid-run, confirm partial test_results are preserved and `error="user_aborted"`.
- [ ] Same for an LLM benchmark.
- [ ] Start an evaluator-run on an annotation task, abort mid-run, confirm partial `evaluator_runs` rows survive and the job goes to `done`.
- [ ] After each abort, confirm the next queued job (if any) starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)