### PR TITLE
Track updated_at on annotation_items

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -791,8 +791,7 @@ def test_annotation_pipeline(user):
     assert len(db.get_annotation_items_for_task(task_uuid)) == 2
 
     pre_edit = db.get_annotation_item(item_ids[0])
-    import time as _time
-    _time.sleep(1.1)  # SQLite CURRENT_TIMESTAMP has 1s resolution
+    time.sleep(1.1)  # SQLite CURRENT_TIMESTAMP has 1s resolution
     updated = db.bulk_update_annotation_items(
         task_uuid,
         [{"uuid": item_ids[0], "payload": {"text": "edited"}}],


### PR DESCRIPTION
## Summary
- `annotation_items` only carried `created_at`, so the items returned under `GET /annotation-tasks/{uuid}` had no timestamp for the last payload edit (bulk-update endpoint left no trace).
- Add `updated_at` to the table, backfill from `created_at` for pre-existing rows (SQLite `ADD COLUMN` rejects `CURRENT_TIMESTAMP` as a default, so column defaults to NULL and we backfill in the same migration), and bump it on every payload write.
- `create_annotation_items` writes `updated_at = CURRENT_TIMESTAMP` on INSERT (migrated DBs default to NULL otherwise); `bulk_update_annotation_items` bumps it on edit.
- The new field surfaces automatically on every item-returning endpoint — they all return raw dicts via `_parse_annotation_item_row` (no Pydantic response model filters items).

## Test plan
- [x] `uv run --group dev pytest tests/test_db.py -k annotation -q` — new assertions pin: fresh rows have `updated_at == created_at`; `bulk_update_annotation_items` moves `updated_at` past both the previous value and `created_at`.
- [x] `uv run --group dev pytest tests/test_routers_annotation.py -k annotation_items_crud -q`
- [ ] Verify in the UI / via API that `GET /annotation-tasks/{uuid}` returns `updated_at` on each item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)