### PR TITLE
Add POST /agents/resolve to map agent names to UUIDs

### DIFF
--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -23,7 +23,7 @@ from db import (
     add_tool_to_agent,
     add_test_to_agent,
 )
-from auth_utils import get_current_org, OrgContext
+from auth_utils import get_current_org, get_org_jwt_or_api_key, OrgContext
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +242,17 @@ class AgentDuplicateResponse(BaseModel):
     message: str
 
 
+class ResolveAgentNamesRequest(BaseModel):
+    names: List[str]
+
+
+class ResolveAgentNamesResponse(BaseModel):
+    # name -> agent UUID for every requested name that resolved in the org
+    resolved: Dict[str, str]
+    # requested names with no matching agent in the org
+    not_found: List[str]
+
+
 class VerifyConnectionRequest(BaseModel):
     agent_url: Optional[str] = None
     agent_headers: Optional[Dict[str, str]] = None
@@ -343,6 +354,33 @@ async def verify_agent_connection(
         update_agent(agent_uuid=agent_uuid, config=new_config)
 
     return VerifyConnectionResponse(**result)
+
+
+@router.post("/resolve", response_model=ResolveAgentNamesResponse)
+async def resolve_agent_names(
+    request: ResolveAgentNamesRequest,
+    ctx: OrgContext = Depends(get_org_jwt_or_api_key),
+):
+    """Resolve a list of agent names to their UUIDs within the caller's org.
+
+    Auth accepts either a JWT (frontend) or an `sk_` API key (programmatic
+    clients) via `get_org_jwt_or_api_key`, so CI tooling can map human-friendly
+    agent names to the UUIDs the run/poll endpoints expect. Agent names are
+    unique per org, so each name resolves to at most one agent. Names with no
+    matching (non-deleted) agent in the org are returned under `not_found`.
+    """
+    agents = get_all_agents(org_uuid=ctx.org_uuid)
+    name_to_uuid = {agent["name"]: agent["uuid"] for agent in agents}
+
+    resolved: Dict[str, str] = {}
+    not_found: List[str] = []
+    for name in request.names:
+        if name in name_to_uuid:
+            resolved[name] = name_to_uuid[name]
+        elif name not in not_found:
+            not_found.append(name)
+
+    return ResolveAgentNamesResponse(resolved=resolved, not_found=not_found)
 
 
 @router.post("", response_model=AgentCreateResponse)

--- a/tests/test_routers_agents.py
+++ b/tests/test_routers_agents.py
@@ -1,0 +1,125 @@
+"""Integration tests for /agents, focused on the name→UUID resolve endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="module")
+def app():
+    import main as main_mod
+
+    return main_mod.app
+
+
+@pytest.fixture(scope="module")
+def client(app):
+    with patch("main.recover_pending_jobs"):
+        with TestClient(app) as c:
+            yield c
+
+
+def _signup(client):
+    suffix = uuid.uuid4().hex[:8]
+    body = client.post(
+        "/auth/signup",
+        json={
+            "first_name": "Res",
+            "last_name": "Olve",
+            "email": f"res-{suffix}@example.com",
+            "password": "passw0rd",
+        },
+    ).json()
+    return {"Authorization": f"Bearer {body['access_token']}"}
+
+
+def _create_agent(client, h, name):
+    return client.post(
+        "/agents", json={"name": name, "type": "agent"}, headers=h
+    ).json()
+
+
+def _raw_key(client, h, name="ci"):
+    return client.post("/api-keys", json={"name": name}, headers=h).json()["key"]
+
+
+def test_resolve_agent_names_with_jwt(client):
+    h = _signup(client)
+    n1 = f"alpha-{uuid.uuid4().hex[:6]}"
+    n2 = f"beta-{uuid.uuid4().hex[:6]}"
+    a1 = _create_agent(client, h, n1)
+    a2 = _create_agent(client, h, n2)
+    missing = f"ghost-{uuid.uuid4().hex[:6]}"
+
+    r = client.post(
+        "/agents/resolve", json={"names": [n1, n2, missing]}, headers=h
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["resolved"] == {n1: a1["uuid"], n2: a2["uuid"]}
+    assert body["not_found"] == [missing]
+
+
+def test_resolve_agent_names_with_api_key(client):
+    h = _signup(client)
+    name = f"keyed-{uuid.uuid4().hex[:6]}"
+    agent = _create_agent(client, h, name)
+    raw = _raw_key(client, h)
+
+    # X-API-Key header
+    r1 = client.post(
+        "/agents/resolve", json={"names": [name]}, headers={"X-API-Key": raw}
+    )
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["resolved"] == {name: agent["uuid"]}
+
+    # Authorization: Bearer sk_…
+    r2 = client.post(
+        "/agents/resolve",
+        json={"names": [name]},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["resolved"] == {name: agent["uuid"]}
+
+
+def test_resolve_dedupes_not_found(client):
+    h = _signup(client)
+    missing = f"none-{uuid.uuid4().hex[:6]}"
+    r = client.post(
+        "/agents/resolve", json={"names": [missing, missing]}, headers=h
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["resolved"] == {}
+    assert body["not_found"] == [missing]
+
+
+def test_resolve_is_org_scoped(client):
+    """An agent in org A must not resolve for a caller in org B."""
+    ha = _signup(client)
+    name = f"private-{uuid.uuid4().hex[:6]}"
+    _create_agent(client, ha, name)
+
+    hb = _signup(client)
+    r = client.post("/agents/resolve", json={"names": [name]}, headers=hb)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["resolved"] == {}
+    assert body["not_found"] == [name]
+
+
+def test_resolve_requires_auth(client):
+    r = client.post("/agents/resolve", json={"names": ["whatever"]})
+    assert r.status_code in (401, 403)
+
+    bad = client.post(
+        "/agents/resolve",
+        json={"names": ["whatever"]},
+        headers={"X-API-Key": "sk_not-a-real-key"},
+    )
+    assert bad.status_code == 401


### PR DESCRIPTION
- Add `POST /agents/resolve` to map a batch of agent names to their UUIDs within the caller's org
- Auth via JWT or `sk_` API key (`get_org_jwt_or_api_key`), so CI/programmatic clients can resolve without a JWT
- Response splits hits (`resolved`) from misses (`not_found`); names are org-scoped and unique, so each resolves to at most one agent
- Add `tests/test_routers_agents.py` covering JWT/API-key auth, org isolation, dedupe, and auth rejection