### PR TITLE
Gate SDK auto-publish with SDK_AUTO_PUBLISH_ENABLED secret

### DIFF
--- a/.github/actions/check-publish-gate/action.yml
+++ b/.github/actions/check-publish-gate/action.yml
@@ -1,0 +1,36 @@
+name: Check publish gate
+description: >-
+  Sets publish_enabled when SDK_AUTO_PUBLISH_ENABLED is true and
+  PUSH_TO_REPO_TOKEN is set (Production secrets). Used by auto-publish-sdk.yml
+  and publish-sdk.yml.
+
+inputs:
+  sdk_auto_publish_enabled:
+    description: Value of the SDK_AUTO_PUBLISH_ENABLED Production secret
+    required: false
+    default: ""
+  push_to_repo_token:
+    description: Value of the PUSH_TO_REPO_TOKEN Production secret
+    required: false
+    default: ""
+
+outputs:
+  publish_enabled:
+    description: Whether SDK/CLI publish prerequisites are met
+    value: ${{ steps.check.outputs.publish_enabled }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check publish prerequisites
+      id: check
+      shell: bash
+      env:
+        SDK_AUTO_PUBLISH_ENABLED: ${{ inputs.sdk_auto_publish_enabled }}
+        PUSH_TO_REPO_TOKEN: ${{ inputs.push_to_repo_token }}
+      run: |
+        if [ "$SDK_AUTO_PUBLISH_ENABLED" = "true" ] && [ -n "$PUSH_TO_REPO_TOKEN" ]; then
+          echo "publish_enabled=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "publish_enabled=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -2,7 +2,7 @@ name: Auto-publish SDK and CLI
 
 # After a successful production deploy, publishes clients when the public OpenAPI
 # spec changed. Manual dispatch can force a publish or pin a version.
-# Only runs on the canonical upstream repo (not forks / self-hosted copies).
+# Gated by SDK_AUTO_PUBLISH_ENABLED (Production secret) — not set on forks/self-hosts.
 # Setup: SETUP_SDK.md
 on:
   workflow_run:
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   detect:
     if: >-
-      github.repository == 'ARTPARK-SAHAI-ORG/calibrate-backend' &&
+      secrets.SDK_AUTO_PUBLISH_ENABLED == 'true' &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -2,7 +2,7 @@ name: Auto-publish SDK and CLI
 
 # After a successful production deploy, publishes clients when the public OpenAPI
 # spec changed. Manual dispatch can force a publish or pin a version.
-# Gated by SDK_AUTO_PUBLISH_ENABLED (Production secret) — not set on forks/self-hosts.
+# Gated by Production secrets (SDK_AUTO_PUBLISH_ENABLED + PUSH_TO_REPO_TOKEN).
 # Setup: SETUP_SDK.md
 on:
   workflow_run:
@@ -26,6 +26,7 @@ jobs:
   detect:
     if: >-
       secrets.SDK_AUTO_PUBLISH_ENABLED == 'true' &&
+      secrets.PUSH_TO_REPO_TOKEN != '' &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -30,19 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     outputs:
-      publish_enabled: ${{ steps.check.outputs.publish_enabled }}
+      publish_enabled: ${{ steps.gate.outputs.publish_enabled }}
     steps:
-      - name: Check publish prerequisites
-        id: check
-        env:
-          SDK_AUTO_PUBLISH_ENABLED: ${{ secrets.SDK_AUTO_PUBLISH_ENABLED }}
-          PUSH_TO_REPO_TOKEN: ${{ secrets.PUSH_TO_REPO_TOKEN }}
-        run: |
-          if [ "$SDK_AUTO_PUBLISH_ENABLED" = "true" ] && [ -n "$PUSH_TO_REPO_TOKEN" ]; then
-            echo "publish_enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish_enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+      - uses: ./.github/actions/check-publish-gate
+        id: gate
+        with:
+          sdk_auto_publish_enabled: ${{ secrets.SDK_AUTO_PUBLISH_ENABLED }}
+          push_to_repo_token: ${{ secrets.PUSH_TO_REPO_TOKEN }}
 
   detect:
     needs: gate

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -2,6 +2,7 @@ name: Auto-publish SDK and CLI
 
 # After a successful production deploy, publishes clients when the public OpenAPI
 # spec changed. Manual dispatch can force a publish or pin a version.
+# Only runs on the canonical upstream repo (not forks / self-hosted copies).
 # Setup: SETUP_SDK.md
 on:
   workflow_run:
@@ -24,8 +25,9 @@ concurrency:
 jobs:
   detect:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      github.repository == 'ARTPARK-SAHAI-ORG/calibrate-backend' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     environment: Production
     outputs:

--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -23,12 +23,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  detect:
+  gate:
     if: >-
-      secrets.SDK_AUTO_PUBLISH_ENABLED == 'true' &&
-      secrets.PUSH_TO_REPO_TOKEN != '' &&
-      (github.event_name == 'workflow_dispatch' ||
-       github.event.workflow_run.conclusion == 'success')
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment: Production
+    outputs:
+      publish_enabled: ${{ steps.check.outputs.publish_enabled }}
+    steps:
+      - name: Check publish prerequisites
+        id: check
+        env:
+          SDK_AUTO_PUBLISH_ENABLED: ${{ secrets.SDK_AUTO_PUBLISH_ENABLED }}
+          PUSH_TO_REPO_TOKEN: ${{ secrets.PUSH_TO_REPO_TOKEN }}
+        run: |
+          if [ "$SDK_AUTO_PUBLISH_ENABLED" = "true" ] && [ -n "$PUSH_TO_REPO_TOKEN" ]; then
+            echo "publish_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  detect:
+    needs: gate
+    if: needs.gate.outputs.publish_enabled == 'true'
     runs-on: ubuntu-latest
     environment: Production
     outputs:

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -6,7 +6,7 @@ name: Publish SDK and CLI
 # Setup: SETUP_SDK.md
 #
 # Trigger: workflow_call (from auto-publish-sdk.yml), or workflow_dispatch.
-# Only runs on the canonical upstream repo (not forks / self-hosted copies).
+# Gated by SDK_AUTO_PUBLISH_ENABLED (Production secret) — not set on forks/self-hosts.
 on:
   workflow_dispatch:
     inputs:
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   prepare:
-    if: github.repository == 'ARTPARK-SAHAI-ORG/calibrate-backend'
+    if: secrets.SDK_AUTO_PUBLISH_ENABLED == 'true'
     runs-on: ubuntu-latest
     environment: Production
     outputs:

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -6,6 +6,7 @@ name: Publish SDK and CLI
 # Setup: SETUP_SDK.md
 #
 # Trigger: workflow_call (from auto-publish-sdk.yml), or workflow_dispatch.
+# Only runs on the canonical upstream repo (not forks / self-hosted copies).
 on:
   workflow_dispatch:
     inputs:
@@ -28,6 +29,7 @@ permissions:
 
 jobs:
   prepare:
+    if: github.repository == 'ARTPARK-SAHAI-ORG/calibrate-backend'
     runs-on: ubuntu-latest
     environment: Production
     outputs:

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -28,10 +28,27 @@ permissions:
   contents: read
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: Production
+    outputs:
+      publish_enabled: ${{ steps.check.outputs.publish_enabled }}
+    steps:
+      - name: Check publish prerequisites
+        id: check
+        env:
+          SDK_AUTO_PUBLISH_ENABLED: ${{ secrets.SDK_AUTO_PUBLISH_ENABLED }}
+          PUSH_TO_REPO_TOKEN: ${{ secrets.PUSH_TO_REPO_TOKEN }}
+        run: |
+          if [ "$SDK_AUTO_PUBLISH_ENABLED" = "true" ] && [ -n "$PUSH_TO_REPO_TOKEN" ]; then
+            echo "publish_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
   prepare:
-    if: >-
-      secrets.SDK_AUTO_PUBLISH_ENABLED == 'true' &&
-      secrets.PUSH_TO_REPO_TOKEN != ''
+    needs: gate
+    if: needs.gate.outputs.publish_enabled == 'true'
     runs-on: ubuntu-latest
     environment: Production
     outputs:

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -32,19 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     outputs:
-      publish_enabled: ${{ steps.check.outputs.publish_enabled }}
+      publish_enabled: ${{ steps.gate.outputs.publish_enabled }}
     steps:
-      - name: Check publish prerequisites
-        id: check
-        env:
-          SDK_AUTO_PUBLISH_ENABLED: ${{ secrets.SDK_AUTO_PUBLISH_ENABLED }}
-          PUSH_TO_REPO_TOKEN: ${{ secrets.PUSH_TO_REPO_TOKEN }}
-        run: |
-          if [ "$SDK_AUTO_PUBLISH_ENABLED" = "true" ] && [ -n "$PUSH_TO_REPO_TOKEN" ]; then
-            echo "publish_enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish_enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+      - uses: ./.github/actions/check-publish-gate
+        id: gate
+        with:
+          sdk_auto_publish_enabled: ${{ secrets.SDK_AUTO_PUBLISH_ENABLED }}
+          push_to_repo_token: ${{ secrets.PUSH_TO_REPO_TOKEN }}
 
   prepare:
     needs: gate

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -6,7 +6,7 @@ name: Publish SDK and CLI
 # Setup: SETUP_SDK.md
 #
 # Trigger: workflow_call (from auto-publish-sdk.yml), or workflow_dispatch.
-# Gated by SDK_AUTO_PUBLISH_ENABLED (Production secret) — not set on forks/self-hosts.
+# Gated by Production secrets (SDK_AUTO_PUBLISH_ENABLED + PUSH_TO_REPO_TOKEN).
 on:
   workflow_dispatch:
     inputs:
@@ -29,7 +29,9 @@ permissions:
 
 jobs:
   prepare:
-    if: secrets.SDK_AUTO_PUBLISH_ENABLED == 'true'
+    if: >-
+      secrets.SDK_AUTO_PUBLISH_ENABLED == 'true' &&
+      secrets.PUSH_TO_REPO_TOKEN != ''
     runs-on: ubuntu-latest
     environment: Production
     outputs:

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -42,6 +42,7 @@ Add these to **this repo** → Settings → Environments → **Production**:
 
 | Secret | Used by | Notes |
 |--------|---------|-------|
+| `SDK_AUTO_PUBLISH_ENABLED` | `auto-publish-sdk.yml`, `publish-sdk.yml` | Set to **`true`** only on the canonical upstream repo (Production). **Do not set on forks or self-hosted copies** — workflows skip when absent. Editing workflow YAML cannot bypass this without also adding the secret. Prefer an **org secret** shared only with this repo so forks never inherit it. |
 | `FERN_TOKEN` | Fern Python SDK generate | From [buildwithfern.com](https://buildwithfern.com); Fern GitHub App must be authorized on `dalmia` |
 | `PYPI_TOKEN` | Fern generate (metadata) | Passed to `fern generate`; actual PyPI upload is in `calibrate-python-sdk` CI |
 | `SPEAKEASY_API_KEY` | Speakeasy CLI generate + validate | From [speakeasy.com](https://www.speakeasy.com) |

--- a/SETUP_SDK.md
+++ b/SETUP_SDK.md
@@ -42,11 +42,11 @@ Add these to **this repo** → Settings → Environments → **Production**:
 
 | Secret | Used by | Notes |
 |--------|---------|-------|
-| `SDK_AUTO_PUBLISH_ENABLED` | `auto-publish-sdk.yml`, `publish-sdk.yml` | Set to **`true`** only on the canonical upstream repo (Production). **Do not set on forks or self-hosted copies** — workflows skip when absent. Editing workflow YAML cannot bypass this without also adding the secret. Prefer an **org secret** shared only with this repo so forks never inherit it. |
+| `SDK_AUTO_PUBLISH_ENABLED` | `auto-publish-sdk.yml`, `publish-sdk.yml` | Set to **`true`** only on the canonical upstream repo (Production). **Do not set on forks or self-hosted copies** — workflows skip when absent. Both this and `PUSH_TO_REPO_TOKEN` must be set for publish to run. |
 | `FERN_TOKEN` | Fern Python SDK generate | From [buildwithfern.com](https://buildwithfern.com); Fern GitHub App must be authorized on `dalmia` |
 | `PYPI_TOKEN` | Fern generate (metadata) | Passed to `fern generate`; actual PyPI upload is in `calibrate-python-sdk` CI |
 | `SPEAKEASY_API_KEY` | Speakeasy CLI generate + validate | From [speakeasy.com](https://www.speakeasy.com) |
-| `PUSH_TO_REPO_TOKEN` | CLI sync + tagging both client repos | Classic PAT with **`contents:write`** and **`workflow`** on `dalmia/calibrate-python-sdk` and `dalmia/calibrate-cli` |
+| `PUSH_TO_REPO_TOKEN` | CLI sync + tagging both client repos | Classic PAT with **`contents:write`** and **`workflow`** on `dalmia/calibrate-python-sdk` and `dalmia/calibrate-cli`. **Required for publish workflows to start** (gate check) as well as client-repo pushes. |
 | `PUBLIC_API_BASE_URL` | Fetch public OpenAPI spec | Production API URL injected into `servers` (e.g. `https://pense-backend.artpark.ai`) |
 
 ### PAT scopes (`PUSH_TO_REPO_TOKEN`)


### PR DESCRIPTION
## Summary
- Gate `auto-publish-sdk.yml` and `publish-sdk.yml` on a `SDK_AUTO_PUBLISH_ENABLED=true` Production secret instead of a hardcoded `github.repository` check (trivial to edit in self-hosted copies).
- Document the secret in `SETUP_SDK.md`; recommend an org-level secret scoped only to the canonical repo so forks never inherit it.

## Test plan
- [ ] Add `SDK_AUTO_PUBLISH_ENABLED=true` to Production secrets on the canonical repo
- [ ] Manual dispatch **Auto-publish SDK and CLI** — detect job runs
- [ ] Remove/unset the secret (or test on a fork without it) — jobs are skipped
- [ ] Confirm editing workflow YAML alone does not enable publish without the secret