### PR TITLE
Evaluator response normalization: top-level evaluators[], rubric defaults, value labels

### DIFF
--- a/src/llm_judge.py
+++ b/src/llm_judge.py
@@ -57,6 +57,31 @@ def _format_scale_rubric(output_config: Optional[Dict[str, Any]]) -> str:
     return "\n\nRubric:\n" + "\n".join(lines)
 
 
+def evaluator_value_name(
+    value: Any,
+    output_type: Optional[str],
+    output_config: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Map an evaluator-run scalar to its display name. Prefers an explicit
+    `name` from `output_config.scale`; falls back to `Correct`/`Wrong` for
+    binary true/false, and stringified score for rating."""
+    if value is None:
+        return None
+    scale = (output_config or {}).get("scale")
+    if isinstance(scale, list):
+        for entry in scale:
+            if entry.get("value") == value and entry.get("name"):
+                return entry["name"]
+    if output_type == "binary":
+        if value is True:
+            return "Correct"
+        if value is False:
+            return "Wrong"
+    if output_type == "rating" and isinstance(value, (int, float)):
+        return str(value)
+    return None
+
+
 def _scale_bounds(output_config: Optional[Dict[str, Any]]) -> tuple[Optional[float], Optional[float]]:
     """For rating evaluators, derive scale_min/scale_max from output_config.scale.
 

--- a/src/llm_judge.py
+++ b/src/llm_judge.py
@@ -57,6 +57,26 @@ def _format_scale_rubric(output_config: Optional[Dict[str, Any]]) -> str:
     return "\n\nRubric:\n" + "\n".join(lines)
 
 
+_DEFAULT_BINARY_OUTPUT_CONFIG: Dict[str, Any] = {
+    "scale": [
+        {"value": True, "name": "Correct"},
+        {"value": False, "name": "Wrong"},
+    ]
+}
+
+
+def default_output_config(output_type: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Sensible default `output_config` for versions that don't carry their
+    own rubric. Binary → Correct/Wrong scale (mirrors the
+    `evaluator_value_name` fallback). Rating returns None because no meaningful
+    default scale exists without bounds — `evaluator_value_name` falls back to
+    `str(value)` there, which the FE can replicate. Returns a deep-ish copy so
+    callers can mutate it without leaking back into the constant."""
+    if output_type == "binary":
+        return {"scale": [dict(e) for e in _DEFAULT_BINARY_OUTPUT_CONFIG["scale"]]}
+    return None
+
+
 def evaluator_value_name(
     value: Any,
     output_type: Optional[str],

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -1035,9 +1035,9 @@ def _build_evaluators_block_for_test_run(
         evaluator_cache if evaluator_cache is not None else {}
     )
 
-    # uuid → snapshot entry (last one wins; snapshots for the same evaluator
-    # across test cases carry the same rubric — only `variable_values` varies
-    # and that's per-row, not block-level).
+    # uuid → snapshot entry (first one wins via setdefault; snapshots for
+    # the same evaluator across test cases carry the same rubric — only
+    # `variable_values` varies and that's per-row, not block-level).
     by_uuid: Dict[str, Dict[str, Any]] = {}
     for entries in (evaluators_by_test_id or {}).values():
         if not isinstance(entries, list):

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -194,36 +194,36 @@ class TestOutput(BaseModel):
 class JudgeResult(BaseModel):
     """One evaluator's verdict for a response-type test case.
 
-    `name` is the **current** evaluator name from the DB (refreshed at every read).
-    `description` is the current evaluator description from the DB (refreshed at every read).
-    `evaluator_uuid` is None for legacy runs that pre-date the evaluator-snapshot
-    capture or when the evaluator can't be resolved from the snapshot.
-    Exactly one of `match` (binary) / `score` (rating) is set per entry; both are
-    None for tool-call tests, but tool-call tests don't carry `judge_results`.
+    Per-row data only — anything constant across rows for the same evaluator
+    (name, description, output_type, output_config, scale_min/max) lives on
+    the response-level `evaluators[]` block; look it up by `evaluator_uuid`.
 
-    `variable_values` are the {{var}} substitutions used for this evaluator on
-    this test case, frozen from `test_evaluators.variable_values` at submission
-    time. `scale_min` / `scale_max` are present only for rating evaluators and
-    come from the pinned version's `output_config.scale`, so the score is always
-    framed against the rubric the run actually used.
+    `evaluator_uuid` is None for legacy runs that pre-date the evaluator-
+    snapshot capture or when the evaluator can't be resolved from the
+    snapshot.
 
-    `value_name` is the human-readable label for `match`/`score` resolved against
-    the rubric the run actually used (snapshot's `output_config.scale.name`).
-    Falls back to `Correct`/`Wrong` for binary or the stringified score for
-    rating when the snapshot lacks named scale entries (e.g. legacy runs
-    captured before the rubric was snapshotted).
+    Exactly one of `match` (binary) / `score` (rating) is set per entry;
+    both are None for tool-call tests, but tool-call tests don't carry
+    `judge_results`.
+
+    `variable_values` are the {{var}} substitutions used for this evaluator
+    on this test case, frozen from `test_evaluators.variable_values` at
+    submission time — stays on the row because it varies per test case.
+
+    `value_name` is the human-readable label for `match`/`score` resolved
+    against the rubric the run actually used (snapshot's
+    `output_config.scale.name`). Falls back to `Correct`/`Wrong` for binary
+    or the stringified score for rating when the snapshot lacks named
+    scale entries (e.g. legacy runs captured before the rubric was
+    snapshotted).
     """
 
     evaluator_uuid: Optional[str] = None
-    name: str
-    description: Optional[str] = None
     reasoning: Optional[str] = None
     match: Optional[bool] = None
     score: Optional[float] = None
     value_name: Optional[str] = None
     variable_values: Optional[Dict[str, Any]] = None
-    scale_min: Optional[float] = None
-    scale_max: Optional[float] = None
 
 
 class TestCaseResult(BaseModel):
@@ -248,6 +248,10 @@ class TestRunStatusResponse(BaseModel):
     total_tests: Optional[int] = None
     passed: Optional[int] = None
     failed: Optional[int] = None
+    # Top-level evaluator block — name/description/output_type/rubric
+    # shared across every judge_results row. Per-row entries reference
+    # back via `evaluator_uuid` so the rubric isn't duplicated per test.
+    evaluators: Optional[List[Dict[str, Any]]] = None
     results: Optional[List[TestCaseResult]] = None
     results_s3_prefix: Optional[str] = None
     error: bool = False
@@ -261,6 +265,8 @@ class AgentTestRunListItem(BaseModel):
     status: str
     type: str
     updated_at: str
+    # Top-level evaluator block — see TestRunStatusResponse.evaluators.
+    evaluators: Optional[List[Dict[str, Any]]] = None
     # Unit test results (for llm-unit-test type)
     total_tests: Optional[int] = None
     passed: Optional[int] = None
@@ -396,6 +402,12 @@ async def get_agent_test_runs(agent_uuid: str):
             evaluators_snapshot,
             _evaluator_cache,
         )
+        evaluators_block = _build_evaluators_block_for_test_run(
+            evaluators_snapshot,
+            test_results=job_results.get("test_results"),
+            model_results=job_results.get("model_results"),
+            evaluator_cache=_evaluator_cache,
+        )
 
         run_item = AgentTestRunListItem(
             uuid=job["uuid"],
@@ -403,6 +415,7 @@ async def get_agent_test_runs(agent_uuid: str):
             status=job["status"],
             type=job_type,
             updated_at=job.get("updated_at", job.get("created_at", "")),
+            evaluators=evaluators_block or None,
             # Unit test results
             total_tests=job_results.get("total_tests"),
             passed=job_results.get("passed"),
@@ -482,6 +495,12 @@ async def get_all_test_runs_for_user(
             evaluators_snapshot,
             _evaluator_cache,
         )
+        evaluators_block = _build_evaluators_block_for_test_run(
+            evaluators_snapshot,
+            test_results=job_results.get("test_results"),
+            model_results=job_results.get("model_results"),
+            evaluator_cache=_evaluator_cache,
+        )
 
         run_item = GlobalTestRunListItem(
             uuid=job["uuid"],
@@ -489,6 +508,7 @@ async def get_all_test_runs_for_user(
             status=job["status"],
             type=job.get("type", ""),
             updated_at=job.get("updated_at", job.get("created_at", "")),
+            evaluators=evaluators_block or None,
             # Unit test fields
             total_tests=job_results.get("total_tests"),
             passed=job_results.get("passed"),
@@ -983,6 +1003,99 @@ def _get_evaluator_cached_for_enrichment(
     return cache[uid]
 
 
+_REDUNDANT_JUDGE_RESULT_KEYS = ("name", "description", "scale_min", "scale_max")
+
+
+def _build_evaluators_block_for_test_run(
+    evaluators_by_test_id: Optional[Dict[str, List[Dict[str, Any]]]],
+    test_results: Optional[List[Dict[str, Any]]] = None,
+    model_results: Optional[List[Dict[str, Any]]] = None,
+    evaluator_cache: Optional[Dict[str, Optional[Dict[str, Any]]]] = None,
+) -> List[Dict[str, Any]]:
+    """Build the top-level `evaluators[]` block for an agent-test / benchmark
+    response: one entry per unique evaluator UUID, carrying the
+    `name`/`description`/`output_type`/`output_config`/scale bounds that
+    would otherwise be duplicated across every judge_results row.
+
+    Sources, in order of preference:
+      1. `evaluators_by_test_id` snapshot — fixed at submission time, so
+         `output_config` reflects the rubric the run actually used.
+      2. `test_results` / `model_results` — fallback for legacy runs whose
+         snapshot is missing the evaluator (we still want SOMETHING in the
+         block so the FE doesn't 'unknown evaluator' the row).
+      3. `get_evaluator(uuid)` — for current name/description (the snapshot
+         only carried the calibrate-aligned name, not the live one).
+
+    Binary evaluators with no rubric snapshot get the Correct/Wrong default
+    (via `default_output_config`) so the FE always has a scale to render.
+    """
+    from llm_judge import default_output_config
+
+    cache: Dict[str, Optional[Dict[str, Any]]] = (
+        evaluator_cache if evaluator_cache is not None else {}
+    )
+
+    # uuid → snapshot entry (last one wins; snapshots for the same evaluator
+    # across test cases carry the same rubric — only `variable_values` varies
+    # and that's per-row, not block-level).
+    by_uuid: Dict[str, Dict[str, Any]] = {}
+    for entries in (evaluators_by_test_id or {}).values():
+        if not isinstance(entries, list):
+            continue
+        for e in entries:
+            if isinstance(e, dict) and e.get("uuid"):
+                by_uuid.setdefault(e["uuid"], e)
+
+    # Fallback: pick up evaluator UUIDs that appear on rows but not in the
+    # snapshot (legacy runs).
+    def _scan_rows(rows: Optional[List[Dict[str, Any]]]) -> None:
+        if not rows:
+            return
+        for r in rows:
+            if not isinstance(r, dict):
+                continue
+            jr = r.get("judge_results")
+            if isinstance(jr, list):
+                iterator = (e for e in jr if isinstance(e, dict))
+                uid_key = "evaluator_uuid"
+            elif isinstance(jr, dict):
+                iterator = (e for e in jr.values() if isinstance(e, dict))
+                uid_key = "evaluator_id"
+            else:
+                continue
+            for e in iterator:
+                uid = e.get(uid_key)
+                if uid and uid not in by_uuid:
+                    by_uuid[uid] = {"uuid": uid}
+
+    _scan_rows(test_results)
+    for mr in model_results or []:
+        if isinstance(mr, dict):
+            _scan_rows(mr.get("test_results"))
+
+    block: List[Dict[str, Any]] = []
+    for uid, snap in by_uuid.items():
+        ev = _get_evaluator_cached_for_enrichment(uid, cache)
+        output_type = snap.get("output_type") or (
+            ev.get("output_type") if ev else None
+        )
+        output_config = snap.get("output_config")
+        if output_config is None:
+            output_config = default_output_config(output_type)
+        block.append(
+            {
+                "uuid": uid,
+                "name": (ev.get("name") if ev else None) or snap.get("name"),
+                "description": ev.get("description") if ev else None,
+                "output_type": output_type,
+                "output_config": output_config,
+                "scale_min": snap.get("scale_min"),
+                "scale_max": snap.get("scale_max"),
+            }
+        )
+    return block
+
+
 def _enrich_test_results_with_evaluators(
     test_results: Optional[List[Dict[str, Any]]],
     evaluators_by_test_id: Optional[Dict[str, List[Dict[str, Any]]]],
@@ -1033,11 +1146,8 @@ def _enrich_test_results_with_evaluators(
                 uid = entry.get("evaluator_uuid")
                 if not uid:
                     continue
-                ev = _get_evaluator_cached_for_enrichment(uid, cache)
-                if ev and ev.get("name"):
-                    entry["name"] = ev["name"]
-                entry["description"] = ev.get("description") if ev else None
                 meta = uuid_to_meta.get(uid) or {}
+                ev = _get_evaluator_cached_for_enrichment(uid, cache)
                 snap_output_type = meta.get("output_type") or (
                     ev.get("output_type") if ev else None
                 )
@@ -1049,6 +1159,10 @@ def _enrich_test_results_with_evaluators(
                 entry["value_name"] = evaluator_value_name(
                     value, snap_output_type, meta.get("output_config")
                 )
+                # Drop fields that have been promoted to the top-level
+                # evaluators[] block so the row stays minimal.
+                for k in _REDUNDANT_JUDGE_RESULT_KEYS:
+                    entry.pop(k, None)
             continue
 
         if not isinstance(raw, dict):
@@ -1061,21 +1175,18 @@ def _enrich_test_results_with_evaluators(
             echoed_uid = entry.get("evaluator_id")
             meta = (uuid_to_meta.get(echoed_uid) if echoed_uid else None) or {}
             uid = echoed_uid
-            current_name: Optional[str] = None
-            current_description: Optional[str] = None
+            # We don't bake evaluator name/description onto each row anymore
+            # — the FE reads them from the top-level evaluators[] block via
+            # `evaluator_uuid`. We still warm the cache here so the block
+            # builder can reuse it without re-querying.
             if uid:
-                ev = _get_evaluator_cached_for_enrichment(uid, cache)
-                if ev:
-                    current_name = ev.get("name")
-                    current_description = ev.get("description")
+                _get_evaluator_cached_for_enrichment(uid, cache)
             match_val = entry.get("match")
             score_val = entry.get("score")
             scalar = match_val if match_val is not None else score_val
             out.append(
                 {
                     "evaluator_uuid": uid,
-                    "name": current_name or cal_name,
-                    "description": current_description,
                     "reasoning": entry.get("reasoning"),
                     "match": match_val,
                     "score": score_val,
@@ -1085,8 +1196,6 @@ def _enrich_test_results_with_evaluators(
                         meta.get("output_config"),
                     ),
                     "variable_values": meta.get("variable_values") or None,
-                    "scale_min": meta.get("scale_min"),
-                    "scale_max": meta.get("scale_max"),
                 }
             )
         r["judge_results"] = out
@@ -1804,10 +1913,15 @@ async def get_agent_test_run_status(task_id: str):
     #         # Try to start the next queued job
     #         try_start_queued_agent_test_job(AGENT_TEST_JOB_TYPES)
 
+    evaluators_snapshot = details.get("evaluators_by_test_id") or {}
+    evaluator_cache: Dict[str, Optional[Dict[str, Any]]] = {}
     _enrich_test_results_with_evaluators(
-        results.get("test_results"),
-        details.get("evaluators_by_test_id")
-        or {},
+        results.get("test_results"), evaluators_snapshot, evaluator_cache
+    )
+    evaluators_block = _build_evaluators_block_for_test_run(
+        evaluators_snapshot,
+        test_results=results.get("test_results"),
+        evaluator_cache=evaluator_cache,
     )
 
     return TestRunStatusResponse(
@@ -1816,6 +1930,7 @@ async def get_agent_test_run_status(task_id: str):
         total_tests=results.get("total_tests"),
         passed=results.get("passed"),
         failed=results.get("failed"),
+        evaluators=evaluators_block or None,
         results=results.get("test_results"),
         results_s3_prefix=results.get("results_s3_prefix"),
         error=bool(results.get("error")),

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -1175,12 +1175,17 @@ def _enrich_test_results_with_evaluators(
             echoed_uid = entry.get("evaluator_id")
             meta = (uuid_to_meta.get(echoed_uid) if echoed_uid else None) or {}
             uid = echoed_uid
-            # We don't bake evaluator name/description onto each row anymore
-            # — the FE reads them from the top-level evaluators[] block via
-            # `evaluator_uuid`. We still warm the cache here so the block
-            # builder can reuse it without re-querying.
+            # Warm the cache so the block builder can reuse it. Also use
+            # the live evaluator's output_type as a fallback when the
+            # snapshot lacks it (legacy jobs) — matches the list-path
+            # behavior so `value_name` resolves consistently across both
+            # enrichment paths.
+            ev: Optional[Dict[str, Any]] = None
             if uid:
-                _get_evaluator_cached_for_enrichment(uid, cache)
+                ev = _get_evaluator_cached_for_enrichment(uid, cache)
+            snap_output_type = meta.get("output_type") or (
+                ev.get("output_type") if ev else None
+            )
             match_val = entry.get("match")
             score_val = entry.get("score")
             scalar = match_val if match_val is not None else score_val
@@ -1192,7 +1197,7 @@ def _enrich_test_results_with_evaluators(
                     "score": score_val,
                     "value_name": evaluator_value_name(
                         scalar,
-                        meta.get("output_type"),
+                        snap_output_type,
                         meta.get("output_config"),
                     ),
                     "variable_values": meta.get("variable_values") or None,
@@ -1960,6 +1965,10 @@ class ModelResult(BaseModel):
 class BenchmarkStatusResponse(BaseModel):
     task_id: str
     status: str
+    # Top-level evaluator block — see TestRunStatusResponse.evaluators.
+    # Shared by every model's test_results since all models run the
+    # same suite.
+    evaluators: Optional[List[Dict[str, Any]]] = None
     model_results: Optional[List[ModelResult]] = None
     leaderboard_summary: Optional[List[Dict[str, Any]]] = None
     results_s3_prefix: Optional[str] = None
@@ -2623,15 +2632,21 @@ async def get_benchmark_status(task_id: str):
     #         # Try to start the next queued job
     #         try_start_queued_agent_test_job(AGENT_TEST_JOB_TYPES)
 
+    evaluators_snapshot = details.get("evaluators_by_test_id") or {}
+    evaluator_cache: Dict[str, Optional[Dict[str, Any]]] = {}
     _enrich_model_results_with_evaluators(
-        results.get("model_results"),
-        details.get("evaluators_by_test_id")
-        or {},
+        results.get("model_results"), evaluators_snapshot, evaluator_cache
+    )
+    evaluators_block = _build_evaluators_block_for_test_run(
+        evaluators_snapshot,
+        model_results=results.get("model_results"),
+        evaluator_cache=evaluator_cache,
     )
 
     return BenchmarkStatusResponse(
         task_id=task_id,
         status=status,
+        evaluators=evaluators_block or None,
         model_results=results.get("model_results"),
         leaderboard_summary=results.get("leaderboard_summary"),
         results_s3_prefix=results.get("results_s3_prefix"),

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -38,7 +38,7 @@ from db import (
     get_agent_test_jobs_for_org,
     delete_agent_test_job,
 )
-from llm_judge import build_test_evaluators_payload
+from llm_judge import build_test_evaluators_payload, evaluator_value_name
 from auth_utils import get_current_org, OrgContext
 from utils import (
     TaskStatus,
@@ -206,6 +206,12 @@ class JudgeResult(BaseModel):
     time. `scale_min` / `scale_max` are present only for rating evaluators and
     come from the pinned version's `output_config.scale`, so the score is always
     framed against the rubric the run actually used.
+
+    `value_name` is the human-readable label for `match`/`score` resolved against
+    the rubric the run actually used (snapshot's `output_config.scale.name`).
+    Falls back to `Correct`/`Wrong` for binary or the stringified score for
+    rating when the snapshot lacks named scale entries (e.g. legacy runs
+    captured before the rubric was snapshotted).
     """
 
     evaluator_uuid: Optional[str] = None
@@ -214,6 +220,7 @@ class JudgeResult(BaseModel):
     reasoning: Optional[str] = None
     match: Optional[bool] = None
     score: Optional[float] = None
+    value_name: Optional[str] = None
     variable_values: Optional[Dict[str, Any]] = None
     scale_min: Optional[float] = None
     scale_max: Optional[float] = None
@@ -737,14 +744,19 @@ def _build_calibrate_config(
             if not ev_uuid or i >= len(refs):
                 continue
             output_type = ev.get("output_type") or "binary"
+            output_config = ev.get("output_config")
             snap_entry: Dict[str, Any] = {
                 "uuid": ev_uuid,
                 "name": refs[i].get("name", ""),
                 "output_type": output_type,
                 "variable_values": ev.get("variable_values") or {},
             }
+            # Snapshot the pinned version's rubric so `value_name` can be
+            # resolved at read time without re-reading the version row
+            # (which may have drifted). Applies to binary and rating both.
+            if isinstance(output_config, dict):
+                snap_entry["output_config"] = output_config
             if output_type == "rating":
-                output_config = ev.get("output_config")
                 if isinstance(output_config, dict):
                     scale = output_config.get("scale")
                     if isinstance(scale, list) and scale:
@@ -1006,6 +1018,14 @@ def _enrich_test_results_with_evaluators(
         if raw is None:
             continue
 
+        test_id = r.get("test_case_id")
+        snapshot = snapshot_map.get(test_id) if test_id else None
+        uuid_to_meta: Dict[str, Dict[str, Any]] = {}
+        if isinstance(snapshot, list):
+            for e in snapshot:
+                if isinstance(e, dict) and e.get("uuid"):
+                    uuid_to_meta[e["uuid"]] = e
+
         if isinstance(raw, list):
             for entry in raw:
                 if not isinstance(entry, dict):
@@ -1017,18 +1037,22 @@ def _enrich_test_results_with_evaluators(
                 if ev and ev.get("name"):
                     entry["name"] = ev["name"]
                 entry["description"] = ev.get("description") if ev else None
+                meta = uuid_to_meta.get(uid) or {}
+                snap_output_type = meta.get("output_type") or (
+                    ev.get("output_type") if ev else None
+                )
+                value = (
+                    entry.get("match")
+                    if entry.get("match") is not None
+                    else entry.get("score")
+                )
+                entry["value_name"] = evaluator_value_name(
+                    value, snap_output_type, meta.get("output_config")
+                )
             continue
 
         if not isinstance(raw, dict):
             continue
-
-        test_id = r.get("test_case_id")
-        snapshot = snapshot_map.get(test_id) if test_id else None
-        uuid_to_meta: Dict[str, Dict[str, Any]] = {}
-        if isinstance(snapshot, list):
-            for e in snapshot:
-                if isinstance(e, dict) and e.get("uuid"):
-                    uuid_to_meta[e["uuid"]] = e
 
         out: List[Dict[str, Any]] = []
         for cal_name, entry in raw.items():
@@ -1044,14 +1068,22 @@ def _enrich_test_results_with_evaluators(
                 if ev:
                     current_name = ev.get("name")
                     current_description = ev.get("description")
+            match_val = entry.get("match")
+            score_val = entry.get("score")
+            scalar = match_val if match_val is not None else score_val
             out.append(
                 {
                     "evaluator_uuid": uid,
                     "name": current_name or cal_name,
                     "description": current_description,
                     "reasoning": entry.get("reasoning"),
-                    "match": entry.get("match"),
-                    "score": entry.get("score"),
+                    "match": match_val,
+                    "score": score_val,
+                    "value_name": evaluator_value_name(
+                        scalar,
+                        meta.get("output_type"),
+                        meta.get("output_config"),
+                    ),
                     "variable_values": meta.get("variable_values") or None,
                     "scale_min": meta.get("scale_min"),
                     "scale_max": meta.get("scale_max"),

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -318,6 +318,7 @@ async def list_task_evaluators(
         EvaluatorDetailResponse,
         EvaluatorVersionResponse,
         _evaluator_response,
+        _live_version_index,
         _version_dict,
     )
     from db import get_evaluator_versions
@@ -341,7 +342,11 @@ async def list_task_evaluators(
         ]
         out.append(
             EvaluatorDetailResponse(
-                **base.model_dump(exclude={"live_version"}), versions=versions
+                **base.model_dump(exclude={"live_version"}),
+                versions=versions,
+                live_version_index=_live_version_index(
+                    versions, base.live_version_id
+                ),
             )
         )
     return out

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -1460,9 +1460,56 @@ def _shape_eval_job_for_response(job: Dict[str, Any]) -> Dict[str, Any]:
 async def list_evaluator_run_jobs(
     task_uuid: str, ctx: OrgContext = Depends(get_current_org)
 ):
+    """Slim list of evaluator-run jobs for the task. Each row carries
+    just the identifiers + status + counts + updated_at; the FE looks up
+    each row's evaluators via the top-level `evaluators[]` block by
+    `(evaluator_id, evaluator_version_id)`. Status `"done"` is normalized
+    to `"completed"` to match the detail endpoint."""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     jobs = get_generic_jobs_for_task(task_uuid, ANNOTATION_EVAL_JOB_TYPE)
-    return [_shape_eval_job_for_response(j) for j in jobs]
+
+    # Aggregate the per-job snapshots into one combined block so the FE
+    # only needs to fetch evaluator/version metadata once per unique
+    # (evaluator_id, evaluator_version_id) pair across the list.
+    combined_snapshot: List[Dict[str, Any]] = []
+    seen_slots: set = set()
+    for j in jobs:
+        for entry in (j.get("details") or {}).get("evaluators") or []:
+            if not isinstance(entry, dict):
+                continue
+            slot = (entry.get("evaluator_id"), entry.get("evaluator_version_id"))
+            if slot[0] and slot not in seen_slots:
+                seen_slots.add(slot)
+                combined_snapshot.append(entry)
+    evaluators_block = _build_evaluators_block_for_eval_job(
+        {"evaluators": combined_snapshot}, []
+    )
+
+    runs: List[Dict[str, Any]] = []
+    for j in jobs:
+        details = j.get("details") or {}
+        status = j.get("status")
+        if status == "done":
+            status = "completed"
+        row_evals = [
+            {
+                "evaluator_id": e.get("evaluator_id"),
+                "evaluator_version_id": e.get("evaluator_version_id"),
+            }
+            for e in (details.get("evaluators") or [])
+            if isinstance(e, dict) and e.get("evaluator_id")
+        ]
+        runs.append(
+            {
+                "uuid": j["uuid"],
+                "status": status,
+                "item_count": details.get("item_count"),
+                "updated_at": j.get("updated_at"),
+                "evaluators": row_evals,
+            }
+        )
+
+    return {"evaluators": evaluators_block, "runs": runs}
 
 
 def _human_agreement_for_run(

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -323,9 +323,16 @@ async def list_task_evaluators(
     from db import get_evaluator_versions
 
     _ensure_owned_task(task_uuid, ctx.org_uuid)
+    # `get_evaluators_for_annotation_task` projects a slim column set with a
+    # `linked_at` alias on the pivot — it omits the evaluator row's own
+    # `created_at`/`updated_at`. Refetch the canonical evaluator row so
+    # `_evaluator_response` has every field it expects.
     linked = get_evaluators_for_annotation_task(task_uuid)
     out: List[EvaluatorDetailResponse] = []
-    for ev in linked:
+    for stub in linked:
+        ev = get_evaluator(stub["uuid"])
+        if not ev:
+            continue
         base = _evaluator_response(ev)
         versions = [
             EvaluatorVersionResponse(**_version_dict(v))

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -334,8 +334,9 @@ async def list_task_evaluators(
         if not ev:
             continue
         base = _evaluator_response(ev)
+        ev_output_type = ev.get("output_type", "binary")
         versions = [
-            EvaluatorVersionResponse(**_version_dict(v))
+            EvaluatorVersionResponse(**_version_dict(v, ev_output_type))
             for v in get_evaluator_versions(ev["uuid"])
         ]
         out.append(

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -1634,17 +1634,26 @@ def _human_agreement_for_run(
             continue
         # Bucket the raw human annotations on this item by evaluator so the
         # FE can show every annotator's exact value alongside the agreement
-        # number. Annotations are already filtered to the run's slot set,
-        # so every entry here is in scope.
-        annotations_by_evaluator: Dict[str, List[Dict[str, Any]]] = {}
+        # number. Annotations are already filtered to the run's slot set.
+        #
+        # **Latest-wins per (evaluator, annotator)** — matches the summary
+        # endpoint's semantics ([`task_summary`](annotation_tasks.py)). If
+        # the same annotator labeled the same slot across multiple
+        # annotation jobs, only the most recent submission surfaces in
+        # `human_annotations[]`. Input is sorted by `updated_at ASC`
+        # (`get_annotations_for_slots`), so dict-overwrite per
+        # `(ev_id, annotator_id)` gives latest-wins.
+        latest_by_slot: Dict[tuple, Dict[str, Any]] = {}
         for a in item_annotations:
             ev_id = a.get("evaluator_id")
-            if not ev_id:
-                continue
             annotator_id = a.get("annotator_id")
-            annotator = (
-                annotators_by_uuid.get(annotator_id) if annotator_id else None
-            )
+            if not ev_id or not annotator_id:
+                continue
+            latest_by_slot[(ev_id, annotator_id)] = a
+
+        annotations_by_evaluator: Dict[str, List[Dict[str, Any]]] = {}
+        for (ev_id, annotator_id), a in latest_by_slot.items():
+            annotator = annotators_by_uuid.get(annotator_id) if annotator_id else None
             raw_value = a.get("value")
             reasoning = (
                 raw_value.get("reasoning")
@@ -1665,7 +1674,7 @@ def _human_agreement_for_run(
                 }
             )
         # Sort each evaluator's annotations deterministically (oldest first)
-        # so the FE can render them in submission order.
+        # so the FE can render them in a stable order.
         for entries in annotations_by_evaluator.values():
             entries.sort(key=lambda e: (e.get("updated_at") or "", e.get("annotation_id") or ""))
         # Inline the raw annotations onto each evaluator block keyed by

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -1358,6 +1358,15 @@ def _build_evaluators_block_for_eval_job(
             seen.add(slot)
             slots.append(slot)
 
+    # Look up the slim snapshot name as a final fallback for soft-deleted
+    # evaluators (get_evaluator filters deleted_at IS NULL).
+    snapshot_name_by_uuid: Dict[str, str] = {}
+    for entry in snapshot:
+        if isinstance(entry, dict) and entry.get("evaluator_id"):
+            snapshot_name_by_uuid.setdefault(
+                entry["evaluator_id"], entry.get("name") or ""
+            )
+
     eval_cache: Dict[str, Optional[Dict[str, Any]]] = {}
     version_cache: Dict[str, Optional[Dict[str, Any]]] = {}
     out: List[Dict[str, Any]] = []
@@ -1365,8 +1374,10 @@ def _build_evaluators_block_for_eval_job(
         if ev_id not in eval_cache:
             eval_cache[ev_id] = get_evaluator(ev_id)
         ev = eval_cache.get(ev_id)
-        if not ev:
-            continue
+        # If the evaluator was soft-deleted we still want a stub entry so
+        # rows[] consumers can resolve the slot — otherwise the FE sees
+        # `evaluator_id` references with no matching block entry. Fields
+        # we can't recover (description, output_type, rubric) stay null.
         if version_id and version_id not in version_cache:
             version_cache[version_id] = get_evaluator_version(version_id)
         version = version_cache.get(version_id) if version_id else None
@@ -1374,12 +1385,13 @@ def _build_evaluators_block_for_eval_job(
         scale_min, scale_max = _scale_bounds(output_config)
         out.append(
             {
-                "uuid": ev["uuid"],
-                "name": ev.get("name"),
-                "description": ev.get("description"),
-                "output_type": ev.get("output_type"),
-                "evaluator_type": ev.get("evaluator_type"),
-                "data_type": ev.get("data_type"),
+                "uuid": ev_id,
+                "name": (ev.get("name") if ev else None)
+                or snapshot_name_by_uuid.get(ev_id),
+                "description": ev.get("description") if ev else None,
+                "output_type": ev.get("output_type") if ev else None,
+                "evaluator_type": ev.get("evaluator_type") if ev else None,
+                "data_type": ev.get("data_type") if ev else None,
                 "evaluator_version_id": version_id,
                 "version_number": (
                     version.get("version_number") if version else None
@@ -1389,6 +1401,7 @@ def _build_evaluators_block_for_eval_job(
                 "scale_min": scale_min,
                 "scale_max": scale_max,
                 "variables": version.get("variables") if version else None,
+                "deleted": ev is None,
             }
         )
     return out

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -302,12 +302,39 @@ async def delete_annotation_task_endpoint(
 # ============ Evaluator linking ============
 
 
-@router.get("/{task_uuid}/evaluators", response_model=List[Dict[str, Any]])
+@router.get("/{task_uuid}/evaluators")
 async def list_task_evaluators(
     task_uuid: str, ctx: OrgContext = Depends(get_current_org)
 ):
+    """Return each evaluator linked to this task in the same shape as
+    `GET /evaluators/{uuid}` — i.e. full `EvaluatorDetailResponse` with
+    `live_version` and the complete `versions[]` history. Lets the FE
+    render the per-evaluator detail (rubric, prompt, judge model,
+    variable specs) without an N+1 fan-out of `/evaluators/{uuid}` calls.
+    """
+    # Lazy import to avoid a circular module-load between the two router
+    # files (annotation_tasks ↔ evaluators).
+    from routers.evaluators import (
+        EvaluatorDetailResponse,
+        EvaluatorVersionResponse,
+        _evaluator_response,
+        _version_dict,
+    )
+    from db import get_evaluator_versions
+
     _ensure_owned_task(task_uuid, ctx.org_uuid)
-    return get_evaluators_for_annotation_task(task_uuid)
+    linked = get_evaluators_for_annotation_task(task_uuid)
+    out: List[EvaluatorDetailResponse] = []
+    for ev in linked:
+        base = _evaluator_response(ev)
+        versions = [
+            EvaluatorVersionResponse(**_version_dict(v))
+            for v in get_evaluator_versions(ev["uuid"])
+        ]
+        out.append(
+            EvaluatorDetailResponse(**base.model_dump(), versions=versions)
+        )
+    return out
 
 
 @router.post("/{task_uuid}/evaluators")

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -1337,7 +1337,7 @@ def _build_evaluators_block_for_eval_job(
     snapshot (legacy `details.evaluators` absent) still get a populated
     block.
     """
-    from llm_judge import _scale_bounds  # local to avoid module-load cycle
+    from llm_judge import _scale_bounds, default_output_config  # local to avoid module-load cycle
 
     snapshot = (job_details or {}).get("evaluators") or []
     # Dedupe (evaluator_id, evaluator_version_id) slots across snapshot
@@ -1382,6 +1382,13 @@ def _build_evaluators_block_for_eval_job(
             version_cache[version_id] = get_evaluator_version(version_id)
         version = version_cache.get(version_id) if version_id else None
         output_config = version.get("output_config") if version else None
+        # Apply the Correct/Wrong fallback for binary evaluators whose
+        # pinned version has a null rubric — consistent with the other
+        # evaluator-returning endpoints in this PR (evaluator detail,
+        # versions list, summary, agent-test block builder).
+        ev_output_type = ev.get("output_type") if ev else None
+        if output_config is None:
+            output_config = default_output_config(ev_output_type)
         scale_min, scale_max = _scale_bounds(output_config)
         out.append(
             {

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -1278,6 +1278,104 @@ def _enrich_runs_with_live_evaluator(
     return out
 
 
+def _build_evaluators_block_for_eval_job(
+    job_details: Optional[Dict[str, Any]],
+    raw_runs: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Build the top-level `evaluators[]` block returned alongside an
+    evaluator-run job detail response. Mirrors the shape used by the
+    labelling-job viewer (`GET /public/annotation-jobs/view/{token}`) so the
+    FE can read `output_config.scale` from one consistent place across both
+    surfaces. Each entry pins the evaluator-VERSION the job actually ran
+    against (from `details.evaluators` snapshot), not the live version —
+    rubric edits after the run don't retroactively rewrite what the run
+    was measured by.
+
+    Also seeds entries from the runs themselves so jobs predating the
+    snapshot (legacy `details.evaluators` absent) still get a populated
+    block.
+    """
+    from llm_judge import _scale_bounds  # local to avoid module-load cycle
+
+    snapshot = (job_details or {}).get("evaluators") or []
+    # Dedupe (evaluator_id, evaluator_version_id) slots across snapshot
+    # and runs so legacy/snapshot-less jobs still emit one entry per pinned
+    # version actually used.
+    slots: List[tuple] = []
+    seen: set = set()
+    for entry in snapshot:
+        if not isinstance(entry, dict):
+            continue
+        slot = (entry.get("evaluator_id"), entry.get("evaluator_version_id"))
+        if slot[0] and slot not in seen:
+            seen.add(slot)
+            slots.append(slot)
+    for r in raw_runs or []:
+        slot = (r.get("evaluator_id"), r.get("evaluator_version_id"))
+        if slot[0] and slot not in seen:
+            seen.add(slot)
+            slots.append(slot)
+
+    eval_cache: Dict[str, Optional[Dict[str, Any]]] = {}
+    version_cache: Dict[str, Optional[Dict[str, Any]]] = {}
+    out: List[Dict[str, Any]] = []
+    for ev_id, version_id in slots:
+        if ev_id not in eval_cache:
+            eval_cache[ev_id] = get_evaluator(ev_id)
+        ev = eval_cache.get(ev_id)
+        if not ev:
+            continue
+        if version_id and version_id not in version_cache:
+            version_cache[version_id] = get_evaluator_version(version_id)
+        version = version_cache.get(version_id) if version_id else None
+        output_config = version.get("output_config") if version else None
+        scale_min, scale_max = _scale_bounds(output_config)
+        out.append(
+            {
+                "uuid": ev["uuid"],
+                "name": ev.get("name"),
+                "description": ev.get("description"),
+                "output_type": ev.get("output_type"),
+                "evaluator_type": ev.get("evaluator_type"),
+                "data_type": ev.get("data_type"),
+                "evaluator_version_id": version_id,
+                "version_number": (
+                    version.get("version_number") if version else None
+                ),
+                "judge_model": version.get("judge_model") if version else None,
+                "output_config": output_config,
+                "scale_min": scale_min,
+                "scale_max": scale_max,
+                "variables": version.get("variables") if version else None,
+            }
+        )
+    return out
+
+
+def _strip_run_evaluator_blocks(
+    runs: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return the runs without the per-row `evaluator` / `evaluator_version`
+    blobs. Callers surface that metadata via the top-level `evaluators[]`
+    block instead, keyed by `(evaluator_id, evaluator_version_id)` on each
+    run row."""
+    if not runs:
+        return runs
+    return [
+        {k: v for k, v in r.items() if k not in ("evaluator", "evaluator_version")}
+        for r in runs
+    ]
+
+
+def _strip_details_evaluators(shaped: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop the slim `evaluators` snapshot from `details` — promoted to the
+    response's top-level `evaluators[]` block (with rubric)."""
+    details = shaped.get("details")
+    if isinstance(details, dict) and "evaluators" in details:
+        shaped["details"] = {k: v for k, v in details.items() if k != "evaluators"}
+    return shaped
+
+
 def _shape_eval_job_for_response(job: Dict[str, Any]) -> Dict[str, Any]:
     """Adapt a generic-jobs row into the annotation-eval job response shape.
     Lifts task_id from `details` and exposes `error`/`completed_at` at the
@@ -1517,7 +1615,17 @@ async def get_evaluator_run_job(
         raise HTTPException(status_code=404, detail="Job not found")
     shaped = _shape_eval_job_for_response(job)
     raw_runs = get_evaluator_runs_for_job(job_uuid)
-    shaped["runs"] = _enrich_runs_with_live_evaluator(raw_runs)
+    # Top-level evaluators[] mirrors the labelling-job viewer shape so the
+    # FE reads `output_config.scale` from one consistent place across the
+    # two surfaces. Each entry pins the version the job ran against.
+    shaped["evaluators"] = _build_evaluators_block_for_eval_job(
+        job.get("details"), raw_runs
+    )
+    _strip_details_evaluators(shaped)
+    # Per-run `evaluator` / `evaluator_version` are intentionally NOT
+    # surfaced here — `(evaluator_id, evaluator_version_id)` on each run
+    # row keys back into the top-level evaluators[] block.
+    shaped["runs"] = _strip_run_evaluator_blocks(raw_runs)
     shaped["human_agreement"] = _human_agreement_for_run(task_uuid, raw_runs)
     # Frozen item snapshot — what calibrate actually saw, regardless of
     # any post-submit edits / soft-deletes on the source annotation_items.

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -340,7 +340,9 @@ async def list_task_evaluators(
             for v in get_evaluator_versions(ev["uuid"])
         ]
         out.append(
-            EvaluatorDetailResponse(**base.model_dump(), versions=versions)
+            EvaluatorDetailResponse(
+                **base.model_dump(exclude={"live_version"}), versions=versions
+            )
         )
     return out
 

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -1883,35 +1883,63 @@ async def task_summary(
       {
         "task_id": str,
         "task_type": "stt" | "llm" | "simulation",
-        "evaluators": [{evaluator_id, name, output_type, run_count}],
-                                        # `run_count` = total evaluator-runs for
-                                        # this evaluator across ALL versions,
-                                        # over the items in scope (honors
-                                        # `item_id` filter; unaffected by
-                                        # `live_only`)
-        "annotators": [{uuid, name}],   # union of annotators with ≥1 (item, evaluator)
-                                        # annotation in this task; column order
+        "evaluators": [
+          {
+            "uuid": str,
+            "name": str, "description": str|null,
+            "output_type": "binary" | "rating",
+            "evaluator_type": str, "data_type": str,
+            "live_version_id": str|null,
+            "live_version_index": int|null,         # array position of the
+                                                    # live version inside
+                                                    # `versions[]`, or null
+                                                    # when no live version
+                                                    # / no match
+            "versions": [
+              {
+                "uuid": str|null,                   # null only for the
+                                                    # placeholder slot when
+                                                    # the evaluator has no
+                                                    # runs + no live version
+                "version_number": int|null,
+                "output_config": {scale: [...]}|null,  # binary defaults to
+                                                       # Correct/Wrong when
+                                                       # unset; rating stays
+                                                       # null
+                "scale_min": float|null,
+                "scale_max": float|null,
+                "is_live": bool
+              }
+            ],
+            "run_count": int,                       # total evaluator-runs
+                                                    # across ALL versions,
+                                                    # restricted to items in
+                                                    # scope (honors
+                                                    # `item_id`; ignores
+                                                    # `live_only`)
+          }
+        ],
+        "annotators": [{uuid, name}],               # union of annotators with
+                                                    # ≥1 (item, evaluator)
+                                                    # annotation in this task
         "rows": [
           {
             "item_id": str,
-            "payload": <item.payload>,             # FE derives display per task_type
-            "evaluator_id": str,
-            "evaluator_name": str,
-            "output_type": "binary" | "rating",
-            "evaluator_version_id": str | null,
-            "evaluator_version_number": int | null,
-            "evaluator_value": <scalar | null>,    # latest run on this slot
-            "evaluator_value_name": str | null,    # human-readable name for the
-                                                   # value: from output_config.scale
-                                                   # entry's `name` if set, else
-                                                   # `Correct`/`Wrong` for binary
-                                                   # true/false or stringified
-                                                   # score for rating
-            "evaluator_reasoning": str | null,
+            "payload": <item.payload>,              # FE derives display per task_type
+            "evaluator_id": str,                    # FK into evaluators[].uuid
+            "evaluator_version_id": str|null,       # FK into evaluators[].versions[].uuid
+            "evaluator_value": <scalar|null>,       # latest run on this slot
+            "evaluator_value_name": str|null,       # resolved label per row
+                                                    # (FE could re-derive
+                                                    # from output_config but
+                                                    # we precompute it)
+            "evaluator_reasoning": str|null,
             "annotations": {
-              "<annotator_uuid>": {"value": <scalar>, "reasoning": str | null} | null,
+              "<annotator_uuid>": {"value": <scalar>, "reasoning": str|null} | null,
               ...
-            }
+            },
+            "human_agreement": float|null,
+            "evaluator_agreement": float|null
           }
         ]
       }
@@ -1924,8 +1952,10 @@ async def task_summary(
         emitted per `(item, evaluator)`.
       - `evaluator_value` is the latest evaluator-run for THAT specific
         version slot, regardless of which evaluator-run job produced it.
-      - `is_live_version` flags rows whose `evaluator_version_id` matches
-        the evaluator's current `live_version_id`.
+      - To check whether a row is on the live version, compare
+        `evaluator_version_id` to the matching evaluator's `live_version_id`
+        (or use `live_version_index` to index `versions[]` and read `is_live`).
+        That flag is intentionally NOT duplicated on every row.
       - Each annotator cell is that annotator's latest annotation for the slot,
         across ALL annotation jobs (matches the agreement aggregator's
         latest-wins-per-annotator semantics). `null` if they haven't annotated it.
@@ -2123,28 +2153,12 @@ async def task_summary(
                     {
                         "item_id": item["uuid"],
                         "payload": item.get("payload"),
+                        # Reference into the top-level `evaluators[]` block
+                        # — name/description/output_type and the version's
+                        # rubric (output_config, scale_min/max, is_live)
+                        # live there, not duplicated on every row.
                         "evaluator_id": ev_id,
-                        "evaluator_name": ev.get("name"),
-                        "output_type": ev.get("output_type"),
                         "evaluator_version_id": version_id,
-                        "evaluator_version_number": (
-                            version_meta.get("version_number")
-                            if version_meta
-                            else None
-                        ),
-                        "scale_min": (
-                            version_meta.get("scale_min")
-                            if version_meta
-                            else None
-                        ),
-                        "scale_max": (
-                            version_meta.get("scale_max")
-                            if version_meta
-                            else None
-                        ),
-                        "is_live_version": (
-                            version_id == live_v if version_id else False
-                        ),
                         "evaluator_value": ev_value,
                         "evaluator_value_name": _evaluator_value_name(
                             ev_value,
@@ -2158,18 +2172,72 @@ async def task_summary(
                     }
                 )
 
+    # Build the enriched top-level `evaluators[]` block — one entry per
+    # linked evaluator with the per-version rubric inlined so the FE has
+    # everything to render row labels without joining per-row metadata.
+    from llm_judge import default_output_config
+
+    evaluators_block: List[Dict[str, Any]] = []
+    for ev in evaluators:
+        ev_id = ev["uuid"]
+        live_v = ev.get("live_version_id")
+        version_ids = _version_row_keys(ev_id, live_v)
+        versions_payload: List[Dict[str, Any]] = []
+        live_version_index: Optional[int] = None
+        for v_id in version_ids:
+            if v_id is None:
+                # Placeholder for evaluators with no live version + no runs
+                # — keep the slot so the table can still render an empty
+                # evaluator column.
+                versions_payload.append(
+                    {
+                        "uuid": None,
+                        "version_number": None,
+                        "output_config": default_output_config(
+                            ev.get("output_type")
+                        ),
+                        "scale_min": None,
+                        "scale_max": None,
+                        "is_live": False,
+                    }
+                )
+                continue
+            meta = _version_meta(v_id) or {}
+            output_config = meta.get("output_config")
+            if output_config is None:
+                output_config = default_output_config(ev.get("output_type"))
+            is_live = v_id == live_v
+            if is_live:
+                live_version_index = len(versions_payload)
+            versions_payload.append(
+                {
+                    "uuid": v_id,
+                    "version_number": meta.get("version_number"),
+                    "output_config": output_config,
+                    "scale_min": meta.get("scale_min"),
+                    "scale_max": meta.get("scale_max"),
+                    "is_live": is_live,
+                }
+            )
+        evaluators_block.append(
+            {
+                "uuid": ev_id,
+                "name": ev.get("name"),
+                "description": ev.get("description"),
+                "output_type": ev.get("output_type"),
+                "evaluator_type": ev.get("evaluator_type"),
+                "data_type": ev.get("data_type"),
+                "live_version_id": live_v,
+                "live_version_index": live_version_index,
+                "versions": versions_payload,
+                "run_count": run_count_by_evaluator.get(ev_id, 0),
+            }
+        )
+
     return {
         "task_id": task_uuid,
         "task_type": task["type"],
-        "evaluators": [
-            {
-                "evaluator_id": e["uuid"],
-                "name": e.get("name"),
-                "output_type": e.get("output_type"),
-                "run_count": run_count_by_evaluator.get(e["uuid"], 0),
-            }
-            for e in evaluators
-        ],
+        "evaluators": evaluators_block,
         "annotators": annotators,
         "rows": rows,
     }

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -90,29 +90,9 @@ def _live_version_map(evaluators: List[Dict[str, Any]]) -> Dict[str, Optional[st
     return {e["uuid"]: e.get("live_version_id") for e in evaluators}
 
 
-def _evaluator_value_name(
-    value: Any,
-    output_type: Optional[str],
-    output_config: Optional[Dict[str, Any]],
-) -> Optional[str]:
-    """Map an evaluator-run scalar to its display name. Prefers an explicit
-    `name` from `output_config.scale`; falls back to `Correct`/`Wrong` for
-    binary true/false, and stringified score for rating."""
-    if value is None:
-        return None
-    scale = (output_config or {}).get("scale")
-    if isinstance(scale, list):
-        for entry in scale:
-            if entry.get("value") == value and entry.get("name"):
-                return entry["name"]
-    if output_type == "binary":
-        if value is True:
-            return "Correct"
-        if value is False:
-            return "Wrong"
-    if output_type == "rating" and isinstance(value, (int, float)):
-        return str(value)
-    return None
+# Re-exported for tests; canonical home is llm_judge so agent-tests/STT/TTS can
+# share the same scalar→label mapping.
+from llm_judge import evaluator_value_name as _evaluator_value_name  # noqa: E402
 
 
 def _enrich_evaluators_with_live_version(

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -187,14 +187,26 @@ def _ensure_unique_evaluator_name(
         raise HTTPException(status_code=409, detail="Evaluator name already exists")
 
 
-def _version_dict(version: Dict[str, Any]) -> Dict[str, Any]:
-    """Shape an evaluator_versions row for the API response."""
+def _version_dict(
+    version: Dict[str, Any],
+    output_type: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Shape an evaluator_versions row for the API response. When `output_config`
+    is missing on the stored row, fill in the evaluator's default rubric for
+    the given `output_type` so consumers don't have to handle a null scale —
+    binary rows get Correct/Wrong, rating rows stay null (the FE falls back to
+    `str(value)`)."""
+    from llm_judge import default_output_config
+
+    output_config = version.get("output_config")
+    if output_config is None:
+        output_config = default_output_config(output_type)
     return {
         "uuid": version["uuid"],
         "version_number": version["version_number"],
         "judge_model": version["judge_model"],
         "system_prompt": version["system_prompt"],
-        "output_config": version.get("output_config"),
+        "output_config": output_config,
         "variables": version.get("variables"),
         "created_at": version["created_at"],
     }
@@ -202,10 +214,13 @@ def _version_dict(version: Dict[str, Any]) -> Dict[str, Any]:
 
 def _evaluator_response(evaluator: Dict[str, Any]) -> EvaluatorResponse:
     live_version = None
+    output_type = evaluator.get("output_type", "binary")
     if evaluator.get("live_version_id"):
         v = get_evaluator_version(evaluator["live_version_id"])
         if v:
-            live_version = EvaluatorVersionResponse(**_version_dict(v))
+            live_version = EvaluatorVersionResponse(
+                **_version_dict(v, output_type)
+            )
     return EvaluatorResponse(
         uuid=evaluator["uuid"],
         name=evaluator["name"],
@@ -331,7 +346,11 @@ async def get_evaluator_endpoint(
 ):
     evaluator = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     base = _evaluator_response(evaluator)
-    versions = [EvaluatorVersionResponse(**_version_dict(v)) for v in get_evaluator_versions(evaluator_uuid)]
+    output_type = evaluator.get("output_type", "binary")
+    versions = [
+        EvaluatorVersionResponse(**_version_dict(v, output_type))
+        for v in get_evaluator_versions(evaluator_uuid)
+    ]
     return EvaluatorDetailResponse(**base.model_dump(), versions=versions)
 
 

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -155,10 +155,13 @@ class EvaluatorResponse(EvaluatorResponseBase):
 
 
 class EvaluatorDetailResponse(EvaluatorResponseBase):
-    # Detail shape: `versions[]` is the full history; `live_version_id`
-    # picks the live one out of it. No inlined `live_version` — the FE
-    # indexes by uuid into `versions[]`.
+    # Detail shape: `versions[]` is the full history; `live_version_index`
+    # is the direct array position of the live version (None when the
+    # evaluator has no live version, or when the live id doesn't resolve
+    # to anything in `versions[]`). Clients should prefer the index over
+    # scanning `versions[]` by uuid.
     versions: List[EvaluatorVersionResponse]
+    live_version_index: Optional[int] = None
 
 
 class EvaluatorCreateResponse(BaseModel):
@@ -228,6 +231,20 @@ def _version_dict(
         "variables": version.get("variables"),
         "created_at": version["created_at"],
     }
+
+
+def _live_version_index(
+    versions: List[EvaluatorVersionResponse],
+    live_version_id: Optional[str],
+) -> Optional[int]:
+    """Position of the live version in `versions[]`, or None if no live
+    version is set or the id doesn't match any entry."""
+    if not live_version_id:
+        return None
+    for i, v in enumerate(versions):
+        if v.uuid == live_version_id:
+            return i
+    return None
 
 
 def _evaluator_response(evaluator: Dict[str, Any]) -> EvaluatorResponse:
@@ -370,9 +387,12 @@ async def get_evaluator_endpoint(
         for v in get_evaluator_versions(evaluator_uuid)
     ]
     # base carries `live_version` (list shape); drop it here — detail uses
-    # `versions[]` + `live_version_id` so we don't duplicate the version.
+    # `versions[]` + `live_version_id`/`live_version_index` so we don't
+    # duplicate the version.
     return EvaluatorDetailResponse(
-        **base.model_dump(exclude={"live_version"}), versions=versions
+        **base.model_dump(exclude={"live_version"}),
+        versions=versions,
+        live_version_index=_live_version_index(versions, base.live_version_id),
     )
 
 

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -467,8 +467,15 @@ async def duplicate_evaluator_endpoint(
 async def list_versions(
     evaluator_uuid: str, ctx: OrgContext = Depends(get_current_org)
 ):
-    _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
-    return [EvaluatorVersionResponse(**_version_dict(v)) for v in get_evaluator_versions(evaluator_uuid)]
+    evaluator = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
+    # Pass `output_type` so binary versions stored with a null
+    # output_config surface the Correct/Wrong default — consistent with
+    # the detail / list / annotation-tasks evaluator endpoints.
+    output_type = evaluator.get("output_type", "binary")
+    return [
+        EvaluatorVersionResponse(**_version_dict(v, output_type))
+        for v in get_evaluator_versions(evaluator_uuid)
+    ]
 
 
 @router.post("/{evaluator_uuid}/versions", response_model=VersionCreateResponse)

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -123,7 +123,17 @@ class EvaluatorVersionResponse(BaseModel):
     created_at: str
 
 
-class EvaluatorResponse(BaseModel):
+class EvaluatorResponseBase(BaseModel):
+    """Identity + classification fields shared by every evaluator response.
+
+    `live_version_id` is the FK pointer to the current live version. List
+    views inline the full version on `live_version` because there's no
+    `versions[]` to look it up in. Detail views skip the inlined block and
+    expose `versions[]` instead — clients resolve the live version by
+    matching `live_version_id` to a version entry's `uuid` (avoids
+    duplicating the same version payload twice in the same response).
+    """
+
     uuid: str
     name: str
     description: Optional[str] = None
@@ -136,10 +146,18 @@ class EvaluatorResponse(BaseModel):
     live_version_id: Optional[str] = None
     created_at: str
     updated_at: str
+
+
+class EvaluatorResponse(EvaluatorResponseBase):
+    # List shape: no `versions[]` here, so we inline the live version for
+    # the FE.
     live_version: Optional[EvaluatorVersionResponse] = None
 
 
-class EvaluatorDetailResponse(EvaluatorResponse):
+class EvaluatorDetailResponse(EvaluatorResponseBase):
+    # Detail shape: `versions[]` is the full history; `live_version_id`
+    # picks the live one out of it. No inlined `live_version` — the FE
+    # indexes by uuid into `versions[]`.
     versions: List[EvaluatorVersionResponse]
 
 
@@ -351,7 +369,11 @@ async def get_evaluator_endpoint(
         EvaluatorVersionResponse(**_version_dict(v, output_type))
         for v in get_evaluator_versions(evaluator_uuid)
     ]
-    return EvaluatorDetailResponse(**base.model_dump(), versions=versions)
+    # base carries `live_version` (list shape); drop it here — detail uses
+    # `versions[]` + `live_version_id` so we don't duplicate the version.
+    return EvaluatorDetailResponse(
+        **base.model_dump(exclude={"live_version"}), versions=versions
+    )
 
 
 @router.put("/{evaluator_uuid}", response_model=EvaluatorResponse)

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -68,7 +68,9 @@ from routers.agent_tests import (
     _enrich_model_results_with_evaluators,
 )
 from routers.annotation_tasks import (
-    _enrich_runs_with_live_evaluator,
+    _build_evaluators_block_for_eval_job,
+    _strip_details_evaluators,
+    _strip_run_evaluator_blocks,
     _human_agreement_for_run,
     _shape_eval_job_for_response,
 )
@@ -640,6 +642,12 @@ async def get_public_annotation_eval(share_token: str):
     public_details = {
         k: v for k, v in details.items() if k in public_details_whitelist
     }
+    # `evaluators` is promoted to the response's top-level field — drop the
+    # slim snapshot from the forwarded `details` to keep the auth and
+    # public responses shaped the same way.
+    public_details.pop("evaluators", None)
+
+    evaluators_block = _build_evaluators_block_for_eval_job(details, raw_runs)
 
     return PublicAnnotationEvalResponse(
         task_id=task_uuid,
@@ -655,10 +663,13 @@ async def get_public_annotation_eval(share_token: str):
             description=task.get("description"),
         ),
         details=public_details,
-        evaluators=details.get("evaluators"),
+        evaluators=evaluators_block,
         item_count=details.get("item_count"),
         items=get_eval_job_items(job["uuid"]),
-        runs=_enrich_runs_with_live_evaluator(raw_runs),
+        # Per-run `evaluator` / `evaluator_version` blobs are intentionally
+        # not surfaced — `(evaluator_id, evaluator_version_id)` on each run
+        # keys back into the top-level evaluators[] block.
+        runs=_strip_run_evaluator_blocks(raw_runs),
         human_agreement=_human_agreement_for_run(task_uuid, raw_runs),
         error=shaped.get("error"),
     )

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -66,6 +66,7 @@ from routers.simulations import (
 from routers.agent_tests import (
     _enrich_test_results_with_evaluators,
     _enrich_model_results_with_evaluators,
+    _build_evaluators_block_for_test_run,
 )
 from routers.annotation_tasks import (
     _build_evaluators_block_for_eval_job,
@@ -114,6 +115,10 @@ class PublicTestRunResponse(BaseModel):
     total_tests: Optional[int] = None
     passed: Optional[int] = None
     failed: Optional[int] = None
+    # Top-level evaluator block — name/description/output_type/rubric
+    # shared across every judge_results row. Rows reference back via
+    # `evaluator_uuid` so the rubric isn't duplicated per test case.
+    evaluators: Optional[List[Dict[str, Any]]] = None
     results: Optional[List[Dict[str, Any]]] = None
     error: bool = False
 
@@ -121,6 +126,9 @@ class PublicTestRunResponse(BaseModel):
 class PublicBenchmarkResponse(BaseModel):
     task_id: str
     status: str
+    # Same as PublicTestRunResponse.evaluators — shared by every model's
+    # test_results inside model_results[] (all models run the same suite).
+    evaluators: Optional[List[Dict[str, Any]]] = None
     model_results: Optional[List[Dict[str, Any]]] = None
     leaderboard_summary: Optional[List[Dict[str, Any]]] = None
     error: bool = False
@@ -499,9 +507,15 @@ async def get_public_test_run(share_token: str):
     results = job.get("results") or {}
     details = job.get("details") or {}
 
+    evaluators_snapshot = details.get("evaluators_by_test_id") or {}
+    evaluator_cache: Dict[str, Optional[Dict[str, Any]]] = {}
     _enrich_test_results_with_evaluators(
-        results.get("test_results"),
-        details.get("evaluators_by_test_id") or {},
+        results.get("test_results"), evaluators_snapshot, evaluator_cache
+    )
+    evaluators_block = _build_evaluators_block_for_test_run(
+        evaluators_snapshot,
+        test_results=results.get("test_results"),
+        evaluator_cache=evaluator_cache,
     )
 
     return PublicTestRunResponse(
@@ -510,6 +524,7 @@ async def get_public_test_run(share_token: str):
         total_tests=results.get("total_tests"),
         passed=results.get("passed"),
         failed=results.get("failed"),
+        evaluators=evaluators_block or None,
         results=results.get("test_results"),
         error=bool(results.get("error")),
     )
@@ -531,14 +546,21 @@ async def get_public_benchmark(share_token: str):
     results = job.get("results") or {}
     details = job.get("details") or {}
 
+    evaluators_snapshot = details.get("evaluators_by_test_id") or {}
+    evaluator_cache: Dict[str, Optional[Dict[str, Any]]] = {}
     _enrich_model_results_with_evaluators(
-        results.get("model_results"),
-        details.get("evaluators_by_test_id") or {},
+        results.get("model_results"), evaluators_snapshot, evaluator_cache
+    )
+    evaluators_block = _build_evaluators_block_for_test_run(
+        evaluators_snapshot,
+        model_results=results.get("model_results"),
+        evaluator_cache=evaluator_cache,
     )
 
     return PublicBenchmarkResponse(
         task_id=task_id,
         status=status,
+        evaluators=evaluators_block or None,
         model_results=results.get("model_results"),
         leaderboard_summary=results.get("leaderboard_summary"),
         error=bool(results.get("error")),

--- a/tests/test_agent_test_helpers.py
+++ b/tests/test_agent_test_helpers.py
@@ -95,7 +95,9 @@ def test_enrich_test_results_with_evaluators_none():
 
 
 def test_enrich_test_results_with_evaluators_dict_judge():
-    """judge_results is the raw dict shape calibrate emits."""
+    """judge_results is the raw dict shape calibrate emits — converted to
+    a minimal list (per-row data only; name/description live on the
+    top-level evaluators[] block)."""
     from routers.agent_tests import _enrich_test_results_with_evaluators
 
     test_results = [
@@ -118,18 +120,33 @@ def test_enrich_test_results_with_evaluators_dict_judge():
         return_value={"uuid": "ev-1", "name": "Safety NEW", "description": "d"},
     ):
         _enrich_test_results_with_evaluators(test_results, snapshot)
-    assert test_results[0]["judge_results"][0]["name"] == "Safety NEW"
+    entry = test_results[0]["judge_results"][0]
+    assert entry["evaluator_uuid"] == "ev-1"
+    assert entry["match"] is True
+    assert entry["reasoning"] == "ok"
+    # Evaluator-level fields are promoted to the top-level evaluators[]
+    # block; they MUST NOT be duplicated on each row.
+    for k in ("name", "description", "scale_min", "scale_max"):
+        assert k not in entry, f"{k} should not be on judge_results row"
 
 
 def test_enrich_test_results_with_evaluators_list_judge():
-    """Idempotent when judge_results is already a structured list."""
+    """Idempotent when judge_results is already a structured list. The list
+    path also strips evaluator-level fields if a legacy row carries them."""
     from routers.agent_tests import _enrich_test_results_with_evaluators
 
     test_results = [
         {
             "test_case_id": "t1",
             "judge_results": [
-                {"evaluator_uuid": "ev-1", "name": "Stale"},
+                {
+                    "evaluator_uuid": "ev-1",
+                    "name": "Stale",
+                    "description": "old",
+                    "scale_min": 1,
+                    "scale_max": 5,
+                    "match": True,
+                },
             ],
         }
     ]
@@ -138,7 +155,10 @@ def test_enrich_test_results_with_evaluators_list_judge():
         return_value={"uuid": "ev-1", "name": "Refreshed", "description": "d"},
     ):
         _enrich_test_results_with_evaluators(test_results, None)
-    assert test_results[0]["judge_results"][0]["name"] == "Refreshed"
+    entry = test_results[0]["judge_results"][0]
+    assert entry["evaluator_uuid"] == "ev-1"
+    for k in ("name", "description", "scale_min", "scale_max"):
+        assert k not in entry
 
 
 def test_enrich_test_results_with_evaluators_value_name_binary():
@@ -259,6 +279,116 @@ def test_enrich_test_results_with_evaluators_value_name_list_path():
     ):
         _enrich_test_results_with_evaluators(test_results, snapshot)
     assert test_results[0]["judge_results"][0]["value_name"] == "Unsafe"
+
+
+def test_build_evaluators_block_for_test_run_dedupes_and_enriches():
+    """Block dedupes evaluators across test cases, pulls
+    name/description from the live DB, and falls back to the snapshot's
+    name when the DB lookup misses (or returns None)."""
+    from routers.agent_tests import _build_evaluators_block_for_test_run
+
+    snapshot = {
+        "t1": [
+            {
+                "uuid": "ev-1",
+                "name": "Safety",
+                "output_type": "binary",
+                "output_config": {
+                    "scale": [
+                        {"value": True, "name": "Safe"},
+                        {"value": False, "name": "Unsafe"},
+                    ]
+                },
+            },
+            {
+                "uuid": "ev-2",
+                "name": "Helpfulness",
+                "output_type": "rating",
+                "scale_min": 1,
+                "scale_max": 5,
+                "output_config": {
+                    "scale": [{"value": 5, "name": "Great"}]
+                },
+            },
+        ],
+        # Same evaluator appears again under another test — dedup expected.
+        "t2": [
+            {
+                "uuid": "ev-1",
+                "name": "Safety",
+                "output_type": "binary",
+                "output_config": {
+                    "scale": [
+                        {"value": True, "name": "Safe"},
+                        {"value": False, "name": "Unsafe"},
+                    ]
+                },
+            },
+        ],
+    }
+    fake_db = {
+        "ev-1": {"uuid": "ev-1", "name": "Safety LIVE", "description": "d1"},
+        "ev-2": {"uuid": "ev-2", "name": "Helpfulness LIVE", "description": "d2"},
+    }
+    with patch("db.get_evaluator", side_effect=lambda u: fake_db.get(u)):
+        block = _build_evaluators_block_for_test_run(snapshot)
+    assert len(block) == 2
+    by_uuid = {e["uuid"]: e for e in block}
+    assert by_uuid["ev-1"]["name"] == "Safety LIVE"
+    assert by_uuid["ev-1"]["output_type"] == "binary"
+    assert by_uuid["ev-1"]["output_config"]["scale"][0]["name"] == "Safe"
+    assert by_uuid["ev-2"]["scale_min"] == 1
+    assert by_uuid["ev-2"]["scale_max"] == 5
+
+
+def test_build_evaluators_block_for_test_run_default_output_config():
+    """Binary evaluators without a snapshotted output_config still get a
+    Correct/Wrong scale via the shared default."""
+    from routers.agent_tests import _build_evaluators_block_for_test_run
+
+    snapshot = {
+        "t1": [{"uuid": "ev-1", "name": "Anything", "output_type": "binary"}]
+    }
+    with patch("db.get_evaluator", return_value={"uuid": "ev-1", "name": "x", "description": None}):
+        block = _build_evaluators_block_for_test_run(snapshot)
+    assert block[0]["output_config"]["scale"] == [
+        {"value": True, "name": "Correct"},
+        {"value": False, "name": "Wrong"},
+    ]
+
+
+def test_build_evaluators_block_for_test_run_legacy_row_fallback():
+    """Legacy run with no snapshot still emits a block entry for the
+    evaluator referenced by judge_results so the FE doesn't see an unknown
+    evaluator_uuid."""
+    from routers.agent_tests import _build_evaluators_block_for_test_run
+
+    test_results = [
+        {
+            "test_case_id": "t1",
+            "judge_results": {
+                "Safety": {"evaluator_id": "ev-legacy", "match": True},
+            },
+        }
+    ]
+    with patch(
+        "db.get_evaluator",
+        return_value={
+            "uuid": "ev-legacy",
+            "name": "Legacy",
+            "description": "d",
+            "output_type": "binary",
+        },
+    ):
+        block = _build_evaluators_block_for_test_run(
+            None, test_results=test_results
+        )
+    assert len(block) == 1
+    assert block[0]["uuid"] == "ev-legacy"
+    assert block[0]["name"] == "Legacy"
+    assert block[0]["output_type"] == "binary"
+    # Default binary scale was injected.
+    assert block[0]["output_config"]["scale"][0]["name"] == "Correct"
 
 
 def test_enrich_test_results_with_evaluators_value_name_legacy_fallback():

--- a/tests/test_agent_test_helpers.py
+++ b/tests/test_agent_test_helpers.py
@@ -391,6 +391,41 @@ def test_build_evaluators_block_for_test_run_legacy_row_fallback():
     assert block[0]["output_config"]["scale"][0]["name"] == "Correct"
 
 
+def test_enrich_test_results_with_evaluators_dict_output_type_live_fallback():
+    """Dict-path enrichment must fall back to the LIVE evaluator's
+    output_type when the snapshot lacks it — otherwise value_name comes
+    out null on legacy runs whose snapshot didn't capture output_type."""
+    from routers.agent_tests import _enrich_test_results_with_evaluators
+
+    test_results = [
+        {
+            "test_case_id": "t1",
+            "judge_results": {
+                "Safety": {
+                    "evaluator_id": "ev-1",
+                    "match": True,
+                }
+            },
+        }
+    ]
+    # Snapshot has the evaluator but no output_type — simulates a legacy
+    # capture that pre-dates the field.
+    snapshot = {"t1": [{"uuid": "ev-1"}]}
+    with patch(
+        "db.get_evaluator",
+        return_value={
+            "uuid": "ev-1",
+            "name": "Safety",
+            "description": "d",
+            "output_type": "binary",
+        },
+    ):
+        _enrich_test_results_with_evaluators(test_results, snapshot)
+    # Live evaluator's output_type kicks in and the binary fallback
+    # resolves the label.
+    assert test_results[0]["judge_results"][0]["value_name"] == "Correct"
+
+
 def test_enrich_test_results_with_evaluators_value_name_legacy_fallback():
     """Legacy snapshot without `output_config` falls back to Correct/Wrong
     for binary so old runs still surface a label."""

--- a/tests/test_agent_test_helpers.py
+++ b/tests/test_agent_test_helpers.py
@@ -141,6 +141,153 @@ def test_enrich_test_results_with_evaluators_list_judge():
     assert test_results[0]["judge_results"][0]["name"] == "Refreshed"
 
 
+def test_enrich_test_results_with_evaluators_value_name_binary():
+    """Binary judge_results pick up `value_name` from the snapshot's rubric."""
+    from routers.agent_tests import _enrich_test_results_with_evaluators
+
+    test_results = [
+        {
+            "test_case_id": "t1",
+            "judge_results": {
+                "Safety": {
+                    "evaluator_id": "ev-1",
+                    "reasoning": "ok",
+                    "match": True,
+                }
+            },
+        }
+    ]
+    snapshot = {
+        "t1": [
+            {
+                "uuid": "ev-1",
+                "name": "Safety",
+                "output_type": "binary",
+                "output_config": {
+                    "scale": [
+                        {"value": True, "name": "Safe"},
+                        {"value": False, "name": "Unsafe"},
+                    ]
+                },
+            }
+        ]
+    }
+    with patch(
+        "db.get_evaluator",
+        return_value={"uuid": "ev-1", "name": "Safety", "description": "d"},
+    ):
+        _enrich_test_results_with_evaluators(test_results, snapshot)
+    entry = test_results[0]["judge_results"][0]
+    assert entry["value_name"] == "Safe"
+
+
+def test_enrich_test_results_with_evaluators_value_name_rating():
+    """Rating judge_results resolve `value_name` via the numeric scale entry."""
+    from routers.agent_tests import _enrich_test_results_with_evaluators
+
+    test_results = [
+        {
+            "test_case_id": "t1",
+            "judge_results": {
+                "Helpfulness": {
+                    "evaluator_id": "ev-2",
+                    "reasoning": "great",
+                    "score": 4,
+                }
+            },
+        }
+    ]
+    snapshot = {
+        "t1": [
+            {
+                "uuid": "ev-2",
+                "name": "Helpfulness",
+                "output_type": "rating",
+                "scale_min": 1,
+                "scale_max": 5,
+                "output_config": {
+                    "scale": [
+                        {"value": 1, "name": "Terrible"},
+                        {"value": 4, "name": "Good"},
+                        {"value": 5, "name": "Excellent"},
+                    ]
+                },
+            }
+        ]
+    }
+    with patch(
+        "db.get_evaluator",
+        return_value={"uuid": "ev-2", "name": "Helpfulness", "description": "d"},
+    ):
+        _enrich_test_results_with_evaluators(test_results, snapshot)
+    entry = test_results[0]["judge_results"][0]
+    assert entry["value_name"] == "Good"
+
+
+def test_enrich_test_results_with_evaluators_value_name_list_path():
+    """List-shape judge_results (idempotent re-enrichment) also resolves
+    `value_name` from the snapshot — matches the dict-path behavior so the
+    field doesn't disappear on re-read."""
+    from routers.agent_tests import _enrich_test_results_with_evaluators
+
+    test_results = [
+        {
+            "test_case_id": "t1",
+            "judge_results": [
+                {"evaluator_uuid": "ev-1", "name": "Safety", "match": False},
+            ],
+        }
+    ]
+    snapshot = {
+        "t1": [
+            {
+                "uuid": "ev-1",
+                "name": "Safety",
+                "output_type": "binary",
+                "output_config": {
+                    "scale": [
+                        {"value": True, "name": "Safe"},
+                        {"value": False, "name": "Unsafe"},
+                    ]
+                },
+            }
+        ]
+    }
+    with patch(
+        "db.get_evaluator",
+        return_value={"uuid": "ev-1", "name": "Safety", "description": "d"},
+    ):
+        _enrich_test_results_with_evaluators(test_results, snapshot)
+    assert test_results[0]["judge_results"][0]["value_name"] == "Unsafe"
+
+
+def test_enrich_test_results_with_evaluators_value_name_legacy_fallback():
+    """Legacy snapshot without `output_config` falls back to Correct/Wrong
+    for binary so old runs still surface a label."""
+    from routers.agent_tests import _enrich_test_results_with_evaluators
+
+    test_results = [
+        {
+            "test_case_id": "t1",
+            "judge_results": {
+                "Safety": {
+                    "evaluator_id": "ev-1",
+                    "match": True,
+                }
+            },
+        }
+    ]
+    snapshot = {
+        "t1": [{"uuid": "ev-1", "name": "Safety", "output_type": "binary"}]
+    }
+    with patch(
+        "db.get_evaluator",
+        return_value={"uuid": "ev-1", "name": "Safety", "description": "d"},
+    ):
+        _enrich_test_results_with_evaluators(test_results, snapshot)
+    assert test_results[0]["judge_results"][0]["value_name"] == "Correct"
+
+
 def test_enrich_model_results_with_evaluators():
     from routers.agent_tests import _enrich_model_results_with_evaluators
 

--- a/tests/test_annotation_eval_run_endpoints.py
+++ b/tests/test_annotation_eval_run_endpoints.py
@@ -317,6 +317,50 @@ def test_build_evaluators_block_keeps_stub_for_deleted_evaluator():
     assert block[0]["output_type"] is None
 
 
+def test_build_evaluators_block_applies_binary_default_for_null_rubric():
+    """Binary evaluator whose pinned version has output_config=null
+    surfaces the Correct/Wrong default — consistent with the other
+    evaluator-returning endpoints. Without this, legacy annotation
+    eval-run jobs would expose `output_config=null` and the FE would
+    have nothing to render labels with (per-run evaluator_version
+    blobs were also removed in this PR)."""
+    from routers.annotation_tasks import _build_evaluators_block_for_eval_job
+    from unittest.mock import patch
+
+    job_details = {
+        "evaluators": [
+            {
+                "evaluator_id": "ev-1",
+                "evaluator_version_id": "v-legacy",
+                "name": "Safety",
+            }
+        ]
+    }
+    raw_runs = [{"evaluator_id": "ev-1", "evaluator_version_id": "v-legacy"}]
+    with patch(
+        "routers.annotation_tasks.get_evaluator",
+        return_value={
+            "uuid": "ev-1",
+            "name": "Safety",
+            "description": "d",
+            "output_type": "binary",
+            "evaluator_type": "llm",
+            "data_type": "text",
+        },
+    ), patch(
+        "routers.annotation_tasks.get_evaluator_version",
+        return_value={"uuid": "v-legacy", "version_number": 1, "output_config": None},
+    ):
+        block = _build_evaluators_block_for_eval_job(job_details, raw_runs)
+    assert len(block) == 1
+    assert block[0]["output_config"] == {
+        "scale": [
+            {"value": True, "name": "Correct"},
+            {"value": False, "name": "Wrong"},
+        ]
+    }
+
+
 def test_evaluator_run_with_specific_item_ids(client):
     auth = _signup(client)
     h = auth["headers"]

--- a/tests/test_annotation_eval_run_endpoints.py
+++ b/tests/test_annotation_eval_run_endpoints.py
@@ -111,12 +111,32 @@ def test_evaluator_run_lifecycle(client, monkeypatch):
         start.assert_called_once()
     assert resp2.status_code == 200
 
-    # List
+    # List — slim shape: {evaluators[], runs[{uuid, status, item_count,
+    # updated_at, evaluators}]}. Per-row fluff (details, results, user_id,
+    # org_uuid, created_at, completed_at, error, share_token, ...) is
+    # stripped; evaluator identity/version lives on the top-level block.
     listing = client.get(
         f"/annotation-tasks/{task_uuid}/evaluator-runs", headers=h
     )
     assert listing.status_code == 200
-    assert len(listing.json()) >= 2
+    body = listing.json()
+    assert isinstance(body, dict)
+    assert "evaluators" in body and "runs" in body
+    assert len(body["runs"]) >= 2
+    row = body["runs"][0]
+    assert set(row.keys()) == {
+        "uuid",
+        "status",
+        "item_count",
+        "updated_at",
+        "evaluators",
+    }
+    # Per-row evaluators are FK references only.
+    if row["evaluators"]:
+        assert set(row["evaluators"][0].keys()) == {
+            "evaluator_id",
+            "evaluator_version_id",
+        }
 
     # GET job
     got = client.get(

--- a/tests/test_annotation_eval_run_endpoints.py
+++ b/tests/test_annotation_eval_run_endpoints.py
@@ -288,6 +288,35 @@ def test_evaluator_run_detail_shape(client):
     assert "evaluator_version" not in run
 
 
+def test_build_evaluators_block_keeps_stub_for_deleted_evaluator():
+    """When an evaluator is soft-deleted after the job ran, the block
+    still emits a stub entry so rows[] references stay resolvable on
+    the FE — fields the soft-delete strips (description, output_type,
+    rubric) come back as null + a `deleted: true` flag."""
+    from routers.annotation_tasks import _build_evaluators_block_for_eval_job
+    from unittest.mock import patch
+
+    job_details = {
+        "evaluators": [
+            {
+                "evaluator_id": "ev-gone",
+                "evaluator_version_id": None,
+                "name": "Snapshot Name",
+            }
+        ]
+    }
+    raw_runs = [
+        {"evaluator_id": "ev-gone", "evaluator_version_id": None}
+    ]
+    with patch("routers.annotation_tasks.get_evaluator", return_value=None):
+        block = _build_evaluators_block_for_eval_job(job_details, raw_runs)
+    assert len(block) == 1
+    assert block[0]["uuid"] == "ev-gone"
+    assert block[0]["name"] == "Snapshot Name"
+    assert block[0]["deleted"] is True
+    assert block[0]["output_type"] is None
+
+
 def test_evaluator_run_with_specific_item_ids(client):
     auth = _signup(client)
     h = auth["headers"]

--- a/tests/test_annotation_eval_run_endpoints.py
+++ b/tests/test_annotation_eval_run_endpoints.py
@@ -337,6 +337,82 @@ def test_build_evaluators_block_keeps_stub_for_deleted_evaluator():
     assert block[0]["output_type"] is None
 
 
+def test_human_agreement_for_run_latest_wins_per_annotator():
+    """Eval-run detail's `human_annotations[]` block is latest-wins per
+    (item, evaluator, annotator) — matches the summary endpoint. If the
+    same annotator labeled the same slot in multiple annotation jobs,
+    only the most recent submission surfaces."""
+    from routers.annotation_tasks import _human_agreement_for_run
+    from unittest.mock import patch
+
+    # Two annotators each labeled the same (item, evaluator) slot
+    # twice — once in an older job, once in a newer one. Input is
+    # sorted updated_at ASC to match what get_annotations_for_slots
+    # returns.
+    annotations = [
+        {
+            "uuid": "ann-aman-old",
+            "item_id": "item-1",
+            "evaluator_id": "ev-1",
+            "annotator_id": "aman",
+            "job_id": "job-old",
+            "value": {"value": False, "reasoning": "first try"},
+            "updated_at": "2026-05-01 10:00:00",
+        },
+        {
+            "uuid": "ann-pri-only",
+            "item_id": "item-1",
+            "evaluator_id": "ev-1",
+            "annotator_id": "pri",
+            "job_id": "job-old",
+            "value": {"value": True, "reasoning": "p1"},
+            "updated_at": "2026-05-01 11:00:00",
+        },
+        {
+            "uuid": "ann-aman-new",
+            "item_id": "item-1",
+            "evaluator_id": "ev-1",
+            "annotator_id": "aman",
+            "job_id": "job-new",
+            "value": {"value": True, "reasoning": "changed my mind"},
+            "updated_at": "2026-05-02 09:00:00",
+        },
+    ]
+    job_runs = [
+        {
+            "uuid": "run-1",
+            "item_id": "item-1",
+            "evaluator_id": "ev-1",
+            "evaluator_version_id": "v-1",
+            "value": {"value": True, "reasoning": "ok"},
+        }
+    ]
+    with patch(
+        "routers.annotation_tasks.get_annotations_for_slots",
+        return_value=annotations,
+    ), patch(
+        "routers.annotation_tasks.get_annotators_by_uuids",
+        return_value={
+            "aman": {"uuid": "aman", "name": "aman"},
+            "pri": {"uuid": "pri", "name": "pri"},
+        },
+    ):
+        result = _human_agreement_for_run("task-1", job_runs)
+
+    items = result["items"]
+    assert len(items) == 1
+    ev_entries = items[0]["evaluators"]
+    assert len(ev_entries) == 1
+    human_ann = ev_entries[0]["human_annotations"]
+    # aman appears once (the newer 'job-new' submission); pri once.
+    by_annotator = {h["annotator_id"]: h for h in human_ann}
+    assert len(human_ann) == 2
+    assert by_annotator["aman"]["annotation_id"] == "ann-aman-new"
+    assert by_annotator["aman"]["job_id"] == "job-new"
+    assert by_annotator["aman"]["reasoning"] == "changed my mind"
+    assert by_annotator["pri"]["annotation_id"] == "ann-pri-only"
+
+
 def test_build_evaluators_block_applies_binary_default_for_null_rubric():
     """Binary evaluator whose pinned version has output_config=null
     surfaces the Correct/Wrong default — consistent with the other

--- a/tests/test_annotation_eval_run_endpoints.py
+++ b/tests/test_annotation_eval_run_endpoints.py
@@ -187,6 +187,107 @@ def test_evaluator_run_bad_evaluator_resolution(client):
     assert resp.status_code == 400
 
 
+def test_evaluator_run_detail_shape(client):
+    """GET /annotation-tasks/{uuid}/evaluator-runs/{job_uuid} exposes the
+    rubric via top-level `evaluators[].output_config.scale` (mirrors the
+    labelling-job viewer's shape), strips the slim snapshot from
+    `details.evaluators`, and removes the per-run `evaluator` /
+    `evaluator_version` blobs — those are keyed back via
+    `(evaluator_id, evaluator_version_id)` on each run row."""
+    import db as db_mod
+    from annotation_eval_runner import ANNOTATION_EVAL_JOB_TYPE
+
+    auth = _signup(client)
+    h = auth["headers"]
+    user_uuid = auth["user_uuid"]
+    org_uuid = db_mod.get_personal_org_for_user(user_uuid)["uuid"]
+    llm_ev = _llm_ev(client, h)
+    live_version_id = llm_ev["live_version_id"]
+
+    task_uuid = client.post(
+        "/annotation-tasks",
+        json={
+            "name": f"t-{uuid.uuid4().hex[:6]}",
+            "type": "llm",
+            "evaluator_ids": [llm_ev["uuid"]],
+        },
+        headers=h,
+    ).json()["uuid"]
+    item_ids = client.post(
+        f"/annotation-tasks/{task_uuid}/items",
+        json={
+            "items": [
+                {"payload": {"name": "i1", "chat_history": [], "agent_response": "x"}}
+            ]
+        },
+        headers=h,
+    ).json()["item_ids"]
+
+    # Seed a done job + one evaluator-run directly so we exercise the read
+    # path without spawning calibrate. The snapshot in `details.evaluators`
+    # is the slim shape the runner writes — we assert it's promoted to the
+    # enriched top-level `evaluators[]` and dropped from `details`.
+    job_uuid = db_mod.create_job(
+        job_type=ANNOTATION_EVAL_JOB_TYPE,
+        org_uuid=org_uuid,
+        user_id=user_uuid,
+        status="done",
+        details={
+            "task_id": task_uuid,
+            "evaluators": [
+                {
+                    "evaluator_id": llm_ev["uuid"],
+                    "evaluator_version_id": live_version_id,
+                    "name": llm_ev["name"],
+                }
+            ],
+            "item_count": 1,
+            "item_ids": item_ids,
+        },
+    )
+    db_mod.create_evaluator_runs(
+        [
+            {
+                "job_id": job_uuid,
+                "item_id": item_ids[0],
+                "evaluator_id": llm_ev["uuid"],
+                "evaluator_version_id": live_version_id,
+                "status": "completed",
+                "value": {"value": True, "reasoning": "ok"},
+            }
+        ]
+    )
+
+    got = client.get(
+        f"/annotation-tasks/{task_uuid}/evaluator-runs/{job_uuid}", headers=h
+    )
+    assert got.status_code == 200
+    body = got.json()
+
+    # Top-level evaluators[] is the new contract — full rubric exposed once.
+    assert "evaluators" in body
+    assert len(body["evaluators"]) == 1
+    ev_entry = body["evaluators"][0]
+    assert ev_entry["uuid"] == llm_ev["uuid"]
+    assert ev_entry["evaluator_version_id"] == live_version_id
+    assert ev_entry["output_type"] in ("binary", "rating")
+    assert isinstance(ev_entry.get("output_config"), dict)
+    assert isinstance(ev_entry["output_config"].get("scale"), list)
+    assert ev_entry["output_config"]["scale"]  # non-empty
+
+    # Slim snapshot is no longer surfaced inside `details` — promoted to the
+    # top-level block above.
+    assert "evaluators" not in (body.get("details") or {})
+
+    # Runs keep the FK columns but not the duplicated metadata blobs.
+    assert body["runs"]
+    run = body["runs"][0]
+    assert run["evaluator_id"] == llm_ev["uuid"]
+    assert run["evaluator_version_id"] == live_version_id
+    assert "evaluator" not in run
+    assert "evaluator_version" not in run
+
+
 def test_evaluator_run_with_specific_item_ids(client):
     auth = _signup(client)
     h = auth["headers"]

--- a/tests/test_routers_agent_tests.py
+++ b/tests/test_routers_agent_tests.py
@@ -335,6 +335,10 @@ def test_run_agent_benchmark_queued_path(client, monkeypatch):
     task_id = resp.json()["task_id"]
     got = client.get(f"/agent-tests/benchmark/{task_id}")
     assert got.status_code == 200
+    # `evaluators[]` block is now exposed on the benchmark status response
+    # the same way it is on the unit-test status — confirm the field is
+    # at least present (may be empty for a queued/never-run job).
+    assert "evaluators" in got.json()
     assert client.get("/agent-tests/benchmark/missing").status_code == 404
 
     # Visibility toggle

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -912,6 +912,45 @@ def test_annotation_task_agreement_and_summary(client):
         headers=h,
     )
     assert summary_filtered.status_code == 200
+
+    # ---- Top-level evaluators[] / row shape contract --------------------
+    body = summary_filtered.json()
+    assert "evaluators" in body and len(body["evaluators"]) == 1
+    ev_entry = body["evaluators"][0]
+    # Enriched per-evaluator block carries identity + every version's rubric.
+    assert ev_entry["uuid"] == llm_ev["uuid"]
+    assert ev_entry["output_type"] in ("binary", "rating")
+    assert "description" in ev_entry
+    assert "live_version_id" in ev_entry
+    assert isinstance(ev_entry["versions"], list) and ev_entry["versions"]
+    # `live_version_index` indexes into versions[] (or None if no live).
+    if ev_entry["live_version_id"]:
+        assert isinstance(ev_entry["live_version_index"], int)
+        live_v = ev_entry["versions"][ev_entry["live_version_index"]]
+        assert live_v["is_live"] is True
+        assert live_v["uuid"] == ev_entry["live_version_id"]
+    # Rubric exposed once per version (binary defaults to Correct/Wrong).
+    for v in ev_entry["versions"]:
+        if ev_entry["output_type"] == "binary" and v["uuid"] is not None:
+            assert v["output_config"] is not None
+            assert v["output_config"]["scale"]
+
+    # Rows are minimal — evaluator-level / version-level fields live on the
+    # top-level evaluators[] block and MUST NOT be duplicated per row.
+    for row in body["rows"]:
+        assert row["evaluator_id"] == llm_ev["uuid"]
+        for forbidden in (
+            "evaluator_name",
+            "output_type",
+            "evaluator_version_number",
+            "scale_min",
+            "scale_max",
+            "is_live_version",
+        ):
+            assert forbidden not in row, (
+                f"row should not duplicate {forbidden} — read it from "
+                f"evaluators[] via evaluator_id/evaluator_version_id"
+            )
     # Missing item id → 404
     missing_summary = client.get(
         f"/annotation-tasks/{task_uuid}/summary",

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -147,6 +147,14 @@ def test_annotation_task_crud(client):
     canonical = client.get(f"/evaluators/{llm_ev['uuid']}", headers=h).json()
     assert set(one.keys()) == set(canonical.keys())
 
+    # Versions never expose a null output_config for binary evaluators —
+    # they get the Correct/Wrong default when stored as null. Rating
+    # versions may still be null (no enumerable default without bounds).
+    for v in one["versions"]:
+        if one["output_type"] == "binary":
+            assert v["output_config"] is not None
+            assert v["output_config"].get("scale")
+
     # unlink evaluator
     unlink = client.delete(
         f"/annotation-tasks/{task_uuid}/evaluators/{llm_ev['uuid']}", headers=h
@@ -801,6 +809,27 @@ def test_annotation_agreement_endpoints(client):
         "/annotation-agreement/evaluator/missing/trend", headers=h
     )
     assert missing_ev.status_code == 404
+
+
+def test_default_output_config_helper():
+    """Binary evaluators get a Correct/Wrong fallback rubric; rating evaluators
+    stay null because no meaningful default exists without bounds."""
+    from llm_judge import default_output_config
+
+    cfg = default_output_config("binary")
+    assert cfg == {
+        "scale": [
+            {"value": True, "name": "Correct"},
+            {"value": False, "name": "Wrong"},
+        ]
+    }
+    # Mutating returned config must not bleed into subsequent calls.
+    cfg["scale"][0]["name"] = "X"
+    assert default_output_config("binary")["scale"][0]["name"] == "Correct"
+
+    assert default_output_config("rating") is None
+    assert default_output_config(None) is None
+    assert default_output_config("unknown") is None
 
 
 def test_evaluator_value_name_mapping():

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -138,8 +138,14 @@ def test_annotation_task_crud(client):
     # version history + live_version (with rubric).
     assert one["uuid"] == llm_ev["uuid"]
     assert "versions" in one and isinstance(one["versions"], list) and one["versions"]
-    assert "live_version" in one
-    live = one["live_version"]
+    # Detail shape intentionally has NO inline `live_version` — clients
+    # resolve it by indexing `live_version_id` into `versions[]`.
+    assert "live_version" not in one
+    assert one["live_version_id"]
+    live = next(
+        (v for v in one["versions"] if v["uuid"] == one["live_version_id"]),
+        None,
+    )
     assert live is not None
     assert "output_config" in live
     # Compare against the canonical detail endpoint so the two shapes don't

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -139,14 +139,14 @@ def test_annotation_task_crud(client):
     assert one["uuid"] == llm_ev["uuid"]
     assert "versions" in one and isinstance(one["versions"], list) and one["versions"]
     # Detail shape intentionally has NO inline `live_version` — clients
-    # resolve it by indexing `live_version_id` into `versions[]`.
+    # resolve it via `live_version_index` (or `live_version_id`) into
+    # `versions[]`. The index is the cheap path; the id is the fallback
+    # for when the id-list relationship needs to be re-verified.
     assert "live_version" not in one
     assert one["live_version_id"]
-    live = next(
-        (v for v in one["versions"] if v["uuid"] == one["live_version_id"]),
-        None,
-    )
-    assert live is not None
+    assert isinstance(one["live_version_index"], int)
+    live = one["versions"][one["live_version_index"]]
+    assert live["uuid"] == one["live_version_id"]
     assert "output_config" in live
     # Compare against the canonical detail endpoint so the two shapes don't
     # drift apart silently.

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -849,8 +849,7 @@ def test_list_versions_applies_binary_default_output_config(client):
         },
         headers=h,
     )
-    if create.status_code != 200:
-        return  # eval creation gated — nothing to test
+    assert create.status_code == 200, create.text
     ev_uuid = create.json()["uuid"]
     db_mod.create_evaluator_version(
         evaluator_uuid=ev_uuid,

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -817,6 +817,58 @@ def test_annotation_agreement_endpoints(client):
     assert missing_ev.status_code == 404
 
 
+def test_list_versions_applies_binary_default_output_config(client):
+    """GET /evaluators/{uuid}/versions must also apply the Correct/Wrong
+    default when a stored binary version has output_config=null —
+    consistent with the detail / list / annotation-tasks endpoints."""
+    import db as db_mod
+
+    auth = _signup(client)
+    h = auth["headers"]
+    # Create a binary evaluator, then directly insert a NULL-rubric
+    # version to simulate a legacy row.
+    create = client.post(
+        "/evaluators",
+        json={
+            "name": f"e-{uuid.uuid4().hex[:6]}",
+            "evaluator_type": "llm",
+            "data_type": "text",
+            "kind": "single",
+            "output_type": "binary",
+            "version": {
+                "judge_model": "openai/gpt-4",
+                "system_prompt": "p",
+                "variables": [],
+                "output_config": {
+                    "scale": [
+                        {"value": True, "name": "Custom"},
+                        {"value": False, "name": "Other"},
+                    ]
+                },
+            },
+        },
+        headers=h,
+    )
+    if create.status_code != 200:
+        return  # eval creation gated — nothing to test
+    ev_uuid = create.json()["uuid"]
+    db_mod.create_evaluator_version(
+        evaluator_uuid=ev_uuid,
+        judge_model="openai/gpt-4",
+        system_prompt="legacy",
+        output_config=None,
+        variables=None,
+    )
+    versions = client.get(f"/evaluators/{ev_uuid}/versions", headers=h).json()
+    legacy = next(v for v in versions if v["system_prompt"] == "legacy")
+    assert legacy["output_config"] == {
+        "scale": [
+            {"value": True, "name": "Correct"},
+            {"value": False, "name": "Wrong"},
+        ]
+    }
+
+
 def test_default_output_config_helper():
     """Binary evaluators get a Correct/Wrong fallback rubric; rating evaluators
     stay null because no meaningful default exists without bounds."""

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -128,9 +128,24 @@ def test_annotation_task_crud(client):
         == 404
     )
 
-    # list task evaluators
+    # list task evaluators — must mirror GET /evaluators/{uuid} detail shape
     list_ev = client.get(f"/annotation-tasks/{task_uuid}/evaluators", headers=h)
     assert list_ev.status_code == 200
+    detail_list = list_ev.json()
+    assert isinstance(detail_list, list) and detail_list
+    one = detail_list[0]
+    # Spot-check the same fields the per-evaluator detail returns: full
+    # version history + live_version (with rubric).
+    assert one["uuid"] == llm_ev["uuid"]
+    assert "versions" in one and isinstance(one["versions"], list) and one["versions"]
+    assert "live_version" in one
+    live = one["live_version"]
+    assert live is not None
+    assert "output_config" in live
+    # Compare against the canonical detail endpoint so the two shapes don't
+    # drift apart silently.
+    canonical = client.get(f"/evaluators/{llm_ev['uuid']}", headers=h).json()
+    assert set(one.keys()) == set(canonical.keys())
 
     # unlink evaluator
     unlink = client.delete(


### PR DESCRIPTION
## Summary

Normalizes how evaluator metadata + rubric data are surfaced across **every** endpoint that returns evaluator-judged results — annotation tasks, annotation eval-runs, agent tests, benchmarks, and the public viewers — so the FE reads rubric / name / output_config from one consistent place per response instead of duplicated per row.

### Pattern applied everywhere

- **Top-level `evaluators[]` block** per response carries the shared metadata (name, description, output_type, output_config with scale entries, scale_min/max, version info).
- **Per-row entries** keep only row-varying data (`evaluator_id` / `evaluator_version_id` as FK pointers, the row's value / reasoning / value_name / variable_values).
- **Server-side label resolution**: each row's `value_name` is precomputed via the shared `evaluator_value_name(value, output_type, output_config)` helper in `llm_judge`, so the FE doesn't have to redo the scale lookup per row.
- **Default rubric fill**: `default_output_config(\"binary\")` returns `{scale: [Correct/Wrong]}` so binary evaluators with a null stored rubric always surface *something* renderable. Rating evaluators stay null (no enumerable default without bounds; FE falls back to `str(value)`).

### Per-endpoint changes

**`GET /agent-tests/run/{task_id}`** (auth) + `/agent/{uuid}/runs` + `/runs` (lists) + `/public/test-run/{token}` + `/public/benchmark/{token}`
- Adds top-level `evaluators[]` to the response, derived from `details.evaluators_by_test_id` snapshot (rubric pinned at submission time) plus a fallback scan of judge_results rows for legacy runs.
- `JudgeResult` model: drops `name`, `description`, `scale_min`, `scale_max`. Keeps `evaluator_uuid`, `reasoning`, `match`/`score`, `value_name`, `variable_values`.
- Snapshots full `output_config` (not just `scale_min/max`) at submission time so the read path resolves labels against the rubric the run actually used.

**`GET /annotation-tasks/{task_uuid}/evaluator-runs/{job_uuid}`** (auth) + `/public/annotation-eval/{token}`
- Adds top-level `evaluators[]` (mirrors the labelling-job viewer shape).
- Strips `details.evaluators` (slim snapshot) — promoted to the top-level block.
- Strips per-run `evaluator` and `evaluator_version` blobs from each `runs[]` row.

**`GET /annotation-tasks/{task_uuid}/evaluators`**
- Promoted from the slim pivot row to full `EvaluatorDetailResponse` per evaluator — `versions[]` + `live_version_index` so the FE renders the per-evaluator detail without an N+1 fan-out to `/evaluators/{uuid}`.

**`GET /annotation-tasks/{task_uuid}/summary`**
- Top-level `evaluators[]` enriched with per-version rubric inline + `live_version_index` + `run_count`.
- Strips `evaluator_name`, `output_type`, `evaluator_version_number`, `scale_min`, `scale_max`, `is_live_version` from every row.

**`GET /evaluators/{uuid}`** (detail) and `EvaluatorDetailResponse` refactor
- Split `EvaluatorResponse` into `EvaluatorResponseBase` (shared identity) + `EvaluatorResponse` (list shape, inlines `live_version`) + `EvaluatorDetailResponse` (detail shape, exposes `versions[]` + `live_version_index`, drops the duplicated inline `live_version`).
- Every endpoint that returns `versions[]` now applies the binary Correct/Wrong default to versions stored without `output_config`.

### New shared helpers

- `llm_judge.evaluator_value_name(value, output_type, output_config)` — canonical scalar → label mapping (was `_evaluator_value_name` in `routers/annotation_tasks`; moved + re-exported there for back-compat with the existing test).
- `llm_judge.default_output_config(output_type)` — Correct/Wrong scale for binary; None for rating.

### Other fixes along the way

- Fixed `KeyError: 'created_at'` on `GET /annotation-tasks/{uuid}/evaluators` (re-fetch canonical evaluator row instead of using the slim pivot projection).
- Lint cleanup: redundant inline `import time as _time` in `test_db.py` (carry-over from a previous PR's amendment that got rebased away).

## Commits

1. `cf2670e` — Surface evaluator label on agent-test judge results (original scope)
2. `65b306d` — Promote evaluator-run evaluators to top-level with rubric
3. `4aed9ad` — Return full evaluator detail from `/annotation-tasks/{uuid}/evaluators`
4. `a054a7d` — Fix KeyError on the same endpoint
5. `c45364a` — Fill default output_config for binary versions
6. `4629575` — Drop inline live_version from evaluator detail response
7. `7822624` — Add live_version_index to evaluator detail response
8. `d7e94bf` — Promote evaluators[] to top level on agent-test / benchmark runs
9. `27153c8` — Promote evaluators[] to top level on task summary endpoint

## Test plan

- [x] \`uv run --group dev pytest tests/test_routers_annotation.py tests/test_annotation_eval_run_endpoints.py tests/test_main_and_routers.py tests/test_router_extras.py tests/test_routers_public.py tests/test_annotation_advanced.py tests/test_agent_test_helpers.py tests/test_routers_agent_tests.py -q\` — 96+ tests pass, including new shape-pinning assertions on each endpoint (top-level evaluators[] presence, absence of stripped per-row fields, live_version_index correctness, default Correct/Wrong fill for binary).
- [x] Manually verified via curl: `GET /annotation-tasks/{uuid}/evaluators` returns the new `versions[]`+`live_version_index` shape; legacy evaluator versions with null `output_config` get the Correct/Wrong default.
- [ ] FE smoke: each affected page (agent-tests run, benchmark run, annotation task summary, annotation eval-run detail) renders the rubric / labels correctly against the new shape.

## Breaking changes (FE coordination required)

These response shapes changed in non-additive ways — FE needs to read from the new locations:

| Endpoint | Old → New |
|---|---|
| `GET /agent-tests/run/{task_id}` (+ list endpoints + public test-run + public benchmark) | `results[i].judge_results[j].{name,description,scale_min,scale_max}` → `evaluators[k]` (matched by `evaluator_uuid`) |
| `GET /annotation-tasks/{uuid}/evaluator-runs/{job_uuid}` + `/public/annotation-eval/{token}` | `runs[i].evaluator.*` / `runs[i].evaluator_version.*` → `evaluators[k]`. `details.evaluators` → top-level `evaluators` |
| `GET /annotation-tasks/{uuid}/evaluators` | Slim pivot rows → `EvaluatorDetailResponse[]` (full `versions[]`, no `linked_at`) |
| `GET /annotation-tasks/{uuid}/summary` | `rows[i].{evaluator_name,output_type,scale_min,scale_max,evaluator_version_number,is_live_version}` → `evaluators[k]` (matched by `evaluator_id` + `evaluator_version_id`) |
| `GET /evaluators/{uuid}` | Inline `live_version` block → use `versions[live_version_index]` (or match `live_version_id` against `versions[].uuid`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)