### PR TITLE
Fix GoReleaser patch false-positive on Speakeasy brews token

### DIFF
--- a/.github/scripts/patch-goreleaser-config.sh
+++ b/.github/scripts/patch-goreleaser-config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Speakeasy emits brews[].token at the wrong level for GoReleaser >=2.17.
-# Token must live under brews[].repository.token (see goreleaser.com docs).
+# Token must live under brews[].repository.token (same indent as branch).
 set -euo pipefail
 
 FILE="${1:-.speakeasy/out/cli/.goreleaser.yaml}"
@@ -18,18 +18,22 @@ from pathlib import Path
 path = Path(sys.argv[1])
 text = path.read_text()
 
-if re.search(r"^\s+branch: main\n\s+token:", text, re.MULTILINE):
+# Patched: token is a sibling of branch under repository (same indent).
+if re.search(r"^(\s+)branch: main\n\1token:", text, re.MULTILINE):
     print(f"{path}: already patched")
     sys.exit(0)
 
 patched, n = re.subn(
-    r"(?m)^(\s+branch: main)\n\s+token: (.+)$",
-    r"\1\n      token: \2",
+    r"(?m)^(\s+)branch: main\n\s+token: (.+)$",
+    r"\1branch: main\n\1token: \2",
     text,
     count=1,
 )
 if n != 1:
-    print(f"::warning::{path}: expected brews repository.token layout; no change made", file=sys.stderr)
+    print(
+        f"::warning::{path}: expected brews repository.token layout; no change made",
+        file=sys.stderr,
+    )
     sys.exit(0)
 
 path.write_text(patched)

--- a/tests/test_patch_goreleaser_config.py
+++ b/tests/test_patch_goreleaser_config.py
@@ -1,0 +1,48 @@
+"""patch-goreleaser-config.sh must fix Speakeasy's brews[].token indentation."""
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / ".github/scripts/patch-goreleaser-config.sh"
+
+BROKEN = """\
+brews:
+  - name: calibrate
+    repository:
+      owner: dalmia
+      name: homebrew-tap
+      branch: main
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+"""
+
+FIXED = """\
+brews:
+  - name: calibrate
+    repository:
+      owner: dalmia
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+"""
+
+
+def _run_patch(content: str, tmp_path: Path) -> str:
+    target = tmp_path / ".goreleaser.yaml"
+    target.write_text(content)
+    subprocess.run(
+        ["bash", str(SCRIPT), str(target)],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    return target.read_text()
+
+
+def test_moves_token_under_repository(tmp_path):
+    assert _run_patch(BROKEN, tmp_path) == FIXED
+
+
+def test_idempotent_on_already_patched(tmp_path):
+    first = _run_patch(BROKEN, tmp_path)
+    second = _run_patch(first, tmp_path)
+    assert second == FIXED


### PR DESCRIPTION
## Summary
- Fix `patch-goreleaser-config.sh` so the “already patched” check requires `token` at the same indent as `branch` under `repository`, not merely on the next line.
- Speakeasy’s broken layout matched the old check, so the script skipped patching, synced bad `.goreleaser.yaml` to `calibrate-cli`, and GoReleaser 2.17 failed with `field token not found in type config.Homebrew` (e.g. v0.0.5).
- Add regression tests in `tests/test_patch_goreleaser_config.py`.

## Test plan
- [x] `uv run --group dev pytest tests/test_patch_goreleaser_config.py -q`
- [ ] Merge to `main`
- [ ] Re-run **Publish SDK and CLI** for `0.0.5` (or next version); confirm publish log shows `Patched ... for GoReleaser` (not `already patched` on broken input)
- [ ] Delete bad `v0.0.5` tag on `dalmia/calibrate-cli` if needed, then let re-publish re-tag
- [ ] Verify `calibrate-cli` Release workflow succeeds