### PR TITLE
Rename annotation-task type 'simulation' to 'conversation'

### DIFF
--- a/src/annotation_eval_runner.py
+++ b/src/annotation_eval_runner.py
@@ -105,7 +105,7 @@ ANNOTATION_EVAL_JOB_TYPE = "annotation-eval"
 # --eval-only modes. `tts` is omitted because annotation tasks don't store
 # audio S3 keys today; `voice` simulation isn't supported by the CLI in
 # eval-only mode.
-SUPPORTED_EVAL_TASK_TYPES = ("stt", "llm", "simulation")
+SUPPORTED_EVAL_TASK_TYPES = ("stt", "llm", "conversation")
 
 logger = logging.getLogger(__name__)
 
@@ -386,11 +386,11 @@ def build_dataset_for_task_type(
         return _build_stt_dataset(items)
     if task_type == "llm":
         return _build_llm_dataset(items, evaluators_resolved)
-    if task_type == "simulation":
+    if task_type == "conversation":
         return _build_simulation_dataset(items)
     raise DatasetBuildError(
         f"Evaluator runs are not supported for task type {task_type!r} "
-        "(supported: stt, llm, simulation)"
+        "(supported: stt, llm, conversation)"
     )
 
 
@@ -412,7 +412,7 @@ def calibrate_command_for_task_type(
             "--dataset", str(dataset_path),
             "-o", str(output_dir),
         ]
-    if task_type == "simulation":
+    if task_type == "conversation":
         return [
             "calibrate", "simulations",
             "-t", "text",
@@ -761,7 +761,7 @@ def parse_results_for_task_type(
         return _parse_results_stt(output_dir, evaluators_resolved, job_uuid)
     if task_type == "llm":
         return _parse_results_llm(output_dir, evaluators_resolved, job_uuid)
-    if task_type == "simulation":
+    if task_type == "conversation":
         return _parse_results_simulation(
             output_dir, evaluators_resolved, job_uuid, items=items
         )

--- a/src/db.py
+++ b/src/db.py
@@ -976,6 +976,13 @@ def init_db():
         except sqlite3.OperationalError:
             pass
 
+        # Migration: the annotation-task `type` value `simulation` was renamed to
+        # `conversation` (to match the `tests.type` naming for full-conversation
+        # judging). Convert existing rows. Idempotent.
+        cursor.execute(
+            "UPDATE annotation_tasks SET type = 'conversation' WHERE type = 'simulation'"
+        )
+
         # Add deleted_at column to existing tables if not present (migration)
         tables_to_migrate = [
             "agents",
@@ -6144,7 +6151,7 @@ def _parse_annotation_task_row(row: sqlite3.Row) -> Dict[str, Any]:
     return dict(row)
 
 
-ANNOTATION_TASK_TYPES = ("llm", "stt", "tts", "simulation")
+ANNOTATION_TASK_TYPES = ("llm", "stt", "tts", "conversation")
 
 
 def create_annotation_task(

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -419,7 +419,7 @@ class AnnotationItemPayload(BaseModel):
     # `payload` is a free-form JSON value whose shape is owned by the
     # task `type`. The backend doesn't validate the shape — frontend +
     # downstream consumers (evaluator runs, agreement, etc.) interpret it.
-    # For stt/llm/simulation tasks `payload["name"]` is required and must
+    # For stt/llm/conversation tasks `payload["name"]` is required and must
     # be unique within the task.
     payload: Any
     # Optional human annotations to seed alongside the item. Keys are
@@ -533,7 +533,7 @@ async def bulk_create_items(
     annotator covering every newly-inserted item. Annotations are upserted
     as if the annotator had submitted them through the public form.
     Annotations are validated against the task's *currently linked*
-    evaluator set; the task type (`stt | llm | simulation | tts`) does
+    evaluator set; the task type (`stt | llm | conversation | tts`) does
     not affect the contract. Value shape is uniform across output types:
     `{"value": <bool|number|string>, "reasoning"?: str}` — binary uses a
     bool, rating uses a number. This matches what the public form writes
@@ -2116,7 +2116,7 @@ async def task_summary(
     Response shape:
       {
         "task_id": str,
-        "task_type": "stt" | "llm" | "simulation",
+        "task_type": "stt" | "llm" | "conversation",
         "evaluators": [
           {
             "uuid": str,

--- a/tests/test_annotation_eval_runner.py
+++ b/tests/test_annotation_eval_runner.py
@@ -271,7 +271,7 @@ def test_calibrate_command_for_task_type():
     assert out_stt[:3] == ["calibrate", "stt", "--eval-only"]
     out_llm = runner.calibrate_command_for_task_type("llm", p, p, p)
     assert out_llm[:2] == ["calibrate", "llm"]
-    out_sim = runner.calibrate_command_for_task_type("simulation", p, p, p)
+    out_sim = runner.calibrate_command_for_task_type("conversation", p, p, p)
     assert out_sim[:2] == ["calibrate", "simulations"]
     with pytest.raises(runner.DatasetBuildError):
         runner.calibrate_command_for_task_type("unknown", p, p, p)

--- a/tests/test_routers_annotation.py
+++ b/tests/test_routers_annotation.py
@@ -1760,7 +1760,7 @@ def test_annotation_eval_unsupported_task_type(client):
     import db as db_mod
 
     task_types = set(db_mod.ANNOTATION_TASK_TYPES)
-    # SUPPORTED_EVAL_TASK_TYPES is {stt, llm, simulation}; tts is excluded
+    # SUPPORTED_EVAL_TASK_TYPES is {stt, llm, conversation}; tts is excluded
     if "tts" in task_types:
         llm_ev = _llm_evaluator(client, h)
         task_uuid = client.post(


### PR DESCRIPTION
## Summary
- Rename the annotation/labelling task `type` value `simulation` → `conversation` everywhere (`ANNOTATION_TASK_TYPES`, eval-runner dispatch, docstrings).
- Add an idempotent `init_db()` migration converting existing `annotation_tasks` rows (`UPDATE ... SET type = 'conversation' WHERE type = 'simulation'`).
- Aligns labelling-task naming with `tests.type` (which already uses `conversation` for full-conversation judging).

The separate `evaluator_type = "simulation"` (simulations feature, `tests.type` mapping, evaluator filtering) and the `calibrate simulations` CLI subcommand are intentionally left unchanged — different concept from the labelling-task type.

## Test plan
- [x] Scoped tests: `test_annotation_eval_runner.py`, `test_routers_annotation.py`, `test_annotation_eval_run_job.py`
- [x] Full suite: 442 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)