### PR TITLE
Rename CLI env var prefix CLI_ -> CALIBRATE_ for self-hosting

### DIFF
--- a/.github/scripts/patch-cli-auth-commands.sh
+++ b/.github/scripts/patch-cli-auth-commands.sh
@@ -123,7 +123,7 @@ if "whoamiCmd.Hidden = true" not in auth_text:
         r"\t\tLong: `Display the currently configured settings and their sources\.\n\n"
         r"Sources are shown as:\n"
         r"  \[flag\]    - Set via command line flag\n"
-        r"  \[env\]     - Set via environment variable \(CLI_\*\)\n"
+        r"  \[env\]     - Set via environment variable \(CALIBRATE_\*\)\n"
         r"  \[keyring\] - Set via OS keychain \(stored by login/configure command\)\n"
         r"  \[config\]  - Set via config file \(~/.config/calibrate/config\.yaml\)\n"
         r"  \[unset\]   - Not configured\n\n"
@@ -137,7 +137,7 @@ if "whoamiCmd.Hidden = true" not in auth_text:
 
 Sources are shown as:
   [flag]    - Set via command line flag
-  [env]     - Set via environment variable (CLI_*)
+  [env]     - Set via environment variable (CALIBRATE_*)
   [keyring] - Set via OS keychain (stored by login/configure command)
   [config]  - Set via config file (~/.config/calibrate/config.yaml)
   [unset]   - Not configured

--- a/.speakeasy/out/cli/.speakeasy/gen.yaml
+++ b/.speakeasy/out/cli/.speakeasy/gen.yaml
@@ -52,7 +52,7 @@ cli:
       publisherUrl: ""
       repositoryOwner: ""
   enableCustomCodeRegions: false
-  envVarPrefix: CLI
+  envVarPrefix: CALIBRATE
   generateRelease: true
   imports:
     option: openapi


### PR DESCRIPTION
## Summary

- Flip `envVarPrefix` in the Speakeasy CLI `gen.yaml` from `CLI` to `CALIBRATE`, so the next publish generates `CALIBRATE_SERVER_URL` / `CALIBRATE_API_KEY` / `CALIBRATE_BEARER_TOKEN` / `CALIBRATE_TIMEOUT` instead of the generic `CLI_*` names.
- Update `patch-cli-auth-commands.sh` accordingly: its regex must **match** Speakeasy's generated `whoami` help text, which now reads `(CALIBRATE_*)`, so both the match pattern and the replacement string are updated (otherwise the patch silently skips hiding the command).

## Why

Self-hosted deployments need to point the generated Calibrate CLI at their own API host. The CLI already supports this three ways (highest precedence first):

1. `--server-url` flag
2. `CALIBRATE_SERVER_URL` env var
3. persistent `~/.config/calibrate/config.yaml` via `calibrate configure`

...falling back to the spec's `servers[0].url` (baked from `PUBLIC_API_BASE_URL` at publish). The only rough edge was the generic `CLI_*` prefix — unclear and collision-prone in a user's shell/CI. This makes the env vars self-documenting.

No breaking-change concern (client is not yet in real use). The generated Go tree is gitignored, so this takes effect on the next Speakeasy publish; nothing regenerates locally.

## Test plan

- [ ] Next CLI publish emits `CALIBRATE_*` env vars (verify generated `whoami` help + flag env bindings).
- [ ] `patch-cli-auth-commands.sh` still applies cleanly (no `::warning::` about failing to hide `whoami`) against the regenerated source.