### PR TITLE
Fix validate-sdk CI for fork PRs

### DIFF
--- a/.github/scripts/fetch-public-openapi.sh
+++ b/.github/scripts/fetch-public-openapi.sh
@@ -16,6 +16,10 @@ export MAX_CONCURRENT_JOBS="${MAX_CONCURRENT_JOBS:-1}"
 export MAX_CONCURRENT_JOBS_PER_ORG="${MAX_CONCURRENT_JOBS_PER_ORG:-1}"
 export DEFAULT_MAX_ROWS_PER_EVAL="${DEFAULT_MAX_ROWS_PER_EVAL:-20}"
 export SUPERADMIN_EMAIL="${SUPERADMIN_EMAIL:-admin@example.com}"
+# Empty string counts as set for os.getenv — default so servers.url is never blank.
+if [ -z "${PUBLIC_API_BASE_URL:-}" ]; then
+  export PUBLIC_API_BASE_URL="http://localhost:8000"
+fi
 
 (cd src && uv run uvicorn main:app --port 8000 --log-level warning &)
 for _ in $(seq 1 30); do

--- a/.github/workflows/validate-sdk.yml
+++ b/.github/workflows/validate-sdk.yml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/fetch-public-spec
+        env:
+          PUBLIC_API_BASE_URL: http://localhost:8000
 
       - name: Install Fern
         run: npm install -g fern-api

--- a/.github/workflows/validate-sdk.yml
+++ b/.github/workflows/validate-sdk.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Install Speakeasy CLI
         run: curl -fsSL https://go.speakeasy.com/cli-install.sh | sh
 
-      # --skip-upload-spec: compile overlay locally only; no registry auth needed.
-      # Fork PRs do not receive repo secrets (SPEAKEASY_API_KEY), so this must stay offline.
+      # overlay apply: offline merge only. speakeasy run still requires auth in CI
+      # even with --skip-upload-spec; fork PRs also do not receive repo secrets.
       - name: Compile public OpenAPI source (merge spec + overlay)
-        run: speakeasy run -s calibrate-public-api -y --skip-upload-spec
+        run: speakeasy overlay apply -s openapi/openapi.json -o openapi/overlay.yaml --out openapi/compiled.yaml
 
       - name: Lint compiled OpenAPI document
         run: speakeasy lint openapi -s openapi/compiled.yaml

--- a/.github/workflows/validate-sdk.yml
+++ b/.github/workflows/validate-sdk.yml
@@ -26,13 +26,10 @@ permissions:
 jobs:
   validate-clients:
     runs-on: ubuntu-latest
-    environment: Production
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/fetch-public-spec
-        env:
-          PUBLIC_API_BASE_URL: ${{ secrets.PUBLIC_API_BASE_URL }}
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -43,10 +40,10 @@ jobs:
       - name: Install Speakeasy CLI
         run: curl -fsSL https://go.speakeasy.com/cli-install.sh | sh
 
+      # --skip-upload-spec: compile overlay locally only; no registry auth needed.
+      # Fork PRs do not receive repo secrets (SPEAKEASY_API_KEY), so this must stay offline.
       - name: Compile public OpenAPI source (merge spec + overlay)
-        env:
-          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
-        run: speakeasy run -s calibrate-public-api -y
+        run: speakeasy run -s calibrate-public-api -y --skip-upload-spec
 
       - name: Lint compiled OpenAPI document
         run: speakeasy lint openapi -s openapi/compiled.yaml


### PR DESCRIPTION
## Summary
- Fork PRs do not receive repository secrets, so **Validate SDK config** failed when `speakeasy run` required `SPEAKEASY_API_KEY` to upload the compiled spec to the Speakeasy registry.
- Replace `speakeasy run` with offline `speakeasy overlay apply` for the compile step. `--skip-upload-spec` alone still required auth in CI, so overlay apply is the fork-safe path.
- Drop the `Production` environment and `SPEAKEASY_API_KEY` from this workflow — validation only needs local merge + lint, not registry upload.
- Set `PUBLIC_API_BASE_URL: http://localhost:8000` on `fetch-public-spec`. This workflow boots the app on the runner and fetches from localhost; the production secret is unnecessary here. An empty secret also bypassed Python's `os.getenv` default and produced a blank `servers.url`, which failed Speakeasy lint.
- Harden `fetch-public-openapi.sh` to default `PUBLIC_API_BASE_URL` to localhost when unset or empty (belt-and-suspenders for any caller without the secret).

`publish-sdk.yml` is unchanged — real SDK/CLI generation still uses `SPEAKEASY_API_KEY` and the production `PUBLIC_API_BASE_URL` on trusted workflows only.

## Test plan
- [x] Internal PR (`fix/validate-sdk-fork-prs`) — **Validate SDK config** passes
- [ ] Fork PR that touches `openapi/overlay.yaml` or `.speakeasy/**` — confirm the same workflow passes
- [x] `publish-sdk.yml` still uses `SPEAKEASY_API_KEY` for client generation (unchanged)