### PR TITLE
Refresh agent_test link created_at on re-add

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -4946,7 +4946,10 @@ def get_all_simulation_scenarios() -> List[Dict[str, Any]]:
 
 def add_test_to_agent(agent_id: str, test_id: str) -> int:
     """Add a test to an agent. Returns the id of the created/restored link.
-    If a soft-deleted link exists, it will be restored by unsetting deleted_at.
+    If a soft-deleted link exists, it will be restored by unsetting deleted_at
+    and resetting created_at to now, so a re-added test behaves like a fresh
+    add (it sorts as recently-added in get_tests_for_agent's created_at DESC order)
+    instead of silently inheriting its original first-add timestamp.
     """
     with get_db_connection() as conn:
         cursor = conn.cursor()
@@ -4957,9 +4960,10 @@ def add_test_to_agent(agent_id: str, test_id: str) -> int:
         )
         existing = cursor.fetchone()
         if existing:
-            # Restore the soft-deleted link
+            # Restore the soft-deleted link, refreshing created_at so the re-add
+            # registers as a recent action rather than the original add time.
             cursor.execute(
-                "UPDATE agent_tests SET deleted_at = NULL WHERE id = ?",
+                "UPDATE agent_tests SET deleted_at = NULL, created_at = CURRENT_TIMESTAMP WHERE id = ?",
                 (existing["id"],),
             )
             conn.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -566,6 +566,33 @@ def test_agent_tests_pivot_and_test_evaluators(user):
         db.set_test_evaluators(test_uuid, [{"evaluator_id": no_live}])
 
 
+def test_add_test_to_agent_restore_refreshes_created_at(user):
+    """Re-adding a soft-deleted link reuses the row but refreshes created_at
+    to now, so the re-added test sorts as recently-added rather than inheriting
+    its original first-add time."""
+    agent_uuid = db.create_agent(name=_u("a-restore"), user_id=user["uuid"], org_uuid=user["org_uuid"])
+    test_uuid = db.create_test(name=_u("t-restore"), type="llm", user_id=user["uuid"], org_uuid=user["org_uuid"])
+
+    link_id = db.add_test_to_agent(agent_uuid, test_uuid)
+
+    # Backdate created_at so we can detect whether re-add refreshes it.
+    with db.get_db_connection() as conn:
+        conn.execute(
+            "UPDATE agent_tests SET created_at = '2000-01-01 00:00:00' WHERE id = ?",
+            (link_id,),
+        )
+        conn.commit()
+
+    assert db.remove_test_from_agent(agent_uuid, test_uuid) is True
+
+    # Re-add restores the same row...
+    assert db.add_test_to_agent(agent_uuid, test_uuid) == link_id
+    # ...and created_at is no longer the backdated value.
+    restored = db.get_agent_test_link(agent_uuid, test_uuid)
+    assert restored is not None
+    assert restored["created_at"] != "2000-01-01 00:00:00"
+
+
 # ---------------------------------------------------------------------------
 # Generic jobs + queue accounting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
- Re-adding a previously soft-deleted test to an agent now resets the pivot's `created_at` to now, instead of keeping the original first-add time.
- Without this, a delete-then-re-add test sorted as old in `get_tests_for_agent` (orders by `created_at DESC`; the pivot has no `updated_at`), so a re-add left no signal it was recent.

## Notes
- The parent agent's `updated_at` is still not bumped on test add/remove — pre-existing gap, left as-is.