### PR TITLE
Surface STT TTFT, per-row status and error from calibrate

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -944,6 +944,7 @@ _NUMERIC_ROW_KEYS = frozenset(
         "similarity",
         "processing_time",
         "ttfb",
+        "ttft",
         "latency",
         "duration",
         "audio_duration",
@@ -987,7 +988,15 @@ def coerce_evaluator_score(raw: Any, output_type: str) -> Any:
     Rating returns ``int`` when the value is whole-numbered (the common
     case — 1-5 / 1-10 scales), ``float`` when fractional, preserving
     precision for any future fractional rating scale.
+
+    Empty strings and ``None`` collapse to ``None`` — calibrate writes
+    blanks for evaluator columns on rows that failed before the judge ran,
+    and we don't want those leaking out as the literal string ``""``.
     """
+    if raw is None:
+        return None
+    if isinstance(raw, str) and raw.strip() == "":
+        return None
     if output_type == "binary":
         if isinstance(raw, bool):
             return raw
@@ -1140,6 +1149,21 @@ def post_process_provider_results(
         for row in rows:
             if not isinstance(row, dict):
                 continue
+
+            # Row-level failure signal from calibrate (status="success"|"failed",
+            # error=<exception type+message>|""). CSV gives empty string for
+            # both fields on missing — normalize empty to None so the FE can
+            # just truthy-check.
+            row_status = row.get("status")
+            if isinstance(row_status, str) and row_status.strip() == "":
+                row["status"] = None
+                row_status = None
+            row_error = row.get("error")
+            if isinstance(row_error, str) and row_error.strip() == "":
+                row["error"] = None
+                row_error = None
+            row_failed = isinstance(row_status, str) and row_status.lower() == "failed"
+
             outputs = row.get("evaluator_outputs")
             if not isinstance(outputs, dict):
                 outputs = {}
@@ -1156,7 +1180,15 @@ def post_process_provider_results(
                     continue
                 raw_value = row.get(column_name)
                 reasoning = row.get(f"{column_name}_reasoning")
-                is_err = _row_value_looks_like_error(raw_value, reasoning)
+                if isinstance(reasoning, str) and reasoning.strip() == "":
+                    reasoning = None
+                # When the whole row failed before the judge ran, calibrate
+                # leaves the value + reasoning blank. Treat as errored and
+                # surface the row-level error message so the FE has
+                # something meaningful to render in the evaluator cell.
+                is_err = (
+                    row_failed and raw_value in (None, "")
+                ) or _row_value_looks_like_error(raw_value, reasoning)
 
                 if is_err:
                     typed_value: Any = None
@@ -1173,7 +1205,10 @@ def post_process_provider_results(
 
                 entry: Dict[str, Any] = {
                     "value": typed_value,
-                    "reasoning": reasoning,
+                    "reasoning": (
+                        reasoning if reasoning is not None
+                        else (row_error if (is_err and row_failed) else None)
+                    ),
                     "evaluator_version_id": snap.get("evaluator_version_id"),
                     "output_type": snap.get("output_type"),
                     # `name` is the human-facing display name from the


### PR DESCRIPTION
## Summary

The calibrate CLI now emits additional STT data per the new contract:

- `results.csv` has new columns: `ttft` (streaming providers only), `status` (`"success"` | `"failed"`), and `error` (exception type + message, or empty).
- `metrics.json` has a new top-level `ttft` aggregate of shape `{mean, std, values}` (only when at least one row produced a TTFT).
- Failed rows have blank evaluator + WER cells; WER/judge means in `metrics.json` are computed over successful rows only, and the judge keys may be absent entirely if every row failed.

This PR flows that data through the API without changing the response shape:

- Add `ttft` to `_NUMERIC_ROW_KEYS` so per-row values are coerced from string to `float` (and empty cells → `None`) the same way `ttfb` already is. The aggregate `ttft` block in `metrics.json` already flows through as-is since it has no `type` key and isn't classified as an evaluator output.
- In `coerce_evaluator_score`, collapse `None` / empty-string raw values to `None` so blank evaluator cells on failed rows don't leak out as the literal string `""`.
- In `post_process_provider_results`, normalize empty `status` / `error` row cells to `None`, and when `status == "failed"` with a blank evaluator value, mark `evaluator_outputs[uuid].error = True` and fall back to the row-level `error` text as the `reasoning` so the FE has something to render in the cell.

Because the public-share STT endpoint and the in-progress poller both route through the same `post_process_provider_results`, the new columns are visible everywhere the API returns provider results.

## What did NOT change

- `ProviderResult` / `TaskStatusResponse` Pydantic shapes — per-row dicts are free-form (`Dict[str, Any]`), so new CSV columns flow through without schema changes.
- TTS path is untouched (the CLI changes are STT-only); the shared helpers tolerate the new columns being absent.

## Test plan

- [ ] Run a successful STT eval against a streaming provider (sarvam/deepgram/openai/elevenlabs/cartesia/smallest) and confirm `ttft` appears as a float per row and as a `{mean, std, values}` dict in `metrics`.
- [ ] Run an STT eval against a non-streaming provider (groq/google) and confirm `ttft` is absent (or `None`) per row, no `ttft` aggregate in `metrics`.
- [ ] Force a row to fail (e.g. unreachable provider) and confirm: `status == "failed"`, `error` is populated, `wer` is `None`, and each `evaluator_outputs[uuid]` has `value: null`, `error: true`, and the row-level error text in `reasoning`.
- [ ] Confirm the public-share STT endpoint (`GET /public/stt/{share_token}`) returns the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)