### PR TITLE
Surface evaluator version_number on agent-test run/benchmark results

### DIFF
--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -696,6 +696,9 @@ def _build_calibrate_config(
             run actually used even if the link is later edited).
           - ``scale_min`` / ``scale_max`` — present only for ``rating``, derived
             from the pinned evaluator-version ``output_config.scale``.
+          - ``version_number`` — the live-at-run-time evaluator version number,
+            frozen so the finished run keeps displaying the version it judged
+            against even after the evaluator is edited again.
 
         Tests without linked evaluators (e.g. tool_call tests) are absent from
         this dict.
@@ -812,6 +815,11 @@ def _build_calibrate_config(
                 "name": refs[i].get("name", ""),
                 "output_type": output_type,
                 "variable_values": ev.get("variable_values") or {},
+                # Pin the version that actually ran (LLM tests resolve LIVE, so
+                # this is the live-at-run-time number — frozen here so the
+                # finished run keeps showing the version it judged against even
+                # after the evaluator is edited again).
+                "version_number": ev.get("version_number"),
             }
             # Snapshot the live-at-run-time version's rubric so `value_name` can
             # be resolved at read time without re-reading the version row (which
@@ -1077,8 +1085,9 @@ def _build_evaluators_block_for_test_run(
 ) -> List[Dict[str, Any]]:
     """Build the top-level `evaluators[]` block for an agent-test / benchmark
     response: one entry per unique evaluator UUID, carrying the
-    `name`/`description`/`output_type`/`output_config`/scale bounds that
-    would otherwise be duplicated across every judge_results row.
+    `name`/`description`/`output_type`/`output_config`/scale bounds/
+    `version_number` that would otherwise be duplicated across every
+    judge_results row.
 
     Sources, in order of preference:
       1. `evaluators_by_test_id` snapshot — fixed at submission time, so
@@ -1154,6 +1163,9 @@ def _build_evaluators_block_for_test_run(
                 "output_config": output_config,
                 "scale_min": snap.get("scale_min"),
                 "scale_max": snap.get("scale_max"),
+                # Version the run executed against (snapshot only — None for
+                # legacy runs whose snapshot predates this field).
+                "version_number": snap.get("version_number"),
             }
         )
     return block

--- a/tests/test_agent_test_helpers.py
+++ b/tests/test_agent_test_helpers.py
@@ -393,6 +393,7 @@ def test_build_evaluators_block_for_test_run_dedupes_and_enriches():
                 "output_type": "rating",
                 "scale_min": 1,
                 "scale_max": 5,
+                "version_number": 3,
                 "output_config": {
                     "scale": [{"value": 5, "name": "Great"}]
                 },
@@ -426,6 +427,9 @@ def test_build_evaluators_block_for_test_run_dedupes_and_enriches():
     assert by_uuid["ev-1"]["output_config"]["scale"][0]["name"] == "Safe"
     assert by_uuid["ev-2"]["scale_min"] == 1
     assert by_uuid["ev-2"]["scale_max"] == 5
+    # version_number surfaces from the snapshot; absent ⇒ None.
+    assert by_uuid["ev-2"]["version_number"] == 3
+    assert by_uuid["ev-1"]["version_number"] is None
 
 
 def test_build_evaluators_block_for_test_run_default_output_config():

--- a/tests/test_run_tasks.py
+++ b/tests/test_run_tasks.py
@@ -454,8 +454,10 @@ def test_build_calibrate_config_includes_conversation_tests():
     assert case["evaluation"]["type"] == "conversation"
     assert case["evaluation"]["criteria"]
     assert case["evaluation"]["criteria"][0]["name"] in ev_names
-    # Snapshot is built for the read path.
+    # Snapshot is built for the read path, and pins the live-at-run-time
+    # evaluator version number (a fresh evaluator is on version 1).
     assert test_uuid in evaluators_by_test_id
+    assert evaluators_by_test_id[test_uuid][0]["version_number"] == 1
 
 
 def test_conversation_test_no_legacy_llm_evaluator_fallback():


### PR DESCRIPTION
## What
- Add `version_number` to each entry of the top-level `evaluators[]` array on `GET /agent-tests/run/{task_id}` and `GET /agent-tests/benchmark/{task_id}` so the FE can render its "vN" pill.
- The value is snapshotted at submit time — the live-at-run-time evaluator version, frozen so a finished run keeps showing the version it judged against even after a later evaluator edit.

## Notes
- Legacy runs whose snapshot predates the field return `version_number: null` (pill just won't render — no breakage).
- It's the raw integer (`3`), not a string (`"v3"`).