### PR TITLE
Surface tool-call output for agent-connection LLM tests

### DIFF
--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -184,6 +184,13 @@ class RunTestRequest(BaseModel):
 class ToolCallOutput(BaseModel):
     tool: str
     arguments: Optional[Dict[str, Any]] = None
+    # Tool execution result, surfaced only for agent-connection tests where the
+    # external agent actually runs the tool and echoes its return value. Any
+    # JSON value (object/list/string/number/...). Absent for calibrate-agent
+    # mode (tools are declared, never executed) and for agents that don't echo
+    # it. calibrate passes this through verbatim in `output.tool_calls`; without
+    # this field the response_model would drop it on serialization.
+    output: Optional[Any] = None
 
 
 class TestOutput(BaseModel):

--- a/tests/test_agent_test_helpers.py
+++ b/tests/test_agent_test_helpers.py
@@ -64,6 +64,49 @@ def test_parse_agent_test_results():
     assert _parse_agent_test_results("not-a-list") == []
 
 
+def test_parse_agent_test_results_preserves_tool_call_output():
+    """Tool-call entries from agent-connection runs may carry an `output`
+    (the tool's execution result); it must survive parsing verbatim."""
+    from routers.agent_tests import _parse_agent_test_results
+
+    data = [
+        {
+            "test_case_id": "t1",
+            "output": {
+                "response": None,
+                "tool_calls": [
+                    {
+                        "tool": "get_weather",
+                        "arguments": {"city": "NYC"},
+                        "output": {"temp": 72},
+                    }
+                ],
+            },
+            "metrics": {"passed": True},
+            "test_case": {"name": "T1", "id": "t1"},
+        }
+    ]
+    out = _parse_agent_test_results(data)
+    assert out[0]["output"]["tool_calls"][0]["output"] == {"temp": 72}
+
+
+def test_tool_call_output_model_surfaces_output():
+    """The `output` field must be declared on ToolCallOutput, otherwise the
+    response_model drops it on serialization."""
+    from routers.agent_tests import ToolCallOutput, TestOutput
+
+    tc = ToolCallOutput.model_validate(
+        {"tool": "get_weather", "arguments": {"city": "NYC"}, "output": {"temp": 72}}
+    )
+    assert tc.output == {"temp": 72}
+
+    # Optional: absent output serializes as None, not dropped.
+    out = TestOutput.model_validate(
+        {"tool_calls": [{"tool": "noop", "arguments": {}}]}
+    )
+    assert out.tool_calls[0].output is None
+
+
 def test_merge_test_results_by_test_names():
     from routers.agent_tests import _merge_test_results_by_test_names
 


### PR DESCRIPTION
## Summary
- Agent-connection LLM tests can return each tool call's execution result. Calibrate passes this through verbatim in `output.tool_calls`, but the `ToolCallOutput` response_model only declared `tool`/`arguments`, so FastAPI silently dropped the result on serialization.
- Add an optional `output` field (any JSON value) to `ToolCallOutput` so the tool result reaches the frontend. This is the only backend change required — ingest (`_parse_agent_test_results`) and the public router already preserved the data; serialization was the sole bottleneck.
- Scope note: the result only exists for agent-connection mode (the external agent runs the tool and echoes its return); calibrate-agent mode declares tools but never executes them, so `output` is naturally absent there — no gating needed.

## Test plan
- [x] `uv run --group dev pytest tests/test_agent_test_helpers.py -q` (26 passed)
- New tests pin that `_parse_agent_test_results` preserves the tool-call `output` verbatim and that the `ToolCallOutput`/`TestOutput` models surface it on serialization (and serialize absent output as `null`, not dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)