### PR TITLE
Surface per-(item, annotator) comments on annotation-task summary

### DIFF
--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -2017,7 +2017,12 @@ async def task_summary(
             "human_agreement": float|null,
             "evaluator_agreement": float|null
           }
-        ]
+        ],
+        "item_comments": {
+          "<item_uuid>": {
+            "<annotator_uuid>": str   # latest free-text comment
+          }
+        }
       }
 
     Cell rules:
@@ -2035,8 +2040,14 @@ async def task_summary(
       - Each annotator cell is that annotator's latest annotation for the slot,
         across ALL annotation jobs (matches the agreement aggregator's
         latest-wins-per-annotator semantics). `null` if they haven't annotated it.
-      - Row-level overall annotations (`evaluator_id IS NULL`) are not surfaced
-        here — this view is per-evaluator.
+      - Row-level overall annotations (`evaluator_id IS NULL`) are surfaced
+        in the top-level `item_comments` block — one free-text string per
+        (item, annotator) pulled from `value["comment"]`. They are
+        orthogonal to evaluators, so they live outside `rows[]`. Only
+        items/annotators with a non-empty comment appear (the block is
+        sparse). Latest-wins per (item, annotator) on `updated_at`. The
+        `annotators[]` union includes annotators that contributed comments
+        even if they never wrote a per-evaluator annotation.
     """
     task = _ensure_owned_task(task_uuid, ctx.org_uuid)
     items = get_annotation_items_for_task(task_uuid)
@@ -2104,18 +2115,39 @@ async def task_summary(
     # Latest annotation per (item, evaluator, annotator). Input is sorted by
     # updated_at ASC so overwrite gives latest-wins.
     latest_ann: Dict[tuple, Dict[str, Any]] = {}
+    # Row-level (evaluator_id IS NULL) annotations carry per-(item, annotator)
+    # free-text comments. Same latest-wins-on-updated_at semantics; we read the
+    # string out of `value["comment"]` and skip anything that isn't a non-empty
+    # string so a future shape change can't crash the response. Built task-wide
+    # so the annotator union stays consistent with the per-evaluator path —
+    # the per-item filter is applied later, only to the response block.
+    all_item_comments: Dict[str, Dict[str, str]] = {}
     for a in annotations:
         annotator_id = a.get("annotator_id")
         ev_id = a.get("evaluator_id")
         a_item_id = a.get("item_id")
-        if not annotator_id or not ev_id or not a_item_id:
+        if not annotator_id or not a_item_id:
+            continue
+        if ev_id is None:
+            value = a.get("value")
+            if not isinstance(value, dict):
+                continue
+            comment = value.get("comment")
+            if not isinstance(comment, str) or not comment:
+                continue
+            all_item_comments.setdefault(a_item_id, {})[annotator_id] = comment
             continue
         latest_ann[(a_item_id, ev_id, annotator_id)] = a
 
-    # Annotator union — only those with ≥1 (item, evaluator) annotation visible
-    # in this view. Stable ordering by name then uuid. Single bulk lookup
-    # replaces the per-annotator `get_annotator(aid)` round-trips.
-    annotator_ids = list({key[2] for key in latest_ann.keys()})
+    # Annotator union — those with ≥1 (item, evaluator) annotation OR ≥1
+    # free-text comment anywhere in this task. Stays task-wide even when
+    # `item_id` is set, matching the docstring contract. Stable ordering by
+    # name then uuid. Single bulk lookup replaces the per-annotator
+    # `get_annotator(aid)` round-trips.
+    annotator_ids = list(
+        {key[2] for key in latest_ann.keys()}
+        | {aid for cells in all_item_comments.values() for aid in cells.keys()}
+    )
     annotator_rows = get_annotators_by_uuids(annotator_ids)
     annotators: List[Dict[str, Any]] = [
         {"uuid": a["uuid"], "name": a.get("name")}
@@ -2310,12 +2342,19 @@ async def task_summary(
             }
         )
 
+    item_comments = {
+        item_id: cells
+        for item_id, cells in all_item_comments.items()
+        if item_id in scoped_item_ids
+    }
+
     return {
         "task_id": task_uuid,
         "task_type": task["type"],
         "evaluators": evaluators_block,
         "annotators": annotators,
         "rows": rows,
+        "item_comments": item_comments,
     }
 
 

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -2358,11 +2358,21 @@ async def task_summary(
             }
         )
 
-    item_comments = {
-        item_id: cells
-        for item_id, cells in all_item_comments.items()
-        if item_id in scoped_item_ids
-    }
+    # Filter to surviving annotators (soft-deleted ones are dropped from
+    # `annotators[]` by `get_annotators_by_uuids`, so emitting their UUIDs
+    # in `item_comments` would create orphans the FE has no name for).
+    surviving_annotator_ids = {a["uuid"] for a in annotators}
+    item_comments: Dict[str, Dict[str, str]] = {}
+    for cmt_item_id, cells in all_item_comments.items():
+        if cmt_item_id not in scoped_item_ids:
+            continue
+        surviving_cells = {
+            aid: text
+            for aid, text in cells.items()
+            if aid in surviving_annotator_ids
+        }
+        if surviving_cells:
+            item_comments[cmt_item_id] = surviving_cells
 
     return {
         "task_id": task_uuid,

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -2116,11 +2116,18 @@ async def task_summary(
     # updated_at ASC so overwrite gives latest-wins.
     latest_ann: Dict[tuple, Dict[str, Any]] = {}
     # Row-level (evaluator_id IS NULL) annotations carry per-(item, annotator)
-    # free-text comments. Same latest-wins-on-updated_at semantics; we read the
-    # string out of `value["comment"]` and skip anything that isn't a non-empty
-    # string so a future shape change can't crash the response. Built task-wide
-    # so the annotator union stays consistent with the per-evaluator path —
-    # the per-item filter is applied later, only to the response block.
+    # free-text comments. Same latest-wins-on-updated_at semantics as
+    # `latest_ann`, but crucially: a newer cleared/invalid comment ERASES an
+    # older valid one. This matters when the same annotator has multiple
+    # jobs on the same task — the unique row key is (job_id, item_id,
+    # evaluator_id), so each job keeps its own row and a "clear" in the
+    # newer job must not let the older job's "looks bad" survive in the
+    # response. We read the string out of `value["comment"]` and treat
+    # anything that isn't a non-empty string as a clear; this also guards
+    # against future shape changes that would otherwise crash the response.
+    # Built task-wide so the annotator union stays consistent with the
+    # per-evaluator path — the per-item filter is applied later, only to
+    # the response block.
     all_item_comments: Dict[str, Dict[str, str]] = {}
     for a in annotations:
         annotator_id = a.get("annotator_id")
@@ -2130,12 +2137,21 @@ async def task_summary(
             continue
         if ev_id is None:
             value = a.get("value")
-            if not isinstance(value, dict):
-                continue
-            comment = value.get("comment")
-            if not isinstance(comment, str) or not comment:
-                continue
-            all_item_comments.setdefault(a_item_id, {})[annotator_id] = comment
+            comment: Optional[str] = None
+            if isinstance(value, dict):
+                raw = value.get("comment")
+                if isinstance(raw, str) and raw:
+                    comment = raw
+            if comment is not None:
+                all_item_comments.setdefault(a_item_id, {})[annotator_id] = comment
+            else:
+                # Newer cleared/invalid comment wipes any older one so the
+                # response reflects the annotator's latest intent.
+                cells = all_item_comments.get(a_item_id)
+                if cells is not None:
+                    cells.pop(annotator_id, None)
+                    if not cells:
+                        all_item_comments.pop(a_item_id, None)
             continue
         latest_ann[(a_item_id, ev_id, annotator_id)] = a
 

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -1174,6 +1174,83 @@ def test_summary_surfaces_item_comments(client):
     }
 
 
+def test_summary_comment_cleared_in_newer_job_wipes_older(client):
+    """When the same annotator has multiple jobs on the same task (e.g. admin
+    re-assigns items in a fresh batch), the (job_id, item_id, evaluator=NULL)
+    unique key keeps each job's row separate. A cleared/invalid comment in
+    the *newer* job must erase the older job's valid comment from
+    item_comments — otherwise the UI would show stale text after a clear."""
+    auth = _signup(client)
+    h = auth["headers"]
+    llm_ev = _llm_evaluator(client, h)
+    task_uuid = client.post(
+        "/annotation-tasks",
+        json={
+            "name": f"t-{uuid.uuid4().hex[:6]}",
+            "type": "llm",
+            "evaluator_ids": [llm_ev["uuid"]],
+        },
+        headers=h,
+    ).json()["uuid"]
+    item_id = client.post(
+        f"/annotation-tasks/{task_uuid}/items",
+        json={"items": [{"payload": {"name": "i1"}}]},
+        headers=h,
+    ).json()["item_ids"][0]
+    annotator = client.post(
+        "/annotators", json={"name": "rater"}, headers=h
+    ).json()
+
+    # Two separate jobs for the same annotator on the same item.
+    job_old = client.post(
+        f"/annotation-tasks/{task_uuid}/jobs",
+        json={"annotator_ids": [annotator["uuid"]], "item_ids": [item_id]},
+        headers=h,
+    ).json()["jobs"][0]
+    job_new = client.post(
+        f"/annotation-tasks/{task_uuid}/jobs",
+        json={"annotator_ids": [annotator["uuid"]], "item_ids": [item_id]},
+        headers=h,
+    ).json()["jobs"][0]
+    assert job_old["uuid"] != job_new["uuid"]
+
+    # Older job: valid comment.
+    assert (
+        client.post(
+            f"/annotation-tasks/{task_uuid}/annotations",
+            json={
+                "job_id": job_old["uuid"],
+                "item_id": item_id,
+                "value": {"comment": "old comment"},
+            },
+            headers=h,
+        ).status_code
+        == 200
+    )
+    # Newer job: cleared comment (empty string is the UI's "remove" signal).
+    assert (
+        client.post(
+            f"/annotation-tasks/{task_uuid}/annotations",
+            json={
+                "job_id": job_new["uuid"],
+                "item_id": item_id,
+                "value": {"comment": ""},
+            },
+            headers=h,
+        ).status_code
+        == 200
+    )
+
+    body = client.get(
+        f"/annotation-tasks/{task_uuid}/summary", headers=h
+    ).json()
+    # Newer "clear" must wipe the older "old comment" — item drops from
+    # item_comments entirely once the last cell is gone.
+    assert item_id not in body["item_comments"], (
+        "newer cleared comment did not erase older valid one"
+    )
+
+
 def test_evaluator_runs_endpoints(client, monkeypatch):
     auth = _signup(client)
     h = auth["headers"]

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -1174,6 +1174,77 @@ def test_summary_surfaces_item_comments(client):
     }
 
 
+def test_summary_drops_comments_from_soft_deleted_annotator(client):
+    """`get_annotators_by_uuids` filters soft-deleted annotators, so any
+    `item_comments` entry keyed by a deleted UUID would have no matching
+    name in `annotators[]`. Verify the deleted annotator's comment is
+    pruned from `item_comments` instead of leaking as an orphan."""
+    auth = _signup(client)
+    h = auth["headers"]
+    llm_ev = _llm_evaluator(client, h)
+    task_uuid = client.post(
+        "/annotation-tasks",
+        json={
+            "name": f"t-{uuid.uuid4().hex[:6]}",
+            "type": "llm",
+            "evaluator_ids": [llm_ev["uuid"]],
+        },
+        headers=h,
+    ).json()["uuid"]
+    item_id = client.post(
+        f"/annotation-tasks/{task_uuid}/items",
+        json={"items": [{"payload": {"name": "i1"}}]},
+        headers=h,
+    ).json()["item_ids"][0]
+    kept = client.post(
+        "/annotators", json={"name": "kept"}, headers=h
+    ).json()
+    doomed = client.post(
+        "/annotators", json={"name": "doomed"}, headers=h
+    ).json()
+    jobs = client.post(
+        f"/annotation-tasks/{task_uuid}/jobs",
+        json={
+            "annotator_ids": [kept["uuid"], doomed["uuid"]],
+            "item_ids": [item_id],
+        },
+        headers=h,
+    ).json()["jobs"]
+    job_kept = next(j for j in jobs if j["annotator_id"] == kept["uuid"])
+    job_doomed = next(j for j in jobs if j["annotator_id"] == doomed["uuid"])
+
+    for job in (job_kept, job_doomed):
+        assert (
+            client.post(
+                f"/annotation-tasks/{task_uuid}/annotations",
+                json={
+                    "job_id": job["uuid"],
+                    "item_id": item_id,
+                    "value": {"comment": f"from {job['annotator_id']}"},
+                },
+                headers=h,
+            ).status_code
+            == 200
+        )
+
+    # Soft-delete the second annotator.
+    assert (
+        client.delete(f"/annotators/{doomed['uuid']}", headers=h).status_code
+        == 200
+    )
+
+    body = client.get(
+        f"/annotation-tasks/{task_uuid}/summary", headers=h
+    ).json()
+    annotator_uuids = {a["uuid"] for a in body["annotators"]}
+    assert doomed["uuid"] not in annotator_uuids
+    assert kept["uuid"] in annotator_uuids
+    # `kept`'s comment survives; `doomed`'s is pruned.
+    assert body["item_comments"][item_id] == {
+        kept["uuid"]: f"from {kept['uuid']}"
+    }
+
+
 def test_summary_comment_cleared_in_newer_job_wipes_older(client):
     """When the same annotator has multiple jobs on the same task (e.g. admin
     re-assigns items in a fresh batch), the (job_id, item_id, evaluator=NULL)

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -1011,6 +1011,152 @@ def test_annotation_task_agreement_and_summary(client):
     assert missing_summary.status_code == 404
 
 
+def test_summary_surfaces_item_comments(client):
+    """Row-level (evaluator_id IS NULL) annotations carry per-(item, annotator)
+    free-text comments. The summary endpoint exposes them in a top-level
+    `item_comments` block, expands the `annotators[]` union to include
+    comment-only annotators, applies latest-wins per (item, annotator), and
+    drops the block to `{}` for items outside an `item_id` filter."""
+    auth = _signup(client)
+    h = auth["headers"]
+    llm_ev = _llm_evaluator(client, h)
+    task_uuid = client.post(
+        "/annotation-tasks",
+        json={
+            "name": f"t-{uuid.uuid4().hex[:6]}",
+            "type": "llm",
+            "evaluator_ids": [llm_ev["uuid"]],
+        },
+        headers=h,
+    ).json()["uuid"]
+    items = client.post(
+        f"/annotation-tasks/{task_uuid}/items",
+        json={
+            "items": [
+                {"payload": {"name": "i1"}},
+                {"payload": {"name": "i2"}},
+            ]
+        },
+        headers=h,
+    ).json()["item_ids"]
+    item_a, item_b = items
+
+    # Two annotators. `ann_rater` writes both an evaluator annotation AND a
+    # comment so it should appear in `annotators[]` via the per-evaluator
+    # path. `ann_commenter` writes only a comment — it must still appear in
+    # `annotators[]` via the comment-union path.
+    ann_rater = client.post(
+        "/annotators", json={"name": "rater"}, headers=h
+    ).json()
+    ann_commenter = client.post(
+        "/annotators", json={"name": "commenter"}, headers=h
+    ).json()
+    jobs = client.post(
+        f"/annotation-tasks/{task_uuid}/jobs",
+        json={
+            "annotator_ids": [ann_rater["uuid"], ann_commenter["uuid"]],
+            "item_ids": items,
+        },
+        headers=h,
+    ).json()["jobs"]
+    job_rater = next(j for j in jobs if j["annotator_id"] == ann_rater["uuid"])
+    job_commenter = next(
+        j for j in jobs if j["annotator_id"] == ann_commenter["uuid"]
+    )
+
+    # Per-evaluator annotation by `ann_rater` on item_a.
+    assert (
+        client.post(
+            f"/annotation-tasks/{task_uuid}/annotations",
+            json={
+                "job_id": job_rater["uuid"],
+                "item_id": item_a,
+                "evaluator_id": llm_ev["uuid"],
+                "value": {"value": True},
+            },
+            headers=h,
+        ).status_code
+        == 200
+    )
+
+    # Comment by `ann_rater` on item_a, then overwrite to test latest-wins.
+    for comment in ("first take", "final take"):
+        assert (
+            client.post(
+                f"/annotation-tasks/{task_uuid}/annotations",
+                json={
+                    "job_id": job_rater["uuid"],
+                    "item_id": item_a,
+                    "value": {"comment": comment},
+                },
+                headers=h,
+            ).status_code
+            == 200
+        )
+
+    # Comment-only annotator on item_a and item_b.
+    for it, comment in ((item_a, "from commenter"), (item_b, "on item b")):
+        assert (
+            client.post(
+                f"/annotation-tasks/{task_uuid}/annotations",
+                json={
+                    "job_id": job_commenter["uuid"],
+                    "item_id": it,
+                    "value": {"comment": comment},
+                },
+                headers=h,
+            ).status_code
+            == 200
+        )
+
+    # Malformed comment shapes must be ignored, not crash the response.
+    for bad_value in ({"comment": ""}, {"comment": None}, {"note": "x"}, None):
+        assert (
+            client.post(
+                f"/annotation-tasks/{task_uuid}/annotations",
+                json={
+                    "job_id": job_rater["uuid"],
+                    "item_id": item_b,
+                    "value": bad_value,
+                },
+                headers=h,
+            ).status_code
+            == 200
+        )
+
+    # ---- Full summary ----------------------------------------------------
+    body = client.get(
+        f"/annotation-tasks/{task_uuid}/summary", headers=h
+    ).json()
+
+    # Annotator union includes the comment-only annotator.
+    union_uuids = {a["uuid"] for a in body["annotators"]}
+    assert ann_rater["uuid"] in union_uuids
+    assert ann_commenter["uuid"] in union_uuids
+
+    # item_comments shape: sparse, latest-wins, only valid string comments.
+    item_comments = body["item_comments"]
+    assert item_comments[item_a][ann_rater["uuid"]] == "final take"
+    assert item_comments[item_a][ann_commenter["uuid"]] == "from commenter"
+    assert item_comments[item_b] == {ann_commenter["uuid"]: "on item b"}
+    # Malformed shapes (empty string, missing key, None value) didn't leak.
+    assert ann_rater["uuid"] not in item_comments.get(item_b, {})
+
+    # ---- Filtered by item_id ----------------------------------------------
+    filtered = client.get(
+        f"/annotation-tasks/{task_uuid}/summary",
+        params={"item_id": item_a},
+        headers=h,
+    ).json()
+    # Only the filtered item appears in item_comments.
+    assert set(filtered["item_comments"].keys()) == {item_a}
+    # But annotators[] still reflects the task-wide union (per docstring).
+    assert {a["uuid"] for a in filtered["annotators"]} >= {
+        ann_rater["uuid"],
+        ann_commenter["uuid"],
+    }
+
+
 def test_evaluator_runs_endpoints(client, monkeypatch):
     auth = _signup(client)
     h = auth["headers"]

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -1029,17 +1029,22 @@ def test_summary_surfaces_item_comments(client):
         },
         headers=h,
     ).json()["uuid"]
+    # Five items: two carry real comments, three carry one malformed shape
+    # each so every guard branch in the comment reader fires under coverage.
     items = client.post(
         f"/annotation-tasks/{task_uuid}/items",
         json={
             "items": [
                 {"payload": {"name": "i1"}},
                 {"payload": {"name": "i2"}},
+                {"payload": {"name": "i3-empty-string"}},
+                {"payload": {"name": "i4-non-string"}},
+                {"payload": {"name": "i5-non-dict"}},
             ]
         },
         headers=h,
     ).json()["item_ids"]
-    item_a, item_b = items
+    item_a, item_b, item_empty, item_non_string, item_non_dict = items
 
     # Two annotators. `ann_rater` writes both an evaluator annotation AND a
     # comment so it should appear in `annotators[]` via the per-evaluator
@@ -1109,14 +1114,22 @@ def test_summary_surfaces_item_comments(client):
             == 200
         )
 
-    # Malformed comment shapes must be ignored, not crash the response.
-    for bad_value in ({"comment": ""}, {"comment": None}, {"note": "x"}, None):
+    # Malformed comment shapes must be ignored, not crash the response. One
+    # shape per item so the upsert keeps each row distinct (otherwise they
+    # collapse onto a single (job, item, evaluator=NULL) slot and only the
+    # final value persists, leaving the other guard branches uncovered).
+    malformed_by_item = {
+        item_empty: {"comment": ""},      # empty-string guard
+        item_non_string: {"comment": None},  # non-string guard
+        item_non_dict: None,              # non-dict guard
+    }
+    for malformed_item, bad_value in malformed_by_item.items():
         assert (
             client.post(
                 f"/annotation-tasks/{task_uuid}/annotations",
                 json={
                     "job_id": job_rater["uuid"],
-                    "item_id": item_b,
+                    "item_id": malformed_item,
                     "value": bad_value,
                 },
                 headers=h,
@@ -1139,8 +1152,12 @@ def test_summary_surfaces_item_comments(client):
     assert item_comments[item_a][ann_rater["uuid"]] == "final take"
     assert item_comments[item_a][ann_commenter["uuid"]] == "from commenter"
     assert item_comments[item_b] == {ann_commenter["uuid"]: "on item b"}
-    # Malformed shapes (empty string, missing key, None value) didn't leak.
-    assert ann_rater["uuid"] not in item_comments.get(item_b, {})
+    # Each malformed shape exercises a different guard branch in the reader
+    # and must produce an empty cell for that item (the key simply absent).
+    for malformed_item in (item_empty, item_non_string, item_non_dict):
+        assert malformed_item not in item_comments, (
+            f"malformed shape on {malformed_item!r} leaked into item_comments"
+        )
 
     # ---- Filtered by item_id ----------------------------------------------
     filtered = client.get(


### PR DESCRIPTION
## Summary

- `GET /annotation-tasks/{uuid}/summary` now returns a new top-level `item_comments: {[item_uuid]: {[annotator_uuid]: string}}` block built from row-level annotations (`evaluator_id IS NULL`, value shape `{"comment": "..."}`).
- Comments are orthogonal to evaluators (per `(item, annotator)`, no version, no agreement metric), so they live outside `rows[]` rather than making the row schema polymorphic.
- Block is **sparse** (only items/annotators with a non-empty comment appear), **latest-wins** per `(item, annotator)` on `updated_at`, and **narrowed by `?item_id=`** while the `annotators[]` union stays task-wide — comment-only annotators now also appear in `annotators[]` so the FE always has a name to render.
- Reader is defensive: only accepts `value["comment"]` as a non-empty string; other shapes are silently ignored.

No DB or query changes — `get_annotations_for_task` already returned these rows; the previous summary code just dropped them at the `if not ev_id: continue` guard. Nothing in `rows[]` changed.

## Test plan

- [x] `uv run --group dev pytest tests/test_routers_annotation.py::test_summary_surfaces_item_comments -q` — new test covers latest-wins, comment-only annotator in union, malformed-value rejection, item_id scoping
- [x] `uv run --group dev pytest tests/test_routers_annotation.py tests/test_annotation_advanced.py tests/test_annotation_eval_run_endpoints.py -q` — 25 passed, no regressions
- [ ] FE confirms it can read `item_comments[row.item_id]?.[annotator.uuid]` against the new shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)