### PR TITLE
ci: skip redundant publish gate on auto-publish path

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -28,7 +28,11 @@ permissions:
   contents: read
 
 jobs:
+  # Only gate on the manual dispatch path. When invoked via workflow_call
+  # (from auto-publish-sdk.yml), the caller's gate has already run — no need
+  # to re-check the same secrets.
   gate:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: Production
     outputs:
@@ -44,7 +48,9 @@ jobs:
 
   prepare:
     needs: gate
-    if: needs.gate.outputs.publish_enabled == 'yes'
+    if: >-
+      always() &&
+      (needs.gate.result == 'skipped' || needs.gate.outputs.publish_enabled == 'yes')
     runs-on: ubuntu-latest
     environment: Production
     outputs:


### PR DESCRIPTION
## Summary
- `publish-sdk.yml` started with a `gate` job running `check-publish-gate`, but `auto-publish-sdk.yml` already runs the same gate before calling it via `workflow_call` — so the auto path gated twice against the same secrets.
- The inner gate now only runs on the manual `workflow_dispatch` path (in a reusable workflow, `github.event_name` reflects the caller's trigger, so it's `workflow_run` on the auto path and the gate is skipped).
- `prepare` now proceeds when the gate was skipped (auto path, already gated) or passed (manual path). `always()` is required so a skipped `needs` doesn't cascade-skip `prepare`.

Net effect: auto path gates once; manual dispatch of `publish-sdk.yml` still gets its gate. Downstream jobs depend on `prepare`, not `gate`, so nothing else changes.

## Test plan
- [ ] Trigger a Production deploy and confirm `auto-publish-sdk.yml` → `publish-sdk.yml` runs with the inner `gate` skipped and `prepare` proceeding.
- [ ] Manually dispatch `publish-sdk.yml` and confirm the `gate` still runs and blocks when secrets are unset.