### PR TITLE
Add bulk-delete endpoint for dataset items

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -6370,6 +6370,46 @@ def delete_dataset_item(item_uuid: str, dataset_id: str) -> bool:
         return deleted
 
 
+def delete_dataset_items(
+    dataset_id: str, item_uuids: Optional[List[str]] = None
+) -> int:
+    """Soft delete multiple dataset items in one transaction. Returns the count
+    that actually transitioned to deleted.
+
+    `item_uuids=None` deletes every non-deleted item in the dataset (the
+    "select all" path); a list deletes only those uuids, scoped to the dataset.
+    UUIDs not in this dataset (or already deleted) are skipped silently, so the
+    return value can be smaller than `len(item_uuids)`. order_index values of
+    remaining items are intentionally not renumbered (see delete_dataset_item).
+    """
+    if item_uuids is not None and not item_uuids:
+        return 0
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        if item_uuids is None:
+            cursor.execute(
+                "UPDATE dataset_items SET deleted_at = CURRENT_TIMESTAMP WHERE dataset_id = ? AND deleted_at IS NULL",
+                (dataset_id,),
+            )
+        else:
+            placeholders = ",".join("?" for _ in item_uuids)
+            cursor.execute(
+                f"UPDATE dataset_items SET deleted_at = CURRENT_TIMESTAMP WHERE dataset_id = ? AND deleted_at IS NULL AND uuid IN ({placeholders})",
+                [dataset_id, *item_uuids],
+            )
+        deleted_count = cursor.rowcount
+        if deleted_count > 0:
+            cursor.execute(
+                "UPDATE datasets SET updated_at = CURRENT_TIMESTAMP WHERE uuid = ?",
+                (dataset_id,),
+            )
+            logger.info(
+                f"Soft deleted {deleted_count} dataset item(s) from {dataset_id}"
+            )
+        conn.commit()
+        return deleted_count
+
+
 # ============ Org Limits Functions ============
 
 

--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -20,6 +20,7 @@ from db import (
     get_dataset_items_by_uuids,
     update_dataset_item,
     delete_dataset_item,
+    delete_dataset_items,
 )
 
 logger = logging.getLogger(__name__)
@@ -288,6 +289,43 @@ async def update_item(
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
     return _item_row_to_response(item)
+
+
+class BulkDeleteItemsRequest(BaseModel):
+    # When `select_all=True`, `item_uuids` is ignored and every non-deleted
+    # item in the dataset is targeted. Otherwise `item_uuids` must be non-empty.
+    item_uuids: List[str] = []
+    select_all: bool = False
+
+
+@router.delete("/{dataset_id}/items")
+async def remove_items(
+    dataset_id: str,
+    request: BulkDeleteItemsRequest,
+    ctx: OrgContext = Depends(get_current_org),
+):
+    """Soft-delete multiple items from a dataset in one request.
+
+    Pass `item_uuids` to delete a specific set, or `select_all=true` to clear
+    every item in the dataset (in which case `item_uuids` is ignored). UUIDs not
+    in this dataset (or already deleted) are skipped silently, so `deleted_count`
+    reflects how many rows actually transitioned to deleted.
+    """
+    row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
+    if not row:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+
+    if not request.select_all and not request.item_uuids:
+        raise HTTPException(
+            status_code=400,
+            detail="provide item_uuids, or set select_all=true",
+        )
+
+    deleted_count = delete_dataset_items(
+        dataset_id,
+        item_uuids=None if request.select_all else request.item_uuids,
+    )
+    return {"deleted_count": deleted_count}
 
 
 @router.delete("/{dataset_id}/items/{item_uuid}", status_code=204)

--- a/tests/test_main_and_routers.py
+++ b/tests/test_main_and_routers.py
@@ -986,6 +986,81 @@ def test_datasets_items_flow(client):
 
 
 # ---------------------------------------------------------------------------
+# Bulk-delete dataset items
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_items_bulk_delete(client):
+    auth = _auth(client)
+    h = auth["headers"]
+    create = client.post(
+        "/datasets",
+        json={"name": f"d-{uuid.uuid4().hex[:6]}", "dataset_type": "tts"},
+        headers=h,
+    )
+    d_uuid = create.json()["uuid"]
+
+    def _add(n):
+        resp = client.post(
+            f"/datasets/{d_uuid}/items",
+            json=[{"text": f"t{i}"} for i in range(n)],
+            headers=h,
+        )
+        assert resp.status_code == 201
+        return [i["uuid"] for i in resp.json()]
+
+    uuids = _add(5)
+
+    # Neither item_uuids nor select_all → 400
+    bad = client.request("DELETE", f"/datasets/{d_uuid}/items", json={}, headers=h)
+    assert bad.status_code == 400
+
+    # Missing dataset → 404
+    assert (
+        client.request(
+            "DELETE", "/datasets/missing/items", json={"item_uuids": ["x"]}, headers=h
+        ).status_code
+        == 404
+    )
+
+    # Delete a subset; unknown / already-deleted uuids skipped silently
+    resp = client.request(
+        "DELETE",
+        f"/datasets/{d_uuid}/items",
+        json={"item_uuids": [uuids[0], uuids[1], "nope"]},
+        headers=h,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["deleted_count"] == 2
+    # Re-deleting the same uuids now counts 0 (already soft-deleted)
+    again = client.request(
+        "DELETE",
+        f"/datasets/{d_uuid}/items",
+        json={"item_uuids": [uuids[0], uuids[1]]},
+        headers=h,
+    )
+    assert again.json()["deleted_count"] == 0
+    # 3 remain
+    assert client.get(f"/datasets/{d_uuid}", headers=h).json()["item_count"] == 3
+
+    # select_all clears the rest (item_uuids ignored)
+    resp = client.request(
+        "DELETE",
+        f"/datasets/{d_uuid}/items",
+        json={"select_all": True, "item_uuids": ["ignored"]},
+        headers=h,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["deleted_count"] == 3
+    assert client.get(f"/datasets/{d_uuid}", headers=h).json()["item_count"] == 0
+    # select_all on an empty dataset → 0
+    resp = client.request(
+        "DELETE", f"/datasets/{d_uuid}/items", json={"select_all": True}, headers=h
+    )
+    assert resp.json()["deleted_count"] == 0
+
+
+# ---------------------------------------------------------------------------
 # STT-dataset items must include audio_path
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What
- Add `DELETE /datasets/{id}/items` accepting `{item_uuids, select_all}` — soft-delete a subset of rows in one call, or `select_all=true` to clear the whole dataset. Previously deleting many STT/TTS rows required one DELETE per item.
- Unknown/already-deleted uuids are skipped silently; response is `{deleted_count}` reflecting actual transitions.

## Notes
- Soft delete only; bumps the dataset's `updated_at`, doesn't renumber `order_index` (matches the single-item delete). Mirrors the annotation-task bulk-delete contract.