### PR TITLE
Trigger docs OpenAPI sync when public API spec changes

### DIFF
--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -150,14 +150,15 @@ jobs:
       version: ${{ needs.detect.outputs.version }}
     secrets: inherit
 
-  # ARTPARK-SAHAI-ORG/calibrate syncs openapi.json from the live public spec.
-  # Fire only when the spec actually changed (same gate as publish).
+  # ARTPARK-SAHAI-ORG/calibrate syncs docs from the live public spec and
+  # client repos (SDK reference, CLI command pages). Wait for publish so
+  # calibrate-cli/docs/ is already pushed before the docs workflow clones it.
   sync-docs:
-    needs: detect
+    needs: [detect, publish]
     if: needs.detect.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger docs OpenAPI sync
+      - name: Trigger docs sync
         env:
           GH_TOKEN: ${{ secrets.DOCS_SYNC_REPO_TOKEN }}
         run: |

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -149,3 +149,19 @@ jobs:
     with:
       version: ${{ needs.detect.outputs.version }}
     secrets: inherit
+
+  # Mintlify API reference in ARTPARK-SAHAI-ORG/calibrate syncs openapi.json from the
+  # live public spec. Fire only when the spec actually changed (same gate as publish).
+  sync-docs:
+    needs: detect
+    if: needs.detect.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs OpenAPI sync
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TO_REPO_TOKEN }}
+        run: |
+          gh api repos/ARTPARK-SAHAI-ORG/calibrate/dispatches \
+            -f event_type=sync-api-spec \
+            -f "client_payload[version]=${{ needs.detect.outputs.version }}"
+          echo "Triggered sync-api-spec on ARTPARK-SAHAI-ORG/calibrate"

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -169,9 +169,9 @@ jobs:
 
   # dalmia/calibrate-skills drift-checks its agent skills against the live public
   # spec (the skills hardcode CLI flags + payload shapes). Same dispatch as
-  # sync-docs. Reuses PUSH_TO_REPO_TOKEN: it is a classic PAT (not repo-scoped),
-  # and calibrate-skills is under the same dalmia/ owner as the client repos, so
-  # the token already has dispatch access — no separate secret needed.
+  # sync-docs. Reuses PUSH_TO_REPO_TOKEN: the fine-grained PAT (owner dalmia)
+  # already lists calibrate-skills with Contents: write, which is what
+  # repository_dispatch needs — so no separate secret.
   sync-skills:
     needs: [detect, publish]
     if: needs.detect.outputs.should_publish == 'true'

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -166,3 +166,21 @@ jobs:
             -f event_type=sync-api-spec \
             -f "client_payload[version]=${{ needs.detect.outputs.version }}"
           echo "Triggered sync-api-spec on ARTPARK-SAHAI-ORG/calibrate"
+
+  # dalmia/calibrate-skills drift-checks its agent skills against the live public
+  # spec (the skills hardcode CLI flags + payload shapes). Same dispatch as
+  # sync-docs; separate token because the repo is under dalmia/ (personal), not
+  # the org. Independent of sync-docs, so it needs only detect + publish.
+  sync-skills:
+    needs: [detect, publish]
+    if: needs.detect.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger skills sync
+        env:
+          GH_TOKEN: ${{ secrets.SKILLS_SYNC_REPO_TOKEN }}
+        run: |
+          gh api repos/dalmia/calibrate-skills/dispatches \
+            -f event_type=sync-api-spec \
+            -f "client_payload[version]=${{ needs.detect.outputs.version }}"
+          echo "Triggered sync-api-spec on dalmia/calibrate-skills"

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -150,8 +150,8 @@ jobs:
       version: ${{ needs.detect.outputs.version }}
     secrets: inherit
 
-  # Mintlify API reference in ARTPARK-SAHAI-ORG/calibrate syncs openapi.json from the
-  # live public spec. Fire only when the spec actually changed (same gate as publish).
+  # ARTPARK-SAHAI-ORG/calibrate syncs openapi.json from the live public spec.
+  # Fire only when the spec actually changed (same gate as publish).
   sync-docs:
     needs: detect
     if: needs.detect.outputs.should_publish == 'true'

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -159,7 +159,7 @@ jobs:
     steps:
       - name: Trigger docs OpenAPI sync
         env:
-          GH_TOKEN: ${{ secrets.PUSH_TO_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.DOCS_SYNC_REPO_TOKEN }}
         run: |
           gh api repos/ARTPARK-SAHAI-ORG/calibrate/dispatches \
             -f event_type=sync-api-spec \

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -169,8 +169,9 @@ jobs:
 
   # dalmia/calibrate-skills drift-checks its agent skills against the live public
   # spec (the skills hardcode CLI flags + payload shapes). Same dispatch as
-  # sync-docs; separate token because the repo is under dalmia/ (personal), not
-  # the org. Independent of sync-docs, so it needs only detect + publish.
+  # sync-docs. Reuses PUSH_TO_REPO_TOKEN: it is a classic PAT (not repo-scoped),
+  # and calibrate-skills is under the same dalmia/ owner as the client repos, so
+  # the token already has dispatch access — no separate secret needed.
   sync-skills:
     needs: [detect, publish]
     if: needs.detect.outputs.should_publish == 'true'
@@ -178,7 +179,7 @@ jobs:
     steps:
       - name: Trigger skills sync
         env:
-          GH_TOKEN: ${{ secrets.SKILLS_SYNC_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.PUSH_TO_REPO_TOKEN }}
         run: |
           gh api repos/dalmia/calibrate-skills/dispatches \
             -f event_type=sync-api-spec \

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -157,6 +157,7 @@ jobs:
     needs: [detect, publish]
     if: needs.detect.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    environment: Production
     steps:
       - name: Trigger docs sync
         env:
@@ -176,6 +177,7 @@ jobs:
     needs: [detect, publish]
     if: needs.detect.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    environment: Production
     steps:
       - name: Trigger skills sync
         env:

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -246,6 +246,8 @@ uv run --group dev pytest tests/test_sdk_overrides.py -q
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | `gh: set the GH_TOKEN environment variable` | `PUSH_TO_REPO_TOKEN` missing/empty in Production | Add PAT to backend Production secrets |
+| `sync-docs` fails with 401/403 | `DOCS_SYNC_REPO_TOKEN` missing, expired, or lacks Actions write on `ARTPARK-SAHAI-ORG/calibrate` | Regenerate fine-grained PAT; update Production secret |
+| `sync-api-spec` never runs on calibrate | calibrate#108 not merged, or `repository_dispatch` not wired | Merge docs PR; confirm `sync-api-spec.yml` listens for `sync-api-spec` |
 | PAT rejected pushing `release.yaml` | Missing `workflow` scope on `PUSH_TO_REPO_TOKEN` | Add `workflow` scope to the backend PAT |
 | PAT rejected pushing to `calibrate-mcp` | PAT not authorized on `dalmia/calibrate-mcp` | Grant `contents:write` on that repo |
 | Release fails: `gpg_private_key` not supplied | GPG secrets missing in **calibrate-cli** | Add `CLI_GPG_SECRET_KEY` + `CLI_GPG_PASSPHRASE` |

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -39,7 +39,7 @@ production GitHub release published
                  → tag v<version> (PUSH_TO_REPO_TOKEN)
                  → calibrate-mcp publish.yml → npm (@dalmia/calibrate-mcp)
        └─ record sdk-v<version> tag on this repo (version history only)
-       └─ sync-docs → repository_dispatch on ARTPARK-SAHAI-ORG/calibrate (DOCS_SYNC_REPO_TOKEN)
+       └─ sync-docs (after publish) → repository_dispatch on ARTPARK-SAHAI-ORG/calibrate (DOCS_SYNC_REPO_TOKEN)
 ```
 
 Workflows: [`.github/workflows/auto-publish-sdk.yml`](.github/workflows/auto-publish-sdk.yml) (auto + manual gate), [`.github/workflows/publish-sdk.yml`](.github/workflows/publish-sdk.yml) (generate + push)  
@@ -81,6 +81,8 @@ Add the token to **this repo** → Settings → Environments → **Production** 
 **Also on the calibrate repo** (not this repo): add `PUBLIC_API_BASE_URL` under Settings → Secrets and variables → Actions so the sync workflow can fetch the live spec.
 
 Requires [calibrate#108](https://github.com/ARTPARK-SAHAI-ORG/calibrate/pull/108) merged (`sync-api-spec.yml` with `repository_dispatch` listener).
+
+The `sync-docs` job runs **after** `publish` completes so the docs workflow sees freshly synced `calibrate-python-sdk` and `calibrate-cli` output (including CLI `docs/`) before generating pages.
 
 ## One-time: Python SDK (`calibrate-python-sdk`)
 

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -38,6 +38,8 @@ production GitHub release published
                  → sync-client-repo.sh → dalmia/calibrate-mcp
                  → tag v<version> (PUSH_TO_REPO_TOKEN)
                  → calibrate-mcp publish.yml → npm (@dalmia/calibrate-mcp)
+       └─ record sdk-v<version> tag on this repo (version history only)
+       └─ sync-docs → repository_dispatch on ARTPARK-SAHAI-ORG/calibrate (DOCS_SYNC_REPO_TOKEN)
 ```
 
 Workflows: [`.github/workflows/auto-publish-sdk.yml`](.github/workflows/auto-publish-sdk.yml) (auto + manual gate), [`.github/workflows/publish-sdk.yml`](.github/workflows/publish-sdk.yml) (generate + push)  
@@ -54,6 +56,7 @@ Add these to **this repo** → Settings → Environments → **Production**:
 | `PYPI_TOKEN` | Fern generate (metadata) | Passed to `fern generate`; actual PyPI upload is in `calibrate-python-sdk` CI |
 | `SPEAKEASY_API_KEY` | Speakeasy CLI generate + validate | From [speakeasy.com](https://www.speakeasy.com) |
 | `PUSH_TO_REPO_TOKEN` | CLI/MCP sync + tagging all client repos | Classic PAT with **`contents:write`** and **`workflow`** on `dalmia/calibrate-python-sdk`, `dalmia/calibrate-cli`, and `dalmia/calibrate-mcp`. **Required for publish workflows to start** (gate check) as well as client-repo pushes. |
+| `DOCS_SYNC_REPO_TOKEN` | Docs OpenAPI sync dispatch (`sync-docs` job) | Fine-grained PAT on [`ARTPARK-SAHAI-ORG/calibrate`](https://github.com/ARTPARK-SAHAI-ORG/calibrate) with **Actions: Read and write** (see below) |
 | `PUBLIC_API_BASE_URL` | Fetch public OpenAPI spec | Production API URL injected into `servers` (e.g. `https://pense-backend.artpark.ai`) |
 
 ### PAT scopes (`PUSH_TO_REPO_TOKEN`)
@@ -62,6 +65,22 @@ Add these to **this repo** → Settings → Environments → **Production**:
 |-------|-----|
 | `contents:write` | Push CLI/MCP output via `sync-client-repo.sh`; create tags on all client repos |
 | `workflow` | Push Speakeasy-generated `.github/workflows/release.yaml` into `calibrate-cli` on each sync |
+
+### Docs sync token (`DOCS_SYNC_REPO_TOKEN`)
+
+Separate from `PUSH_TO_REPO_TOKEN` because client repos live under **`dalmia/`** (personal) while Mintlify docs live under **`ARTPARK-SAHAI-ORG/calibrate`** (org).
+
+1. GitHub → **Settings → Developer settings → Fine-grained personal access tokens → Generate**
+2. **Resource owner:** `ARTPARK-SAHAI-ORG`
+3. **Repository access:** Only `calibrate`
+4. **Permissions:** **Actions: Read and write** (triggers `repository_dispatch` → `sync-api-spec.yml`)
+5. **Expiration:** org policy caps at 366 days — GitHub emails before expiry; rotate annually and update the Production secret
+
+Add the token to **this repo** → Settings → Environments → **Production** as `DOCS_SYNC_REPO_TOKEN`.
+
+**Also on the calibrate repo** (not this repo): add `PUBLIC_API_BASE_URL` under Settings → Secrets and variables → Actions so the sync workflow can fetch the live spec.
+
+Requires [calibrate#108](https://github.com/ARTPARK-SAHAI-ORG/calibrate/pull/108) merged (`sync-api-spec.yml` with `repository_dispatch` listener).
 
 ## One-time: Python SDK (`calibrate-python-sdk`)
 

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -91,10 +91,10 @@ The `sync-docs` job runs **after** `publish` completes so the docs workflow sees
 
 `sync-skills` does **not** need its own secret. `PUSH_TO_REPO_TOKEN` is a fine-grained PAT owned by `dalmia`, and `dalmia/calibrate-skills` has been **added to its repository list** with **Contents: write** — the permission `repository_dispatch` requires (the token already grants it for pushing to the client repos). So the same token dispatches to the skills repo. (Contrast `DOCS_SYNC_REPO_TOKEN`, which must be separate: a fine-grained PAT is scoped to a single resource owner, and the docs repo is under `ARTPARK-SAHAI-ORG`, not `dalmia`.)
 
-When rotating or regenerating `PUSH_TO_REPO_TOKEN`, keep all three repos —
-`calibrate-python-sdk`, `calibrate-cli`, `calibrate-skills` — in its repository list.
+When rotating or regenerating `PUSH_TO_REPO_TOKEN`, keep all four repos —
+`calibrate-python-sdk`, `calibrate-cli`, `calibrate-mcp`, `calibrate-skills` — in its repository list.
 
-**Nothing to configure on the skills side.** The published spec URL is a public constant baked into [`sync-from-spec.yml`](https://github.com/dalmia/calibrate-skills/blob/main/.github/workflows/sync-from-spec.yml) as its default, so there is no env var to keep in sync between the two repos. The dispatch may pass `client_payload.spec_url` to override it if the host ever moves, but is not required to.
+**Only step on the skills side** (not this repo): add the `OPENAPI_SPEC_URL` variable under `dalmia/calibrate-skills` → Settings → Secrets and variables → Actions → Variables, so its drift check knows which spec to fetch. Its [`sync-from-spec.yml`](https://github.com/dalmia/calibrate-skills/blob/main/.github/workflows/sync-from-spec.yml) listener is already merged. (The URL is kept in the variable rather than hardcoded in the workflow; the dispatch may also pass `client_payload.spec_url` to override it.)
 
 `sync-skills` drift-checks the skills against the published spec (it does not regenerate them — the skills are prose). It runs after `publish` for parity with `sync-docs`, though it only depends on the spec being live.
 
@@ -265,14 +265,9 @@ uv run --group dev pytest tests/test_sdk_overrides.py -q
 | `sync-docs` fails with 401/403 | `DOCS_SYNC_REPO_TOKEN` missing, expired, or lacks Actions write on `ARTPARK-SAHAI-ORG/calibrate` | Regenerate fine-grained PAT; update Production secret |
 | `sync-skills` fails with 401/403 | `PUSH_TO_REPO_TOKEN` expired, or `calibrate-skills` dropped from its repository list | Re-add `calibrate-skills` to the fine-grained PAT with **Contents: write**; refresh the Production secret |
 | `sync-api-spec` never runs on calibrate | calibrate#108 not merged, or `repository_dispatch` not wired | Merge docs PR; confirm `sync-api-spec.yml` listens for `sync-api-spec` |
-<<<<<<< HEAD
-| `sync-from-spec` never runs on calibrate-skills | Dispatch not reaching the repo (token/owner), or the listener not wired | Confirm `PUSH_TO_REPO_TOKEN` is a classic PAT; confirm `sync-from-spec.yml` listens for `sync-api-spec` (spec URL needs no config — it defaults to the public constant) |
-| PAT rejected pushing `release.yaml` | Missing `workflow` scope on `PUSH_TO_REPO_TOKEN` | Add `workflow` scope to the backend PAT |
-| PAT rejected pushing to `calibrate-mcp` | PAT not authorized on `dalmia/calibrate-mcp` | Grant `contents:write` on that repo |
-=======
-| `sync-from-spec` never runs on calibrate-skills | Dispatch not reaching the repo, or the listener not wired | Confirm `calibrate-skills` is in `PUSH_TO_REPO_TOKEN`'s repo list; confirm `sync-from-spec.yml` listens for `sync-api-spec` (spec URL needs no config — it defaults to the public constant) |
+| `sync-from-spec` never runs on calibrate-skills | `OPENAPI_SPEC_URL` unset on calibrate-skills, or dispatch not reaching the repo | Set `OPENAPI_SPEC_URL` on calibrate-skills; confirm `calibrate-skills` is in `PUSH_TO_REPO_TOKEN`'s repo list and `sync-from-spec.yml` listens for `sync-api-spec` |
 | PAT rejected pushing `release.yaml` | Missing **Workflows: write** on `PUSH_TO_REPO_TOKEN` | Add Workflows: write to the fine-grained PAT |
->>>>>>> 4a7fee4 (Correct PUSH_TO_REPO_TOKEN as fine-grained with calibrate-skills in its repo list)
+| PAT rejected pushing to `calibrate-mcp` | `calibrate-mcp` not in `PUSH_TO_REPO_TOKEN`'s repo list | Add `calibrate-mcp` to the fine-grained PAT with **Contents: write** |
 | Release fails: `gpg_private_key` not supplied | GPG secrets missing in **calibrate-cli** | Add `CLI_GPG_SECRET_KEY` + `CLI_GPG_PASSPHRASE` |
 | Release fails: `field token not found in type config.Homebrew` | Speakeasy `.goreleaser.yaml` incompatible with GoReleaser >=2.17 | Merge backend patch (`patch-goreleaser-config.sh`) or move `token` under `repository` in `calibrate-cli`; re-run Release |
 | Homebrew formula never appears | `HOMEBREW_TAP_GITHUB_TOKEN` missing or tap repo missing | Add secret; create `dalmia/homebrew-tap` |

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -40,6 +40,7 @@ production GitHub release published
                  → calibrate-mcp publish.yml → npm (@dalmia/calibrate-mcp)
        └─ record sdk-v<version> tag on this repo (version history only)
        └─ sync-docs (after publish) → repository_dispatch on ARTPARK-SAHAI-ORG/calibrate (DOCS_SYNC_REPO_TOKEN)
+       └─ sync-skills (after publish) → repository_dispatch on dalmia/calibrate-skills (SKILLS_SYNC_REPO_TOKEN)
 ```
 
 Workflows: [`.github/workflows/auto-publish-sdk.yml`](.github/workflows/auto-publish-sdk.yml) (auto + manual gate), [`.github/workflows/publish-sdk.yml`](.github/workflows/publish-sdk.yml) (generate + push)  
@@ -57,6 +58,7 @@ Add these to **this repo** → Settings → Environments → **Production**:
 | `SPEAKEASY_API_KEY` | Speakeasy CLI generate + validate | From [speakeasy.com](https://www.speakeasy.com) |
 | `PUSH_TO_REPO_TOKEN` | CLI/MCP sync + tagging all client repos | Classic PAT with **`contents:write`** and **`workflow`** on `dalmia/calibrate-python-sdk`, `dalmia/calibrate-cli`, and `dalmia/calibrate-mcp`. **Required for publish workflows to start** (gate check) as well as client-repo pushes. |
 | `DOCS_SYNC_REPO_TOKEN` | Docs OpenAPI sync dispatch (`sync-docs` job) | Fine-grained PAT on [`ARTPARK-SAHAI-ORG/calibrate`](https://github.com/ARTPARK-SAHAI-ORG/calibrate) with **Actions: Read and write** (see below) |
+| `SKILLS_SYNC_REPO_TOKEN` | Agent-skills drift-sync dispatch (`sync-skills` job) | Fine-grained PAT on [`dalmia/calibrate-skills`](https://github.com/dalmia/calibrate-skills) with **Actions: Read and write** (see below) |
 | `PUBLIC_API_BASE_URL` | Fetch public OpenAPI spec | Production API URL injected into `servers` (e.g. `https://pense-backend.artpark.ai`) |
 
 ### PAT scopes (`PUSH_TO_REPO_TOKEN`)
@@ -83,6 +85,22 @@ Add the token to **this repo** → Settings → Environments → **Production** 
 Requires [calibrate#108](https://github.com/ARTPARK-SAHAI-ORG/calibrate/pull/108) merged (`sync-api-spec.yml` with `repository_dispatch` listener).
 
 The `sync-docs` job runs **after** `publish` completes so the docs workflow sees freshly synced `calibrate-python-sdk` and `calibrate-cli` output (including CLI `docs/`) before generating pages.
+
+### Skills sync token (`SKILLS_SYNC_REPO_TOKEN`)
+
+Separate from `DOCS_SYNC_REPO_TOKEN` because the skills repo is **`dalmia/calibrate-skills`** (personal), a different owner than the org docs repo. (One PAT could cover both repos if you prefer; keeping them separate scopes each token to a single repo.)
+
+1. GitHub → **Settings → Developer settings → Fine-grained personal access tokens → Generate**
+2. **Resource owner:** `dalmia`
+3. **Repository access:** Only `calibrate-skills`
+4. **Permissions:** **Actions: Read and write** (triggers `repository_dispatch` → `sync-from-spec.yml`)
+5. **Expiration:** rotate annually and update the Production secret
+
+Add the token to **this repo** → Settings → Environments → **Production** as `SKILLS_SYNC_REPO_TOKEN`.
+
+**Also on the calibrate-skills repo** (not this repo): add the `OPENAPI_SPEC_URL` variable under Settings → Secrets and variables → Actions → Variables so its drift check can fetch the live spec. Its [`sync-from-spec.yml`](https://github.com/dalmia/calibrate-skills/blob/main/.github/workflows/sync-from-spec.yml) listener is already merged.
+
+`sync-skills` drift-checks the skills against the published spec (it does not regenerate them — the skills are prose). It runs after `publish` for parity with `sync-docs`, though it only depends on the spec being live.
 
 ## One-time: Python SDK (`calibrate-python-sdk`)
 
@@ -249,7 +267,9 @@ uv run --group dev pytest tests/test_sdk_overrides.py -q
 |---------|--------------|-----|
 | `gh: set the GH_TOKEN environment variable` | `PUSH_TO_REPO_TOKEN` missing/empty in Production | Add PAT to backend Production secrets |
 | `sync-docs` fails with 401/403 | `DOCS_SYNC_REPO_TOKEN` missing, expired, or lacks Actions write on `ARTPARK-SAHAI-ORG/calibrate` | Regenerate fine-grained PAT; update Production secret |
+| `sync-skills` fails with 401/403 | `SKILLS_SYNC_REPO_TOKEN` missing, expired, or lacks Actions write on `dalmia/calibrate-skills` | Regenerate fine-grained PAT; update Production secret |
 | `sync-api-spec` never runs on calibrate | calibrate#108 not merged, or `repository_dispatch` not wired | Merge docs PR; confirm `sync-api-spec.yml` listens for `sync-api-spec` |
+| `sync-from-spec` never runs on calibrate-skills | `OPENAPI_SPEC_URL` variable unset, or dispatch not reaching the repo | Set the variable on calibrate-skills; confirm `sync-from-spec.yml` listens for `sync-api-spec` |
 | PAT rejected pushing `release.yaml` | Missing `workflow` scope on `PUSH_TO_REPO_TOKEN` | Add `workflow` scope to the backend PAT |
 | PAT rejected pushing to `calibrate-mcp` | PAT not authorized on `dalmia/calibrate-mcp` | Grant `contents:write` on that repo |
 | Release fails: `gpg_private_key` not supplied | GPG secrets missing in **calibrate-cli** | Add `CLI_GPG_SECRET_KEY` + `CLI_GPG_PASSPHRASE` |

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -40,7 +40,7 @@ production GitHub release published
                  → calibrate-mcp publish.yml → npm (@dalmia/calibrate-mcp)
        └─ record sdk-v<version> tag on this repo (version history only)
        └─ sync-docs (after publish) → repository_dispatch on ARTPARK-SAHAI-ORG/calibrate (DOCS_SYNC_REPO_TOKEN)
-       └─ sync-skills (after publish) → repository_dispatch on dalmia/calibrate-skills (SKILLS_SYNC_REPO_TOKEN)
+       └─ sync-skills (after publish) → repository_dispatch on dalmia/calibrate-skills (PUSH_TO_REPO_TOKEN)
 ```
 
 Workflows: [`.github/workflows/auto-publish-sdk.yml`](.github/workflows/auto-publish-sdk.yml) (auto + manual gate), [`.github/workflows/publish-sdk.yml`](.github/workflows/publish-sdk.yml) (generate + push)  
@@ -56,9 +56,8 @@ Add these to **this repo** → Settings → Environments → **Production**:
 | `FERN_TOKEN` | Fern Python SDK generate | From [buildwithfern.com](https://buildwithfern.com); Fern GitHub App must be authorized on `dalmia` |
 | `PYPI_TOKEN` | Fern generate (metadata) | Passed to `fern generate`; actual PyPI upload is in `calibrate-python-sdk` CI |
 | `SPEAKEASY_API_KEY` | Speakeasy CLI generate + validate | From [speakeasy.com](https://www.speakeasy.com) |
-| `PUSH_TO_REPO_TOKEN` | CLI/MCP sync + tagging all client repos | Classic PAT with **`contents:write`** and **`workflow`** on `dalmia/calibrate-python-sdk`, `dalmia/calibrate-cli`, and `dalmia/calibrate-mcp`. **Required for publish workflows to start** (gate check) as well as client-repo pushes. |
-| `DOCS_SYNC_REPO_TOKEN` | Docs OpenAPI sync dispatch (`sync-docs` job) | Fine-grained PAT on [`ARTPARK-SAHAI-ORG/calibrate`](https://github.com/ARTPARK-SAHAI-ORG/calibrate) with **Actions: Read and write** (see below) |
-| `SKILLS_SYNC_REPO_TOKEN` | Agent-skills drift-sync dispatch (`sync-skills` job) | Fine-grained PAT on [`dalmia/calibrate-skills`](https://github.com/dalmia/calibrate-skills) with **Actions: Read and write** (see below) |
+| `PUSH_TO_REPO_TOKEN` | CLI/MCP sync + tagging all client repos; skills drift-sync dispatch (`sync-skills` job) | Classic PAT with **`contents:write`** and **`workflow`** on `dalmia/calibrate-python-sdk`, `dalmia/calibrate-cli`, and `dalmia/calibrate-mcp`. **Required for publish workflows to start** (gate check) as well as client-repo pushes. Being a classic PAT it also reaches `dalmia/calibrate-skills` (same owner), so `sync-skills` reuses it — no separate secret. |
+| `DOCS_SYNC_REPO_TOKEN` | Docs OpenAPI sync dispatch (`sync-docs` job) | Fine-grained PAT on [`ARTPARK-SAHAI-ORG/calibrate`](https://github.com/ARTPARK-SAHAI-ORG/calibrate) with **Actions: Read and write** (see below). Separate because the docs repo is a different owner (org), out of the classic PAT's reach. |
 | `PUBLIC_API_BASE_URL` | Fetch public OpenAPI spec | Production API URL injected into `servers` (e.g. `https://pense-backend.artpark.ai`) |
 
 ### PAT scopes (`PUSH_TO_REPO_TOKEN`)
@@ -86,19 +85,11 @@ Requires [calibrate#108](https://github.com/ARTPARK-SAHAI-ORG/calibrate/pull/108
 
 The `sync-docs` job runs **after** `publish` completes so the docs workflow sees freshly synced `calibrate-python-sdk` and `calibrate-cli` output (including CLI `docs/`) before generating pages.
 
-### Skills sync token (`SKILLS_SYNC_REPO_TOKEN`)
+### Skills sync token (reuses `PUSH_TO_REPO_TOKEN`)
 
-Separate from `DOCS_SYNC_REPO_TOKEN` because the skills repo is **`dalmia/calibrate-skills`** (personal), a different owner than the org docs repo. (One PAT could cover both repos if you prefer; keeping them separate scopes each token to a single repo.)
+`sync-skills` does **not** need its own secret. `PUSH_TO_REPO_TOKEN` is a classic PAT, and classic PATs are not repo-restricted — they can write to any repo their owner can access. Since `dalmia/calibrate-skills` shares the `dalmia/` owner with the client repos the token already pushes to, it can dispatch `repository_dispatch` there too. (Contrast `DOCS_SYNC_REPO_TOKEN`, which must be separate because the docs repo is under a different owner.)
 
-1. GitHub → **Settings → Developer settings → Fine-grained personal access tokens → Generate**
-2. **Resource owner:** `dalmia`
-3. **Repository access:** Only `calibrate-skills`
-4. **Permissions:** **Actions: Read and write** (triggers `repository_dispatch` → `sync-from-spec.yml`)
-5. **Expiration:** rotate annually and update the Production secret
-
-Add the token to **this repo** → Settings → Environments → **Production** as `SKILLS_SYNC_REPO_TOKEN`.
-
-**Also on the calibrate-skills repo** (not this repo): add the `OPENAPI_SPEC_URL` variable under Settings → Secrets and variables → Actions → Variables so its drift check can fetch the live spec. Its [`sync-from-spec.yml`](https://github.com/dalmia/calibrate-skills/blob/main/.github/workflows/sync-from-spec.yml) listener is already merged.
+**Only step on the skills side** (not this repo): add the `OPENAPI_SPEC_URL` variable under `dalmia/calibrate-skills` → Settings → Secrets and variables → Actions → Variables, so its drift check can fetch the live spec. Its [`sync-from-spec.yml`](https://github.com/dalmia/calibrate-skills/blob/main/.github/workflows/sync-from-spec.yml) listener is already merged.
 
 `sync-skills` drift-checks the skills against the published spec (it does not regenerate them — the skills are prose). It runs after `publish` for parity with `sync-docs`, though it only depends on the spec being live.
 
@@ -267,7 +258,7 @@ uv run --group dev pytest tests/test_sdk_overrides.py -q
 |---------|--------------|-----|
 | `gh: set the GH_TOKEN environment variable` | `PUSH_TO_REPO_TOKEN` missing/empty in Production | Add PAT to backend Production secrets |
 | `sync-docs` fails with 401/403 | `DOCS_SYNC_REPO_TOKEN` missing, expired, or lacks Actions write on `ARTPARK-SAHAI-ORG/calibrate` | Regenerate fine-grained PAT; update Production secret |
-| `sync-skills` fails with 401/403 | `SKILLS_SYNC_REPO_TOKEN` missing, expired, or lacks Actions write on `dalmia/calibrate-skills` | Regenerate fine-grained PAT; update Production secret |
+| `sync-skills` fails with 401/403 | `PUSH_TO_REPO_TOKEN` expired, or is a fine-grained PAT not scoped to `dalmia/calibrate-skills` | Ensure it is a classic PAT (reaches all `dalmia/` repos); if fine-grained, add `calibrate-skills` to its repos |
 | `sync-api-spec` never runs on calibrate | calibrate#108 not merged, or `repository_dispatch` not wired | Merge docs PR; confirm `sync-api-spec.yml` listens for `sync-api-spec` |
 | `sync-from-spec` never runs on calibrate-skills | `OPENAPI_SPEC_URL` variable unset, or dispatch not reaching the repo | Set the variable on calibrate-skills; confirm `sync-from-spec.yml` listens for `sync-api-spec` |
 | PAT rejected pushing `release.yaml` | Missing `workflow` scope on `PUSH_TO_REPO_TOKEN` | Add `workflow` scope to the backend PAT |

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -89,7 +89,7 @@ The `sync-docs` job runs **after** `publish` completes so the docs workflow sees
 
 `sync-skills` does **not** need its own secret. `PUSH_TO_REPO_TOKEN` is a classic PAT, and classic PATs are not repo-restricted — they can write to any repo their owner can access. Since `dalmia/calibrate-skills` shares the `dalmia/` owner with the client repos the token already pushes to, it can dispatch `repository_dispatch` there too. (Contrast `DOCS_SYNC_REPO_TOKEN`, which must be separate because the docs repo is under a different owner.)
 
-**Only step on the skills side** (not this repo): add the `OPENAPI_SPEC_URL` variable under `dalmia/calibrate-skills` → Settings → Secrets and variables → Actions → Variables, so its drift check can fetch the live spec. Its [`sync-from-spec.yml`](https://github.com/dalmia/calibrate-skills/blob/main/.github/workflows/sync-from-spec.yml) listener is already merged.
+**Nothing to configure on the skills side.** The published spec URL is a public constant baked into [`sync-from-spec.yml`](https://github.com/dalmia/calibrate-skills/blob/main/.github/workflows/sync-from-spec.yml) as its default, so there is no env var to keep in sync between the two repos. The dispatch may pass `client_payload.spec_url` to override it if the host ever moves, but is not required to.
 
 `sync-skills` drift-checks the skills against the published spec (it does not regenerate them — the skills are prose). It runs after `publish` for parity with `sync-docs`, though it only depends on the spec being live.
 
@@ -260,7 +260,7 @@ uv run --group dev pytest tests/test_sdk_overrides.py -q
 | `sync-docs` fails with 401/403 | `DOCS_SYNC_REPO_TOKEN` missing, expired, or lacks Actions write on `ARTPARK-SAHAI-ORG/calibrate` | Regenerate fine-grained PAT; update Production secret |
 | `sync-skills` fails with 401/403 | `PUSH_TO_REPO_TOKEN` expired, or is a fine-grained PAT not scoped to `dalmia/calibrate-skills` | Ensure it is a classic PAT (reaches all `dalmia/` repos); if fine-grained, add `calibrate-skills` to its repos |
 | `sync-api-spec` never runs on calibrate | calibrate#108 not merged, or `repository_dispatch` not wired | Merge docs PR; confirm `sync-api-spec.yml` listens for `sync-api-spec` |
-| `sync-from-spec` never runs on calibrate-skills | `OPENAPI_SPEC_URL` variable unset, or dispatch not reaching the repo | Set the variable on calibrate-skills; confirm `sync-from-spec.yml` listens for `sync-api-spec` |
+| `sync-from-spec` never runs on calibrate-skills | Dispatch not reaching the repo (token/owner), or the listener not wired | Confirm `PUSH_TO_REPO_TOKEN` is a classic PAT; confirm `sync-from-spec.yml` listens for `sync-api-spec` (spec URL needs no config — it defaults to the public constant) |
 | PAT rejected pushing `release.yaml` | Missing `workflow` scope on `PUSH_TO_REPO_TOKEN` | Add `workflow` scope to the backend PAT |
 | PAT rejected pushing to `calibrate-mcp` | PAT not authorized on `dalmia/calibrate-mcp` | Grant `contents:write` on that repo |
 | Release fails: `gpg_private_key` not supplied | GPG secrets missing in **calibrate-cli** | Add `CLI_GPG_SECRET_KEY` + `CLI_GPG_PASSPHRASE` |

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -68,7 +68,7 @@ Add these to **this repo** → Settings → Environments → **Production**:
 
 ### Docs sync token (`DOCS_SYNC_REPO_TOKEN`)
 
-Separate from `PUSH_TO_REPO_TOKEN` because client repos live under **`dalmia/`** (personal) while Mintlify docs live under **`ARTPARK-SAHAI-ORG/calibrate`** (org).
+Separate from `PUSH_TO_REPO_TOKEN` because client repos live under **`dalmia/`** (personal) while the docs repo is **`ARTPARK-SAHAI-ORG/calibrate`** (org).
 
 1. GitHub → **Settings → Developer settings → Fine-grained personal access tokens → Generate**
 2. **Resource owner:** `ARTPARK-SAHAI-ORG`

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -56,16 +56,18 @@ Add these to **this repo** → Settings → Environments → **Production**:
 | `FERN_TOKEN` | Fern Python SDK generate | From [buildwithfern.com](https://buildwithfern.com); Fern GitHub App must be authorized on `dalmia` |
 | `PYPI_TOKEN` | Fern generate (metadata) | Passed to `fern generate`; actual PyPI upload is in `calibrate-python-sdk` CI |
 | `SPEAKEASY_API_KEY` | Speakeasy CLI generate + validate | From [speakeasy.com](https://www.speakeasy.com) |
-| `PUSH_TO_REPO_TOKEN` | CLI/MCP sync + tagging all client repos; skills drift-sync dispatch (`sync-skills` job) | Classic PAT with **`contents:write`** and **`workflow`** on `dalmia/calibrate-python-sdk`, `dalmia/calibrate-cli`, and `dalmia/calibrate-mcp`. **Required for publish workflows to start** (gate check) as well as client-repo pushes. Being a classic PAT it also reaches `dalmia/calibrate-skills` (same owner), so `sync-skills` reuses it — no separate secret. |
-| `DOCS_SYNC_REPO_TOKEN` | Docs OpenAPI sync dispatch (`sync-docs` job) | Fine-grained PAT on [`ARTPARK-SAHAI-ORG/calibrate`](https://github.com/ARTPARK-SAHAI-ORG/calibrate) with **Actions: Read and write** (see below). Separate because the docs repo is a different owner (org), out of the classic PAT's reach. |
+| `PUSH_TO_REPO_TOKEN` | CLI/MCP sync + tagging all client repos; skills drift-sync dispatch (`sync-skills` job) | Fine-grained PAT (resource owner `dalmia`) with **Contents: write** and **Workflows: write** on `dalmia/calibrate-python-sdk`, `dalmia/calibrate-cli`, `dalmia/calibrate-mcp`, and `dalmia/calibrate-skills`. **Required for publish workflows to start** (gate check) and client-repo pushes. `calibrate-skills` is in the repo list so `sync-skills` reuses it — `repository_dispatch` needs Contents: write, already granted. |
+| `DOCS_SYNC_REPO_TOKEN` | Docs OpenAPI sync dispatch (`sync-docs` job) | Fine-grained PAT on [`ARTPARK-SAHAI-ORG/calibrate`](https://github.com/ARTPARK-SAHAI-ORG/calibrate) with **Actions: Read and write** (see below). Separate because a fine-grained PAT is scoped to one resource owner, and this repo is under `ARTPARK-SAHAI-ORG`, not `dalmia`. |
 | `PUBLIC_API_BASE_URL` | Fetch public OpenAPI spec | Production API URL injected into `servers` (e.g. `https://pense-backend.artpark.ai`) |
 
-### PAT scopes (`PUSH_TO_REPO_TOKEN`)
+### PAT permissions (`PUSH_TO_REPO_TOKEN`)
 
-| Scope | Why |
-|-------|-----|
-| `contents:write` | Push CLI/MCP output via `sync-client-repo.sh`; create tags on all client repos |
-| `workflow` | Push Speakeasy-generated `.github/workflows/release.yaml` into `calibrate-cli` on each sync |
+Fine-grained, resource owner `dalmia`, repositories: `calibrate-python-sdk`, `calibrate-cli`, `calibrate-mcp`, `calibrate-skills`.
+
+| Permission | Why |
+|------------|-----|
+| Contents: write | Push CLI/MCP output via `sync-client-repo.sh`; create tags on the client repos; dispatch `sync-api-spec` to `calibrate-skills` |
+| Workflows: write | Push Speakeasy-generated `.github/workflows/release.yaml` into `calibrate-cli` on each sync |
 
 ### Docs sync token (`DOCS_SYNC_REPO_TOKEN`)
 
@@ -87,7 +89,10 @@ The `sync-docs` job runs **after** `publish` completes so the docs workflow sees
 
 ### Skills sync token (reuses `PUSH_TO_REPO_TOKEN`)
 
-`sync-skills` does **not** need its own secret. `PUSH_TO_REPO_TOKEN` is a classic PAT, and classic PATs are not repo-restricted — they can write to any repo their owner can access. Since `dalmia/calibrate-skills` shares the `dalmia/` owner with the client repos the token already pushes to, it can dispatch `repository_dispatch` there too. (Contrast `DOCS_SYNC_REPO_TOKEN`, which must be separate because the docs repo is under a different owner.)
+`sync-skills` does **not** need its own secret. `PUSH_TO_REPO_TOKEN` is a fine-grained PAT owned by `dalmia`, and `dalmia/calibrate-skills` has been **added to its repository list** with **Contents: write** — the permission `repository_dispatch` requires (the token already grants it for pushing to the client repos). So the same token dispatches to the skills repo. (Contrast `DOCS_SYNC_REPO_TOKEN`, which must be separate: a fine-grained PAT is scoped to a single resource owner, and the docs repo is under `ARTPARK-SAHAI-ORG`, not `dalmia`.)
+
+When rotating or regenerating `PUSH_TO_REPO_TOKEN`, keep all three repos —
+`calibrate-python-sdk`, `calibrate-cli`, `calibrate-skills` — in its repository list.
 
 **Nothing to configure on the skills side.** The published spec URL is a public constant baked into [`sync-from-spec.yml`](https://github.com/dalmia/calibrate-skills/blob/main/.github/workflows/sync-from-spec.yml) as its default, so there is no env var to keep in sync between the two repos. The dispatch may pass `client_payload.spec_url` to override it if the host ever moves, but is not required to.
 
@@ -258,11 +263,16 @@ uv run --group dev pytest tests/test_sdk_overrides.py -q
 |---------|--------------|-----|
 | `gh: set the GH_TOKEN environment variable` | `PUSH_TO_REPO_TOKEN` missing/empty in Production | Add PAT to backend Production secrets |
 | `sync-docs` fails with 401/403 | `DOCS_SYNC_REPO_TOKEN` missing, expired, or lacks Actions write on `ARTPARK-SAHAI-ORG/calibrate` | Regenerate fine-grained PAT; update Production secret |
-| `sync-skills` fails with 401/403 | `PUSH_TO_REPO_TOKEN` expired, or is a fine-grained PAT not scoped to `dalmia/calibrate-skills` | Ensure it is a classic PAT (reaches all `dalmia/` repos); if fine-grained, add `calibrate-skills` to its repos |
+| `sync-skills` fails with 401/403 | `PUSH_TO_REPO_TOKEN` expired, or `calibrate-skills` dropped from its repository list | Re-add `calibrate-skills` to the fine-grained PAT with **Contents: write**; refresh the Production secret |
 | `sync-api-spec` never runs on calibrate | calibrate#108 not merged, or `repository_dispatch` not wired | Merge docs PR; confirm `sync-api-spec.yml` listens for `sync-api-spec` |
+<<<<<<< HEAD
 | `sync-from-spec` never runs on calibrate-skills | Dispatch not reaching the repo (token/owner), or the listener not wired | Confirm `PUSH_TO_REPO_TOKEN` is a classic PAT; confirm `sync-from-spec.yml` listens for `sync-api-spec` (spec URL needs no config — it defaults to the public constant) |
 | PAT rejected pushing `release.yaml` | Missing `workflow` scope on `PUSH_TO_REPO_TOKEN` | Add `workflow` scope to the backend PAT |
 | PAT rejected pushing to `calibrate-mcp` | PAT not authorized on `dalmia/calibrate-mcp` | Grant `contents:write` on that repo |
+=======
+| `sync-from-spec` never runs on calibrate-skills | Dispatch not reaching the repo, or the listener not wired | Confirm `calibrate-skills` is in `PUSH_TO_REPO_TOKEN`'s repo list; confirm `sync-from-spec.yml` listens for `sync-api-spec` (spec URL needs no config — it defaults to the public constant) |
+| PAT rejected pushing `release.yaml` | Missing **Workflows: write** on `PUSH_TO_REPO_TOKEN` | Add Workflows: write to the fine-grained PAT |
+>>>>>>> 4a7fee4 (Correct PUSH_TO_REPO_TOKEN as fine-grained with calibrate-skills in its repo list)
 | Release fails: `gpg_private_key` not supplied | GPG secrets missing in **calibrate-cli** | Add `CLI_GPG_SECRET_KEY` + `CLI_GPG_PASSPHRASE` |
 | Release fails: `field token not found in type config.Homebrew` | Speakeasy `.goreleaser.yaml` incompatible with GoReleaser >=2.17 | Merge backend patch (`patch-goreleaser-config.sh`) or move `token` under `repository` in `calibrate-cli`; re-run Release |
 | Homebrew formula never appears | `HOMEBREW_TAP_GITHUB_TOKEN` missing or tap repo missing | Add secret; create `dalmia/homebrew-tap` |


### PR DESCRIPTION
## Summary

When `auto-publish-sdk.yml` detects a public OpenAPI spec change (same gate as SDK/CLI publish), it now fires `repository_dispatch` on `ARTPARK-SAHAI-ORG/calibrate` to run `sync-api-spec.yml`.

Runs in parallel with `publish` — docs don't wait for Fern/Speakeasy.

## Depends on

- [calibrate#108](https://github.com/ARTPARK-SAHAI-ORG/calibrate/pull/108) (or #111) merging — adds `repository_dispatch: types: [sync-api-spec]` to `sync-api-spec.yml` (already pushed to those branches)

## Setup

`PUSH_TO_REPO_TOKEN` must be able to trigger workflows on `ARTPARK-SAHAI-ORG/calibrate` (classic PAT: `repo` scope on that org, or fine-grained with Actions write).

`PUBLIC_API_BASE_URL` must be set as a secret on the **calibrate** repo for the sync job itself.

## Test plan

- [ ] Merge docs PR first
- [ ] Deploy a backend change that alters the public OpenAPI spec
- [ ] Confirm `auto-publish-sdk` → `sync-docs` job succeeds
- [ ] Confirm `sync-api-spec` runs on calibrate and commits updated `openapi.json` if changed