### PR TITLE
Check out repo in gate job before using local action

### DIFF
--- a/.github/workflows/auto-publish-sdk.yml
+++ b/.github/workflows/auto-publish-sdk.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       publish_enabled: ${{ steps.gate.outputs.publish_enabled }}
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/check-publish-gate
         id: gate
         with:


### PR DESCRIPTION
## Summary
- The `gate` job in `auto-publish-sdk.yml` used the local composite action `./.github/actions/check-publish-gate` without first running `actions/checkout`, leaving the runner workspace empty so the action file couldn't be found (the failure in the Auto-publish run).
- Added `actions/checkout@v4` as the first step of `gate`, matching the `detect` job which already checks out before using its local action.

## Test plan
- [ ] Re-run the **Auto-publish SDK and CLI** workflow (or `workflow_dispatch`) and confirm the `gate` job passes instead of erroring with "Can't find 'action.yml' … under .github/actions/check-publish-gate".