### PR TITLE
Superadmin bypasses org-membership checks

### DIFF
--- a/src/auth_utils.py
+++ b/src/auth_utils.py
@@ -110,6 +110,16 @@ async def get_current_user_id(
 SUPERADMIN_EMAIL = os.getenv("SUPERADMIN_EMAIL", "")
 
 
+def is_superadmin_user(user_id: str) -> bool:
+    """Return True if `user_id` belongs to the configured superadmin email."""
+    if not SUPERADMIN_EMAIL:
+        return False
+    from db import get_user
+
+    user = get_user(user_id)
+    return bool(user) and user.get("email", "") == SUPERADMIN_EMAIL
+
+
 async def require_superadmin(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> str:
@@ -166,14 +176,21 @@ async def get_current_org(
     """
     user_id = await get_current_user_id(credentials)
 
+    payload = decode_token(credentials.credentials) or {}
+    is_superadmin = bool(SUPERADMIN_EMAIL) and payload.get("email", "") == SUPERADMIN_EMAIL
+
     # Import lazily to dodge the circular dependency (db imports nothing from
     # auth_utils, but routers import both — keeping db out of module-load
     # makes the dep graph robust against future moves).
-    from db import get_member_role, get_personal_org_for_user
+    from db import get_member_role, get_personal_org_for_user, get_organization
 
     if x_org_uuid:
         role = get_member_role(x_org_uuid, user_id)
         if role is None:
+            # Superadmin bypass: grant owner-level access to any existing org
+            # without requiring membership.
+            if is_superadmin and get_organization(x_org_uuid) is not None:
+                return OrgContext(user_id=user_id, org_uuid=x_org_uuid, role="owner")
             raise HTTPException(status_code=404, detail="Organization not found")
         return OrgContext(user_id=user_id, org_uuid=x_org_uuid, role=role)
 

--- a/src/routers/org_limits.py
+++ b/src/routers/org_limits.py
@@ -12,7 +12,7 @@ from db import (
     update_org_limits,
     delete_org_limits,
 )
-from auth_utils import get_current_org, OrgContext, require_superadmin
+from auth_utils import get_current_org, OrgContext, require_superadmin, is_superadmin_user
 
 router = APIRouter(prefix="/org-limits", tags=["org-limits"])
 
@@ -88,7 +88,7 @@ async def get_org_limits_endpoint(
     target_org_uuid: str, ctx: OrgContext = Depends(get_current_org)
 ):
     """Get limits for an org. Must be a member of the target org."""
-    if get_member_role(target_org_uuid, ctx.user_id) is None:
+    if get_member_role(target_org_uuid, ctx.user_id) is None and not is_superadmin_user(ctx.user_id):
         raise HTTPException(status_code=404, detail="Organization limits not found")
     limits = get_org_limits(target_org_uuid)
     if not limits:

--- a/src/routers/organizations.py
+++ b/src/routers/organizations.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from typing import List, Optional
 
-from auth_utils import get_current_user_id
+from auth_utils import get_current_user_id, is_superadmin_user
 from db import (
     add_organization_member,
     create_organization,
@@ -60,13 +60,12 @@ class MemberResponse(BaseModel):
 def _require_membership(org_uuid: str, user_id: str) -> str:
     """Resolve the caller's role in `org_uuid`, 404ing if not a member.
 
-    Both owner and admin have the same permissions everywhere, so the role
-    string is returned only for the few endpoints that distinguish (e.g.
-    add/remove member, rename). 404 (not 403) keeps existence-leak parity
-    with the rest of the codebase.
+    Superadmin bypass: any existing org grants owner-level access.
     """
     role = get_member_role(org_uuid, user_id)
     if role is None:
+        if is_superadmin_user(user_id) and get_organization(org_uuid) is not None:
+            return "owner"
         raise HTTPException(status_code=404, detail="Organization not found")
     return role
 

--- a/tests/test_auth_utils_extra.py
+++ b/tests/test_auth_utils_extra.py
@@ -90,3 +90,60 @@ def test_get_optional_user_id_valid(monkeypatch):
 
 def test_get_optional_user_id_bad_token():
     assert asyncio.run(get_optional_user_id(_creds("garbage"))) is None
+
+
+def test_is_superadmin_user_no_env(monkeypatch):
+    monkeypatch.setattr(auth_utils, "SUPERADMIN_EMAIL", "")
+    assert auth_utils.is_superadmin_user("any-uid") is False
+
+
+def test_is_superadmin_user_match_and_mismatch(monkeypatch):
+    monkeypatch.setattr(auth_utils, "SUPERADMIN_EMAIL", "admin@example.com")
+
+    def fake_get_user(uid):
+        return {
+            "admin-uid": {"email": "admin@example.com"},
+            "regular-uid": {"email": "user@example.com"},
+        }.get(uid)
+
+    import db
+
+    monkeypatch.setattr(db, "get_user", fake_get_user)
+    assert auth_utils.is_superadmin_user("admin-uid") is True
+    assert auth_utils.is_superadmin_user("regular-uid") is False
+    assert auth_utils.is_superadmin_user("unknown-uid") is False
+
+
+def test_get_current_org_superadmin_bypasses_membership(monkeypatch):
+    from auth_utils import get_current_org
+
+    monkeypatch.setattr(auth_utils, "JWT_SECRET_KEY", "test-secret-key-for-unit-tests")
+    monkeypatch.setattr(auth_utils, "SUPERADMIN_EMAIL", "admin@example.com")
+    token = create_access_token("admin-uid", "admin@example.com")
+
+    import db
+
+    monkeypatch.setattr(db, "get_member_role", lambda org, uid: None)
+    monkeypatch.setattr(db, "get_organization", lambda org: {"uuid": org})
+
+    ctx = asyncio.run(get_current_org(_creds(token), x_org_uuid="some-org"))
+    assert ctx.org_uuid == "some-org"
+    assert ctx.role == "owner"
+    assert ctx.user_id == "admin-uid"
+
+
+def test_get_current_org_superadmin_bypass_requires_org_to_exist(monkeypatch):
+    from auth_utils import get_current_org
+
+    monkeypatch.setattr(auth_utils, "JWT_SECRET_KEY", "test-secret-key-for-unit-tests")
+    monkeypatch.setattr(auth_utils, "SUPERADMIN_EMAIL", "admin@example.com")
+    token = create_access_token("admin-uid", "admin@example.com")
+
+    import db
+
+    monkeypatch.setattr(db, "get_member_role", lambda org, uid: None)
+    monkeypatch.setattr(db, "get_organization", lambda org: None)
+
+    with pytest.raises(HTTPException) as ex:
+        asyncio.run(get_current_org(_creds(token), x_org_uuid="ghost-org"))
+    assert ex.value.status_code == 404

--- a/tests/test_main_and_routers.py
+++ b/tests/test_main_and_routers.py
@@ -1198,3 +1198,30 @@ def test_org_limits_router(client, monkeypatch):
     assert deleted.status_code == 200
     # Already gone
     assert client.delete(f"/org-limits/{user_org_uuid}", headers=h).status_code == 404
+
+
+def test_org_limits_get_superadmin_bypasses_membership(client, monkeypatch):
+    """GET /org-limits/{org_uuid} allows superadmin even when they're not a
+    member of the target org."""
+    import auth_utils
+    import db as db_mod
+
+    owner = _auth(client)
+    outsider = _auth(client)
+    target_org_uuid = db_mod.get_personal_org_for_user(owner["user_uuid"])["uuid"]
+
+    # Seed a limits row on owner's org as the owner-superadmin (needed since
+    # creating limits requires superadmin).
+    monkeypatch.setattr(auth_utils, "SUPERADMIN_EMAIL", owner["email"])
+    create = client.post(
+        "/org-limits",
+        json={"org_uuid": target_org_uuid, "limits": {"max_rows_per_eval": 11}},
+        headers=owner["headers"],
+    )
+    assert create.status_code == 200
+
+    # Now switch the superadmin to outsider, who is NOT a member of owner's org.
+    monkeypatch.setattr(auth_utils, "SUPERADMIN_EMAIL", outsider["email"])
+    got = client.get(f"/org-limits/{target_org_uuid}", headers=outsider["headers"])
+    assert got.status_code == 200
+    assert got.json()["limits"]["max_rows_per_eval"] == 11

--- a/tests/test_routers_organizations.py
+++ b/tests/test_routers_organizations.py
@@ -267,7 +267,8 @@ def test_members_list_only_visible_to_members(client):
     assert ok.json()[0]["role"] == "owner"
 
     denied = client.get(
-        f"/organizations/{org['uuid']}/members", headers=outsider["headers"]
+        f"/organizations/{org['uuid']}/members",
+        headers=outsider["headers"],
     )
     assert denied.status_code == 404
 

--- a/tests/test_routers_organizations.py
+++ b/tests/test_routers_organizations.py
@@ -273,6 +273,54 @@ def test_members_list_only_visible_to_members(client):
     assert denied.status_code == 404
 
 
+def test_superadmin_can_manage_org_without_membership(client, monkeypatch):
+    """Superadmin bypass: a user matching SUPERADMIN_EMAIL can list members,
+    add a member, and rename any existing org without being in org_members.
+    """
+    import auth_utils
+
+    owner = _signup(client)
+    outsider = _signup(client, email_prefix="superadmin")
+    invitee = _signup(client, email_prefix="invitee-by-admin")
+
+    org = client.post(
+        "/organizations", json={"name": "Customer Org"}, headers=owner["headers"]
+    ).json()
+
+    # Promote outsider to superadmin via env override.
+    monkeypatch.setattr(auth_utils, "SUPERADMIN_EMAIL", outsider["email"])
+
+    # Listing members works even though outsider is not a member.
+    listing = client.get(
+        f"/organizations/{org['uuid']}/members", headers=outsider["headers"]
+    )
+    assert listing.status_code == 200
+
+    # Adding a member works.
+    added = client.post(
+        f"/organizations/{org['uuid']}/members",
+        json={"email": invitee["email"]},
+        headers=outsider["headers"],
+    )
+    assert added.status_code == 201
+
+    # Renaming works.
+    renamed = client.patch(
+        f"/organizations/{org['uuid']}",
+        json={"name": "Customer Org Renamed"},
+        headers=outsider["headers"],
+    )
+    assert renamed.status_code == 200
+
+    # Bypass requires the org to actually exist.
+    missing = client.patch(
+        "/organizations/00000000-0000-0000-0000-000000000000",
+        json={"name": "ghost"},
+        headers=outsider["headers"],
+    )
+    assert missing.status_code == 404
+
+
 def test_per_org_unique_indexes_exist_after_init(client):
     """The per-org partial unique indexes (`idx_*_org_name_active`) must be
     created on a fresh DB — i.e. they're created AFTER the `ALTER TABLE ...


### PR DESCRIPTION
## Summary

- Adds a superadmin escape hatch on the org-membership gates so the user identified by `SUPERADMIN_EMAIL` can act on any existing org without being listed in `org_members`. Previously, calls like `POST /organizations/{uuid}/members` returned 404 *Organization not found* when the superadmin wasn't a member of the target org.
- Bypass is applied at all three independent gates:
  - `auth_utils.get_current_org` — `X-Org-UUID` header path (the common multi-tenant dep, used by ~116 endpoints).
  - `routers/organizations._require_membership` — used by rename / list-members / add-member / remove-member, which still depend on `get_current_user_id` because their org id comes from the URL path (or, for create, doesn't exist yet).
  - `routers/org_limits` `GET /{target_org_uuid}` — same inline pattern.
- New helper `auth_utils.is_superadmin_user(user_id)` looks up the user's email and compares to `SUPERADMIN_EMAIL`, for code paths that have a `user_id` but no JWT in hand.

## Why

Support / admin workflows (adding a member to a customer's workspace, inspecting an org's limits) need to work without first inviting the superadmin into every org. The 404 was a confusing failure mode — caller has a valid superadmin JWT but the API claims the org doesn't exist.

## Frontend impact

None. Existing `Authorization: Bearer ...` calls keep working unchanged. The bypass is purely additive: non-superadmin behavior is identical (still 404 on non-membership).

## Test plan

- [x] `uv run --group dev pytest tests/test_auth_utils.py tests/test_auth_utils_extra.py tests/test_routers_organizations.py` — 23 passed.
- [ ] Manual: as superadmin, `POST /organizations/{some-other-org-uuid}/members` succeeds (previously 404).
- [ ] Manual: as a non-superadmin non-member, the same call still returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)