### PR TITLE
Overhaul public API docs for clarity and consistency

### DIFF
--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -366,6 +366,48 @@ class TestUpdate(BaseModel):
     )
 ```
 
+### Divergence: context-appropriate vs. a real defect
+
+The same field appearing on create/update/response/bulk models **should** read
+differently when the context differs — that is NOT an inconsistency to "fix":
+
+- **Input-to-set vs. current-state.** `config` on Update means "the config you're
+  writing"; on Response it means "the config as it is now". `"New config for the
+  test. Omit to leave unchanged"` (update) vs `"Config for the test (…)"`
+  (response) is correct and intended.
+- **Update fields** say `"New <thing>. Omit to leave unchanged"` (not
+  "Replacement" — plainer, and matches the codebase's own update wording).
+- **Create fields** may carry extra input-only behavior (deep-merge rules,
+  `agent_url` requirement) that the response gloss omits.
+
+Only two things count as a defect worth consolidating:
+
+1. **Degraded/divergent gloss of the same *meaning*.** An enum's value-meaning
+   explained richly on one model and tersely (or re-listed) on another — e.g. the
+   agent `type` enum glossed five different ways across `AgentResponse` models.
+   The value's meaning must read the same wherever it's explained; factor it into
+   a shared constant (or, across files, one string used verbatim).
+2. **Factual mismatch with enforced behavior.** A description that contradicts or
+   under-states what the code actually enforces — e.g. bulk test `name` said
+   "unique within the batch" but the handler also rejects workspace-wide
+   collisions. Read the validator/DB guard before trusting a scoping claim.
+
+Do NOT mass-normalize create/update/response into one template — that erases the
+legitimate context differences above. Audit for the two defect classes only.
+
+### Describe the field, don't editorialize
+
+State what the field is. Don't append unsolicited advice, opinions, or asides
+about how the system *should* be used or where other things *ought* to live.
+
+```
+BAD:  "Message author role. The agent's system prompt lives in its config, not here"
+GOOD: "Message author role in the conversation history"
+```
+
+If a value is genuinely invalid as input, enforce it in the type (narrow the
+`Literal`), don't lecture about it in the description.
+
 ### Don't repeat the unit that's already in the field name
 
 `latency_ms`/`total_tokens`/`cost_usd` already carry the unit. Never write

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -282,7 +282,14 @@ rewrite it to state purpose instead.
 The public spec is consumed by Mintlify, which renders each field as a **name +
 type chip** (`number | null`, `object`, `object[]`) followed by the description as
 markdown. Write for that surface. Every rule below came from real reader
-complaints — treat them as hard bans, not preferences.
+complaints, so treat them as hard bans, not preferences.
+
+**CI-enforced** ([scripts/check_api_docs_style.py](../../../scripts/check_api_docs_style.py)):
+em-dashes, clause-splitting semicolons, and unit abbreviations repeating a
+field-name suffix (`_ms` → bare "ms") all fail the build. The rest below
+(null-caveat trimming, plain phrasing, "say what it's for") are **judgment
+calls** — too context-dependent to machine-check without false positives (many
+`Null until done`-style caveats are legitimate), so they're on you and review.
 
 ### Say only what the reader needs
 

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -26,8 +26,10 @@ internal implementation).
    fields say what omitting them means. Format/length lives in the schema
    (`min_length`/`max_length`, `examples`) on body/response models — not in prose.
 4. **Be concise. Prefer clarity over completeness.** No filler ("This endpoint
-   allows you to..."). Say the thing. Use markdown (`**bold**`, backticks) only
-   when it earns its place.
+   allows you to..."). Say the thing. Cut what the type chip already conveys
+   (nullability, type) and anything the reader can't act on (internal run modes,
+   provider flags, migration asides). No em-dashes, no semicolons, no unit that
+   just echoes the field name (`latency_ms`). See **Brevity & mechanics**.
 5. **Stay consistent across the whole surface.** Same verbs, same phrasings, same
    param names for the same concepts everywhere (see the vocabulary below).
 
@@ -37,9 +39,11 @@ These routes feed the auto-generated SDK/CLI (`GET /public-api/openapi.json`).
 Hold them to the strictest interpretation of every rule below. Do not add or
 remove the `Public API` tag as part of a docs-only pass.
 
-**Current public routes** (as of this skill): `GET /agents`, `POST /agents/resolve`,
-`POST /agent-tests/agent/{agent_uuid}/run`, `POST /agent-tests/run`,
-`GET /agent-tests/run/{task_id}`.
+**Current public routes** (keep in sync with CLAUDE.md): `GET /agents`, `POST /agents`,
+`GET /agents/{agent_uuid}`, `PUT /agents/{agent_uuid}`, `POST /agents/resolve`,
+`POST /tests`, `GET /tests`, `GET /tests/{test_uuid}`, `PUT /tests/{test_uuid}`,
+`POST /tests/bulk`, `POST /agent-tests/agent/{agent_uuid}/run`,
+`POST /agent-tests/run`, `GET /agent-tests/run/{task_id}`.
 
 ### Endpoint heading (summary + docstring)
 
@@ -126,6 +130,8 @@ models** must match. Never invent `a1b2c3d4`-style placeholders.
 - [ ] Path params — purpose-first `description` + real UUID `examples`; no length constraints
 - [ ] Request fields — what it is + what omitting it does
 - [ ] Response fields — what each value means; error/shape detail here, not in heading
+- [ ] No null caveats / repeated units / em-dashes / internal concepts in any description
+- [ ] Known-shape fields typed as a model (expandable), not `Dict[str, Any]`
 - [ ] Dedicated `response_model` — no cross-domain fields leaking in
 - [ ] Second person ("your workspace"), workspace not org, ID not UUID, API key not sk_/secret
 - [ ] Load-bearing context in `# code comment`, not docstring
@@ -217,12 +223,15 @@ class AgentCreate(BaseModel):
 ```
 
 Field conventions:
-- **Lead with what the thing is and what it's for** — not its format
+- **Lead with what the thing is and what it's for**, not its format
 - Ownership/scoping in a second sentence when relevant (`Must be in your workspace.`)
 - `min_length=36`/`max_length=36` + `examples` on **body/response models only**
 - Mark conditional requirements in **bold**: `**Required for type=connection.**`
-- **Never re-list an enum's own values in its description** (see next section)
-- Response fields (`task_id`, `status`, `uuid`) get purpose-first descriptions — they surface in the SDK
+- **Never re-list an enum's own values in its description** (see enum section)
+- **No null caveats, no repeated units, no em-dashes, no internal concepts** (see
+  Brevity & mechanics) — the type chip already shows nullability and type
+- **Known shape ⇒ a Pydantic model, not `Dict[str, Any]`** (see Model the shape)
+- Response fields (`task_id`, `status`, `uuid`) get purpose-first descriptions; they surface in the SDK
 
 ## Enums / `Literal` — never re-list the values
 
@@ -268,6 +277,111 @@ a route, watch for any enum/`Literal` field or param whose description contains 
 run of ≥2 of that type's own backticked values separated only by connectors, and
 rewrite it to state purpose instead.
 
+## Brevity & mechanics (the docs render in Mintlify)
+
+The public spec is consumed by Mintlify, which renders each field as a **name +
+type chip** (`number | null`, `object`, `object[]`) followed by the description as
+markdown. Write for that surface. Every rule below came from real reader
+complaints — treat them as hard bans, not preferences.
+
+### Say only what the reader needs
+
+Cut anything the type chip, the field name, or the reader's common sense already
+conveys. A description is not a changelog or an implementation note.
+
+- **The `| null` / `| null`-array chip already says the field can be null.** Do
+  **not** append "Null when X", "Null until done", "Null for eval-only runs",
+  "`null` unless…". Drop the null caveat entirely unless the *condition* is both
+  publicly reachable and non-obvious — and even then keep it to a few words. Edge
+  cases the public API can't even trigger (internal run modes, provider-specific
+  flags) must never appear.
+- **A field that's meaningful only for a subset: say what it's *for*, not what
+  happens otherwise.** `match` → "Pass/fail verdict, for binary evaluators".
+  `score` → "Numeric score, for rating evaluators". Not "…else null, `score` is
+  set instead".
+- **No internal/undocumented concepts.** Never reference things that appear
+  nowhere else in the public docs: calibrate internals ("lifted from calibrate's
+  nested `output.cost`"), run modes ("eval-only"), migration asides ("`p50` ≈ the
+  old mean"), provider flags (`--provider openai`), or denormalization rationale
+  ("so the rubric isn't duplicated per case").
+
+```python
+# BAD — caveats the chip implies, internal concepts, migration trivia
+latency_ms: Optional[Dict[str, Any]] = Field(None, description="Aggregated latency `{p50, p95, p99, count}` (ms; `p50` ≈ the old mean). Null for eval-only runs")
+cost: Optional[float] = Field(None, description="Per-case cost in USD, lifted from calibrate's nested `output.cost`. Null when the provider/agent reports none (e.g. `--provider openai`)")
+
+# GOOD — the shape, the unit, done
+latency_ms: Optional[Dict[str, Any]] = Field(None, description="Aggregated response latency in milliseconds: `{p50, p95, p99, count}`")
+cost: Optional[float] = Field(None, description="Cost of this case in USD")
+```
+
+### Don't repeat the unit that's already in the field name
+
+`latency_ms`/`total_tokens`/`cost_usd` already carry the unit. Never write
+"latency in ms" or "(ms)". If a unit genuinely aids reading, spell it **once** in
+words ("in milliseconds", "in USD") — never the abbreviation echoing the suffix.
+
+### No em-dashes. Ever.
+
+Use a period, comma, colon, or parentheses instead. `—` is banned in every
+rendered doc string (field/param `description`, `summary`, endpoint docstrings,
+and markdown-list glosses). Code comments are exempt (they don't render).
+
+```
+BAD:  "Token scheme — always `bearer`"          GOOD: "Always `bearer`"
+BAD:  "**Immutable** — may only echo the value"  GOOD: "**Immutable.** May only echo the value"
+BAD:  "- `response` — judges the reply"          GOOD: "- `response`: judges the reply"
+```
+
+### Prefer semicolon-free, plain phrasing
+
+- **Full stops, not semicolons**, to join two clauses. "X. Null until done", not
+  "X; null until done".
+- **Plain over compressed jargon.** "Results for each test case", not
+  "Per-test-case results". "One verdict per evaluator", not "Per-evaluator
+  verdicts". "Aggregate summary per evaluator", not "Per-evaluator aggregate
+  summary".
+
+### Markdown lists render — use them for per-value glosses
+
+When a field's values each need a gloss, a bullet list reads far better than a
+run-on sentence (and satisfies the "gloss, don't re-list" rule):
+
+```python
+type: TestType = Field(
+    description=(
+        "What the test judges:\n\n"
+        "- `response`: judges the generated reply\n"
+        "- `tool_call`: diffs the generated tool calls\n"
+        "- `conversation`: judges the full conversation"
+    )
+)
+```
+
+## Model the shape — don't ship free-form `Dict[str, Any]`
+
+How a field is **typed** drives how Mintlify renders it. This is a docs decision,
+not just a code one.
+
+- **A field with a known, stable shape must be a Pydantic model, not
+  `Dict[str, Any]`.** A free-form dict renders as a shapeless `object`/`object[]`
+  chip with **no expandable child attributes** and a **misleading auto-title**:
+  Pydantic title-cases the field name (`config` → `Config`, `evaluators` →
+  `Evaluators`), which Mintlify shows as a fake type chip (`Config · object`) that
+  looks like a named type but expands to nothing. Define a model (e.g.
+  `RunEvaluator`) so the docs show "Show child attributes" with each field
+  documented.
+- **Genuinely free-form blobs** (a passthrough `config` stored as-is, with no
+  fixed keys) are the *only* legitimate `Dict[str, Any]`. Their auto-title is
+  stripped from the public spec by `_strip_freeform_titles()` in
+  [main.py](../../../src/main.py) so they render as plain `object`, not a fake
+  type. Don't fight this — if there's no fixed shape, there's nothing to expand,
+  and the description should just say what the blob holds.
+- **`Name · object[]` on a *modeled* array is Mintlify's normal rendering**, not a
+  defect — it prints the model name plus the base JSON type. You cannot suppress
+  the `object[]` half from the backend without losing the model name (worse). Do
+  not try.
+
 ## Terminology (user-facing docs)
 
 | Say | Never (in prose) | Exempt (code identifiers) |
@@ -297,5 +411,8 @@ rewrite it to state purpose instead.
 - [ ] Every request/response model field has `Field(description=...)`
 - [ ] No enum/`Literal` field re-lists its own values in the description (state purpose; narrow the type for lifecycle subsets)
 - [ ] Optional fields explain what omission does
+- [ ] No em-dashes; full stops not semicolons; plain phrasing (not "Per-X …")
+- [ ] No null caveats (chip shows it), no unit repeating the field name, no internal concepts
+- [ ] Known-shape fields modeled (expandable), not free-form `Dict[str, Any]`
 - [ ] No UUID/sk_/org/caller in prose; second person throughout
 - [ ] No path/method/name/tags change (response_model change OK when dedicating a shape)

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -13,6 +13,15 @@ public SDK — a short imperative title, one crisp sentence of intent, and every
 variable described by **what it is and what it's for** (not its wire format or
 internal implementation).
 
+## Generalize every fix (do this without being asked)
+
+A flagged bad description is a **class, not an instance**. When you fix one, in the
+same pass: (1) name the abstract rule, (2) `grep` all `src/routers/*.py` for other
+violations, (3) fix them all, (4) encode the rule below — and in
+[check_api_docs_style.py](../../../scripts/check_api_docs_style.py) if it's
+mechanical. Fixing only the screenshotted instance is a failure; the same
+complaint will recur on the next endpoint.
+
 ## The five rules
 
 1. **Give every route an explicit `summary`.** Short, imperative, sentence-case,

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -51,10 +51,10 @@ One sentence. What the call does — full stop.
 
 | Route | Summary | Description |
 |---|---|---|
-| `GET /agents` | List agents | List all agents in your workspace. |
+| `GET /agents` | List agents | List all agents. |
 | `POST /agents/resolve` | Resolve agent names to IDs | Resolve agent names to their IDs. |
 | `POST /agent-tests/agent/{agent_uuid}/run` | Run agent tests | Run tests for an agent as a background job. |
-| `POST /agent-tests/run` | Run agent tests in batch | Run agent tests for every agent in your workspace, or for a selected set. |
+| `POST /agent-tests/run` | Run agent tests in batch | Run agent tests for every agent, or for a selected set. |
 | `GET /agent-tests/run/{task_id}` | Get test run status | Get the status and results of a test run. |
 
 **Never put in the endpoint heading:**
@@ -63,6 +63,7 @@ One sentence. What the call does — full stop.
 - Response field names (`` `not_found` ``, `` `skipped` ``, `` `task_id` ``)
 - HTTP status codes or error behavior ("404 if…", "400 otherwise")
 - Request-param semantics already on the field ("omit `agent_names` to…")
+- **Workspace scope** ("in your workspace", "for your workspace") — every resource is workspace-scoped by default, so saying it is filler
 - **Which fields the operation touches** ("Update an agent's name and/or config" → just **"Update an agent."**) or PATCH semantics ("only the provided fields change") — what's updatable and the omit behavior live on the body fields
 - Internal preconditions or workflow ("connection must be verified", "call verify-connection")
 - Implementation backstory ("runs the calibrate LLM command", job types, queue behavior)
@@ -78,7 +79,7 @@ async def resolve_agent_names(...):
 
 @router.post("/run", summary="Run agent tests in batch", tags=["Public API"])
 async def run_tests_batch(...):
-    """Run agent tests for every agent in your workspace, or for a selected set."""
+    """Run agent tests for every agent, or for a selected set."""
     # omit-vs-select → BatchRunRequest.agent_names Field description
 ```
 
@@ -184,7 +185,7 @@ async def delete_api_key(...):
 
 @router.get("", response_model=list[AgentResponse], summary="List agents", tags=["Public API"])
 async def list_agents(...):
-    """List all agents in your workspace."""
+    """List all agents."""
 ```
 
 ## Path & query params

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -212,10 +212,10 @@ optional fields default to `None` and their description says what omission means
 
 ```python
 class AgentCreate(BaseModel):
-    name: str = Field(description="Human-readable agent name, unique within the workspace")
+    name: str = Field(description="Name of the agent, unique within the workspace")
     type: Literal["agent", "connection"] = Field(
         "agent",
-        description="`agent` applies managed defaults; `connection` stores the config you supply as-is",
+        description="`agent` (built inside Calibrate) applies managed defaults. `connection` (your existing agent) stores the config you supply as-is",
     )
     config: dict[str, Any] | None = Field(
         None, description="Behavioral config. Deep-merged over defaults for `type=agent`; omit to use defaults"
@@ -320,6 +320,50 @@ cost: Optional[float] = Field(None, description="Per-case cost in USD, lifted fr
 # GOOD — the shape, the unit, done
 latency_ms: Optional[Dict[str, Any]] = Field(None, description="Aggregated response latency in milliseconds: `{p50, p95, p99, count}`")
 cost: Optional[float] = Field(None, description="Cost of this case in USD")
+```
+
+### Concise ≠ cryptic — write a natural phrase, not a two-word label
+
+Cutting filler does **not** mean compressing into terse shorthand. Each
+description should read as a plain, self-explanatory phrase a first-time reader
+understands without decoding. Prefer the natural sentence fragment over a clipped
+noun-label.
+
+```
+BAD (cryptic label)      GOOD (natural phrase)
+"Test ID"                "Unique ID for the test"
+"Test kind"              (the real gloss of what each value judges)
+"Creation timestamp"     "Timestamp when the test was created"
+"Calibrate test config"  "Config for the test (`history`, `evaluation`, ...)"
+```
+
+The bar: filler out, but enough words in to be unambiguous on its own. "Name of
+the test" over "Test name" when a whole model is being read top-to-bottom, so the
+fields read as consistent phrases rather than a telegram.
+
+### Reuse one constant for a description shared across models
+
+When the same field appears on several models (a `type`/`status` enum on the
+create, update, response, and bulk models), don't hand-copy the gloss into each —
+they drift (one gets the rich bulleted gloss, another degrades to "Test kind").
+Define a module-level constant and reference it everywhere, appending
+per-model context with `+` where needed:
+
+```python
+_TEST_TYPE_DESCRIPTION = (
+    "What the test judges:\n\n"
+    "- `response`: judges the generated reply\n"
+    "- `tool_call`: diffs the generated tool calls\n"
+    "- `conversation`: judges the full conversation"
+)
+
+class TestCreate(BaseModel):
+    type: TestType = Field(description=_TEST_TYPE_DESCRIPTION)
+
+class TestUpdate(BaseModel):
+    type: Optional[TestType] = Field(
+        None, description=_TEST_TYPE_DESCRIPTION + "\n\nImmutable. Omit, or send the existing value."
+    )
 ```
 
 ### Don't repeat the unit that's already in the field name

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -63,6 +63,7 @@ One sentence. What the call does — full stop.
 - Response field names (`` `not_found` ``, `` `skipped` ``, `` `task_id` ``)
 - HTTP status codes or error behavior ("404 if…", "400 otherwise")
 - Request-param semantics already on the field ("omit `agent_names` to…")
+- **Which fields the operation touches** ("Update an agent's name and/or config" → just **"Update an agent."**) or PATCH semantics ("only the provided fields change") — what's updatable and the omit behavior live on the body fields
 - Internal preconditions or workflow ("connection must be verified", "call verify-connection")
 - Implementation backstory ("runs the calibrate LLM command", job types, queue behavior)
 - `(non-deleted)` or other DB-filter caveats

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -415,19 +415,23 @@ How a field is **typed** drives how Mintlify renders it. This is a docs decision
 not just a code one.
 
 - **A field with a known, stable shape must be a Pydantic model, not
-  `Dict[str, Any]`.** A free-form dict renders as a shapeless `object`/`object[]`
-  chip with **no expandable child attributes** and a **misleading auto-title**:
-  Pydantic title-cases the field name (`config` → `Config`, `evaluators` →
-  `Evaluators`), which Mintlify shows as a fake type chip (`Config · object`) that
-  looks like a named type but expands to nothing. Define a model (e.g.
-  `RunEvaluator`) so the docs show "Show child attributes" with each field
-  documented.
-- **Genuinely free-form blobs** (a passthrough `config` stored as-is, with no
-  fixed keys) are the *only* legitimate `Dict[str, Any]`. Their auto-title is
+  `Dict[str, Any]` / `List[Dict[str, Any]]`.** A free-form dict (or list of them)
+  renders as a shapeless `object`/`object[]` chip with **no expandable child
+  attributes** and a **misleading auto-title**: Pydantic title-cases the field
+  name (`config` → `Config`, `tool_calls` → `Tool Calls`), which Mintlify shows as
+  a fake type chip (`Config · object`, `Tool Calls · object[]`) that looks like a
+  named type but expands to nothing. Define a model (e.g. `TestRunEvaluator`) so
+  the docs show "Show child attributes" with each field documented.
+- **Genuinely free-form blobs** (a passthrough `config` stored as-is; a
+  user-supplied `tool_calls` list; a calibrate-owned metrics dict) are the *only*
+  legitimate `Dict[str, Any]` / `List[Dict[str, Any]]`. Their auto-title is
   stripped from the public spec by `_strip_freeform_titles()` in
-  [main.py](../../../src/main.py) so they render as plain `object`, not a fake
-  type. Don't fight this — if there's no fixed shape, there's nothing to expand,
-  and the description should just say what the blob holds.
+  [main.py](../../../src/main.py) — which covers **both** dicts and lists of dicts
+  — so they render as plain `object`/`object[]`, not a fake type. A test in
+  `tests/test_main_and_routers.py` asserts **no** free-form field in the whole
+  public spec keeps a title, so this can't regress. Don't fight it — if there's no
+  fixed shape, there's nothing to expand; the description just says what the blob
+  holds.
 - **`Name · object[]` on a *modeled* array is Mintlify's normal rendering**, not a
   defect — it prints the model name plus the base JSON type. You cannot suppress
   the `object[]` half from the backend without losing the model name (worse). Do

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -56,35 +56,39 @@ remove the `Public API` tag as part of a docs-only pass.
 
 ### Endpoint heading (summary + docstring)
 
-One sentence that **adds what the entity is, or what the call returns** — never
-a bare restatement of the summary, never scope/impl filler. The summary is the
-verb + noun ("Create test"); the docstring must earn its place by saying
-something the title doesn't.
+One sentence that **conveys what the entity is or does** — never a bare
+restatement of the summary, never scope/impl filler. **No trailing period**
+(like the summary). The summary is the verb + noun ("Create test"); the docstring
+earns its place by saying something the title doesn't.
 
 - **BAD — bare restatement** (as useless as filler): summary "Create test",
-  docstring `"""Create a test."""`. The reader learned nothing.
-- **GOOD — adds what the entity is**: `"""Create a test that runs your agent
-  against a conversation and grades its reply, tool calls, or the full
-  conversation."""`
-- **For GET/list/poll, add what you get back**: `"""Poll a test run for its
-  status, per-case results, and judge verdicts."""` (cf. Coval: "Retrieve
-  detailed information about a specific simulation run.")
-- **For a lesser-known entity, gloss it in an appositive**: `"""Update a persona,
-  a simulated user profile used in simulations."""`
-- Still **one sentence**, still no scope filler ("in your workspace"), no field
-  enumeration ("name and/or config"), no implementation (deep-merge, job types).
+  docstring `"""Create a test"""`. The reader learned nothing.
+- **GOOD — says what the entity does** (this is where a sentence pays off, most
+  on create): `"""Create a test that runs your agent against a conversation and
+  evaluates its answer quality or the tools it calls"""`
+- **Do NOT append an inventory of what comes back.** A trailing catalog of
+  response fields is padding, not purpose. Keep one clean phrase.
+  - BAD: `"""List your agents, each with its type and config"""`
+  - GOOD: `"""Get the list of all your agents"""`
+  - BAD: `"""Poll a test run for its status, per-case results, and judge
+    verdicts"""`
+  - GOOD: `"""Poll a test run for its status and evaluation results"""`
+- For get/list/simple ops a light natural phrase is enough ("Get one agent by its
+  ID"); don't force a rich sentence where there's nothing to add.
+- Still **one sentence**, no scope filler ("in your workspace"), no field
+  enumeration ("name and/or config"), no implementation (deep-merge, job types),
+  no trailing period.
 
-The model to imitate — Coval's descriptions add purpose, not padding:
-"Launch a new simulation run **to evaluate an agent against test cases using a
-persona**."
+The model — Coval's descriptions add purpose, not padding: "Launch a new
+simulation run **to evaluate an agent against test cases using a persona**."
 
 | Route | Summary | Description |
 |---|---|---|
-| `GET /agents` | List agents | List your agents, each with its type and config. |
-| `POST /agents/resolve` | Resolve agent names to IDs | Look up agent IDs by name, to reference agents in other calls. |
-| `POST /agent-tests/agent/{agent_uuid}/run` | Run agent tests | Run an agent's linked tests as a background job, returning a task ID to poll. |
-| `POST /agent-tests/run` | Run agent tests in batch | Run agent tests for every agent, or for a selected set. |
-| `GET /agent-tests/run/{task_id}` | Get test run status | Poll a test run for its status, per-case results, and judge verdicts. |
+| `GET /agents` | List agents | Get the list of all your agents |
+| `POST /agents/resolve` | Resolve agent names to IDs | Get the IDs for your agents by their names |
+| `PUT /agents/{agent_uuid}` | Update agent | Update an agent's configuration |
+| `POST /tests` | Create test | Create a test that runs your agent against a conversation and evaluates its answer quality or the tools it calls |
+| `GET /agent-tests/run/{task_id}` | Get test run status | Poll a test run for its status and evaluation results |
 
 **Never put in the endpoint heading:**
 
@@ -157,7 +161,7 @@ models** must match. Never invent `a1b2c3d4`-style placeholders.
 ### Public API checklist
 
 - [ ] `summary=` — imperative, no period, says **ID** not UUID
-- [ ] Docstring — **one sentence that adds what the entity is / what it returns** (not a bare restatement of the summary); no fields/errors/auth/impl/scope filler
+- [ ] Docstring — one sentence saying what the entity **is/does** (not a bare restatement, not an inventory of returned fields); **no trailing period**; no fields/errors/auth/impl/scope filler
 - [ ] Path params — purpose-first `description` + real UUID `examples`; no length constraints
 - [ ] Request fields — what it is + what omitting it does
 - [ ] Response fields — what each value means; error/shape detail here, not in heading

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -56,15 +56,35 @@ remove the `Public API` tag as part of a docs-only pass.
 
 ### Endpoint heading (summary + docstring)
 
-One sentence. What the call does — full stop.
+One sentence that **adds what the entity is, or what the call returns** — never
+a bare restatement of the summary, never scope/impl filler. The summary is the
+verb + noun ("Create test"); the docstring must earn its place by saying
+something the title doesn't.
+
+- **BAD — bare restatement** (as useless as filler): summary "Create test",
+  docstring `"""Create a test."""`. The reader learned nothing.
+- **GOOD — adds what the entity is**: `"""Create a test that runs your agent
+  against a conversation and grades its reply, tool calls, or the full
+  conversation."""`
+- **For GET/list/poll, add what you get back**: `"""Poll a test run for its
+  status, per-case results, and judge verdicts."""` (cf. Coval: "Retrieve
+  detailed information about a specific simulation run.")
+- **For a lesser-known entity, gloss it in an appositive**: `"""Update a persona,
+  a simulated user profile used in simulations."""`
+- Still **one sentence**, still no scope filler ("in your workspace"), no field
+  enumeration ("name and/or config"), no implementation (deep-merge, job types).
+
+The model to imitate — Coval's descriptions add purpose, not padding:
+"Launch a new simulation run **to evaluate an agent against test cases using a
+persona**."
 
 | Route | Summary | Description |
 |---|---|---|
-| `GET /agents` | List agents | List all agents. |
-| `POST /agents/resolve` | Resolve agent names to IDs | Resolve agent names to their IDs. |
-| `POST /agent-tests/agent/{agent_uuid}/run` | Run agent tests | Run tests for an agent as a background job. |
+| `GET /agents` | List agents | List your agents, each with its type and config. |
+| `POST /agents/resolve` | Resolve agent names to IDs | Look up agent IDs by name, to reference agents in other calls. |
+| `POST /agent-tests/agent/{agent_uuid}/run` | Run agent tests | Run an agent's linked tests as a background job, returning a task ID to poll. |
 | `POST /agent-tests/run` | Run agent tests in batch | Run agent tests for every agent, or for a selected set. |
-| `GET /agent-tests/run/{task_id}` | Get test run status | Get the status and results of a test run. |
+| `GET /agent-tests/run/{task_id}` | Get test run status | Poll a test run for its status, per-case results, and judge verdicts. |
 
 **Never put in the endpoint heading:**
 
@@ -137,7 +157,7 @@ models** must match. Never invent `a1b2c3d4`-style placeholders.
 ### Public API checklist
 
 - [ ] `summary=` — imperative, no period, says **ID** not UUID
-- [ ] Docstring — **one sentence**, no fields/errors/auth/implementation
+- [ ] Docstring — **one sentence that adds what the entity is / what it returns** (not a bare restatement of the summary); no fields/errors/auth/impl/scope filler
 - [ ] Path params — purpose-first `description` + real UUID `examples`; no length constraints
 - [ ] Request fields — what it is + what omitting it does
 - [ ] Response fields — what each value means; error/shape detail here, not in heading

--- a/.cursor/skills/api-writing-style/SKILL.md
+++ b/.cursor/skills/api-writing-style/SKILL.md
@@ -88,7 +88,7 @@ async def run_tests_batch(...):
 ```python
 # Path param — purpose + example; NO min_length on path (422 before your 404)
 agent_uuid: str = PathParam(
-    description="The agent to test. Must be in your workspace.",
+    description="The agent to test.",
     examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
 )
 
@@ -192,7 +192,7 @@ async def list_agents(...):
 from fastapi import Path, Query
 
 agent_uuid: str = Path(
-    description="The agent to test. Must be in your workspace.",
+    description="The agent to test.",
     examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
 )
 limit: int = Query(50, ge=1, le=1_000_000, description="Maximum number of results to return")
@@ -224,7 +224,7 @@ class AgentCreate(BaseModel):
 
 Field conventions:
 - **Lead with what the thing is and what it's for**, not its format
-- Ownership/scoping in a second sentence when relevant (`Must be in your workspace.`)
+- **Don't add workspace-scoping filler** ("Must be in your workspace.") to a path param identifying a resource you act on — it's self-evident (cross-workspace access just 404s). Keep an ownership/scope note only when it carries real information (e.g. "or a seeded default", a link constraint)
 - `min_length=36`/`max_length=36` + `examples` on **body/response models only**
 - Mark conditional requirements in **bold**: `**Required for type=connection.**`
 - **Never re-list an enum's own values in its description** (see enum section)

--- a/scripts/check_api_docs_style.py
+++ b/scripts/check_api_docs_style.py
@@ -11,6 +11,10 @@ boot) and flags routes/models that violate the house style:
      `description`.
   4. Every field on a Pydantic model (a `BaseModel` subclass, transitively) has a
      `Field(..., description=...)` with a non-empty description.
+  5. Rendered doc text (descriptions, summaries, route/model/module docstrings)
+     contains no banned terms, no em-dashes, and no clause-splitting semicolons.
+  6. A field whose name ends in a unit suffix (e.g. `_ms`) doesn't repeat that
+     unit abbreviation in its description.
 
 Run directly (`uv run python scripts/check_api_docs_style.py`) — exits non-zero
 and prints one line per violation. `tests/test_api_docs_style.py` reuses
@@ -47,6 +51,20 @@ _BANNED_TERMS = [
     (re.compile(r"\b8-char\b"), "IDs are UUID v4 (36 chars) — don't say '8-char'"),
 ]
 
+# Mechanical bans on rendered doc text (see "Brevity & mechanics" in the skill).
+# Applied to the same doc-text set as _BANNED_TERMS (descriptions, summaries,
+# route/model/module docstrings). Code comments are exempt — they don't render.
+_MECHANICS = [
+    (
+        re.compile("—"),  # em-dash
+        "no em-dashes in rendered docs: use a period, comma, colon, or parentheses",
+    ),
+    (
+        re.compile(r";\s"),  # clause-splitting semicolon
+        "no clause-splitting semicolons in docs: use a full stop",
+    ),
+]
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ROUTERS_DIR = REPO_ROOT / "src" / "routers"
 
@@ -60,6 +78,21 @@ def _has_description_kw(call: ast.Call) -> bool:
             # Non-literal (f-string, variable) — accept; can't statically judge.
             return True
     return False
+
+
+# Field-name suffix → the unit abbreviation that must NOT be repeated in prose
+# (the field name already carries it; spell the word out or drop it). See
+# "Don't repeat the unit that's already in the field name" in the skill.
+_UNIT_SUFFIXES = [("_ms", re.compile(r"\bms\b"), "milliseconds")]
+
+
+def _field_description_text(call: ast.Call) -> Optional[str]:
+    """The literal `description=` string on a Field call, or None if absent /
+    non-literal (f-string, variable — can't statically inspect)."""
+    for kw in call.keywords:
+        if kw.arg == "description" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value.value
+    return None
 
 
 def _is_field_call(node: Optional[ast.expr]) -> bool:
@@ -112,6 +145,15 @@ def _check_model_fields(cls: ast.ClassDef, rel: str) -> list[str]:
             out.append(f"{loc}: field is not documented with Field(description=...)")
         elif not _has_description_kw(stmt.value):
             out.append(f"{loc}: Field(...) is missing a non-empty description=")
+        else:
+            desc = _field_description_text(stmt.value)
+            if desc:
+                for suffix, pat, word in _UNIT_SUFFIXES:
+                    if field.endswith(suffix) and pat.search(desc):
+                        out.append(
+                            f"{loc}: unit abbreviation repeats the '{suffix}' "
+                            f"field-name suffix — say '{word}' or drop it"
+                        )
     return out
 
 
@@ -231,6 +273,9 @@ def _check_terminology(tree: ast.Module, rel: str) -> list[str]:
         for pat, msg in _BANNED_TERMS:
             if pat.search(text):
                 out.append(f"{rel}:{node.lineno}: banned term in doc text — {msg}")
+        for pat, msg in _MECHANICS:
+            if pat.search(text):
+                out.append(f"{rel}:{node.lineno}: {msg}")
     return out
 
 

--- a/scripts/check_api_docs_style.py
+++ b/scripts/check_api_docs_style.py
@@ -63,6 +63,14 @@ _MECHANICS = [
         re.compile(r";\s"),  # clause-splitting semicolon
         "no clause-splitting semicolons in docs: use a full stop",
     ),
+    (
+        re.compile(r"(?i)deep[- ]merge"),  # implementation jargon
+        "don't say 'deep-merge' in docs (implementation jargon); describe the effect",
+    ),
+    (
+        re.compile(r"(?i)human-readable"),  # filler
+        "'Human-readable' is filler; drop it",
+    ),
 ]
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -228,54 +236,81 @@ def _is_route_function(func) -> bool:
     return _route_decorator(func) is not None
 
 
+def _resolve_str(node: ast.expr, consts: dict) -> Optional[str]:
+    """Statically resolve a node to a string: a literal, a module-level string
+    constant by name, or an `+`-concatenation of those. Returns None if it
+    can't be resolved (f-strings, calls, unknown names). This lets the checker
+    see `description=_SHARED + "…"` composed descriptions, not just literals."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in consts:
+        return consts[node.id]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _resolve_str(node.left, consts)
+        right = _resolve_str(node.right, consts)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def _module_str_consts(tree: ast.Module) -> dict:
+    """Map module-level `NAME = <string>` assignments (resolving concatenation
+    and references to earlier constants), in source order."""
+    consts: dict = {}
+    for stmt in tree.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+        ):
+            val = _resolve_str(stmt.value, consts)
+            if val is not None:
+                consts[stmt.targets[0].id] = val
+    return consts
+
+
 def _doc_string_nodes(tree: ast.Module):
-    """User-facing doc text: module, route, model class docstrings, summary=/description=."""
+    """User-facing doc text as (lineno, text) pairs: module/route/model-class
+    docstrings and summary=/description= kwargs — including descriptions composed
+    from module-level string constants (`_SHARED + "…"`)."""
+    consts = _module_str_consts(tree)
     out = []
     models = _model_class_names(tree)
-    body = tree.body
-    if (
-        body
-        and isinstance(body[0], ast.Expr)
-        and isinstance(body[0].value, ast.Constant)
-        and isinstance(body[0].value.value, str)
-    ):
-        out.append(body[0].value)
+
+    def _docstring(node):
+        b = getattr(node, "body", None)
+        if (
+            b
+            and isinstance(b[0], ast.Expr)
+            and isinstance(b[0].value, ast.Constant)
+            and isinstance(b[0].value.value, str)
+        ):
+            out.append((b[0].value.lineno, b[0].value.value))
+
+    _docstring(tree)  # module docstring
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name in models:
-            b = node.body
-            if (
-                b
-                and isinstance(b[0], ast.Expr)
-                and isinstance(b[0].value, ast.Constant)
-                and isinstance(b[0].value.value, str)
-            ):
-                out.append(b[0].value)
+            _docstring(node)
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and _is_route_function(node):
-            b = node.body
-            if (
-                b
-                and isinstance(b[0], ast.Expr)
-                and isinstance(b[0].value, ast.Constant)
-                and isinstance(b[0].value.value, str)
-            ):
-                out.append(b[0].value)
+            _docstring(node)
         if isinstance(node, ast.Call):
             for kw in node.keywords:
-                if kw.arg in ("summary", "description") and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
-                    out.append(kw.value)
+                if kw.arg in ("summary", "description"):
+                    text = _resolve_str(kw.value, consts)
+                    if text is not None:
+                        out.append((kw.value.lineno, text))
     return out
 
 
 def _check_terminology(tree: ast.Module, rel: str) -> list[str]:
     out = []
-    for node in _doc_string_nodes(tree):
-        text = node.value
+    for lineno, text in _doc_string_nodes(tree):
         for pat, msg in _BANNED_TERMS:
             if pat.search(text):
-                out.append(f"{rel}:{node.lineno}: banned term in doc text — {msg}")
+                out.append(f"{rel}:{lineno}: banned term in doc text — {msg}")
         for pat, msg in _MECHANICS:
             if pat.search(text):
-                out.append(f"{rel}:{node.lineno}: {msg}")
+                out.append(f"{rel}:{lineno}: {msg}")
     return out
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -174,6 +174,46 @@ def _collect_schema_refs(node: Any, acc: set) -> None:
             _collect_schema_refs(item, acc)
 
 
+def _is_freeform_object_schema(node: Any) -> bool:
+    """True if ``node`` is a free-form object schema — ``type: object`` with
+    ``additionalProperties`` and no declared ``properties`` (i.e. a
+    ``Dict[str, Any]``). These carry no sub-fields to document."""
+    return (
+        isinstance(node, dict)
+        and node.get("type") == "object"
+        and bool(node.get("additionalProperties"))
+        and not node.get("properties")
+    )
+
+
+def _strip_freeform_titles(node: Any) -> None:
+    """Recursively delete Pydantic's auto-generated ``title`` from free-form
+    object schemas (`Dict[str, Any]` fields). Pydantic title-cases the field
+    name (``config`` → ``"Config"``), which Mintlify surfaces as a fake type
+    chip (`Config · object | null`) even though no such named type exists and
+    there's nothing to expand. Real component/model titles are untouched — only
+    inline free-form blobs (including the `anyOf: [object, null]` wrapper that
+    `Optional[Dict]` produces) lose their noise title."""
+    if isinstance(node, dict):
+        if "title" in node:
+            branches = node.get("anyOf") or node.get("oneOf") or []
+            non_null = [
+                b
+                for b in branches
+                if not (isinstance(b, dict) and b.get("type") == "null")
+            ]
+            wraps_freeform = bool(non_null) and all(
+                _is_freeform_object_schema(b) for b in non_null
+            )
+            if _is_freeform_object_schema(node) or wraps_freeform:
+                node.pop("title", None)
+        for value in node.values():
+            _strip_freeform_titles(value)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_freeform_titles(item)
+
+
 def _build_public_openapi() -> Dict[str, Any]:
     full = app.openapi()
     public_paths: Dict[str, Any] = {}
@@ -235,6 +275,12 @@ def _build_public_openapi() -> Dict[str, Any]:
             "description": "Workspace API key. Create one under Workspace settings → API keys.",
         }
     }
+
+    # Drop Pydantic's auto-titles on free-form `Dict[str, Any]` fields so
+    # Mintlify renders them as plain `object | null` instead of a misleading
+    # `Config`-style type chip. Real model titles in `components.schemas` stay.
+    _strip_freeform_titles(public_paths)
+    _strip_freeform_titles(components.get("schemas", {}))
 
     return {
         "openapi": full.get("openapi", "3.1.0"),

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import os
+import copy
 import uuid
 import asyncio
 import logging
@@ -228,6 +229,31 @@ def _strip_freeform_titles(node: Any) -> None:
             _strip_freeform_titles(item)
 
 
+# Request fields that only JWT (frontend) callers can set — API-key writes have
+# them stripped server-side (see agents._strip_verification_fields), so they're
+# inert and misleading in the API-key-facing public spec and its generated SDK/
+# code samples. Kept on the model (the frontend uses them) but hidden from the
+# public spec only. Keyed by component-schema name.
+_PUBLIC_SPEC_HIDDEN_FIELDS: Dict[str, tuple] = {
+    "AgentUpdate": ("connection_verified", "benchmark_models_verified"),
+}
+
+
+def _strip_hidden_public_fields(schemas: Dict[str, Any]) -> None:
+    """Drop JWT-only request fields from the public component schemas."""
+    for model, fields in _PUBLIC_SPEC_HIDDEN_FIELDS.items():
+        schema = schemas.get(model)
+        if not schema:
+            continue
+        props = schema.get("properties")
+        if props:
+            for f in fields:
+                props.pop(f, None)
+        req = schema.get("required")
+        if req:
+            schema["required"] = [r for r in req if r not in fields]
+
+
 def _build_public_openapi() -> Dict[str, Any]:
     full = app.openapi()
     public_paths: Dict[str, Any] = {}
@@ -275,9 +301,11 @@ def _build_public_openapi() -> Dict[str, Any]:
 
     components: Dict[str, Any] = dict(full.get("components", {}))
     if all_schemas:
-        components["schemas"] = {
-            name: schema for name, schema in all_schemas.items() if name in needed
-        }
+        # Deep-copy: the strip passes below mutate these schemas, and the source
+        # objects are shared with the cached `app.openapi()` (internal /docs).
+        components["schemas"] = copy.deepcopy(
+            {name: schema for name, schema in all_schemas.items() if name in needed}
+        )
     # Expose ONLY the API-key scheme on the public spec — see the per-op
     # `security` override above for why the auto-generated bearer scheme is
     # dropped. `X-API-Key: sk_…` is the SDK's auth path.
@@ -295,6 +323,7 @@ def _build_public_openapi() -> Dict[str, Any]:
     # `Config`-style type chip. Real model titles in `components.schemas` stay.
     _strip_freeform_titles(public_paths)
     _strip_freeform_titles(components.get("schemas", {}))
+    _strip_hidden_public_fields(components.get("schemas", {}))
 
     return {
         "openapi": full.get("openapi", "3.1.0"),

--- a/src/main.py
+++ b/src/main.py
@@ -186,14 +186,28 @@ def _is_freeform_object_schema(node: Any) -> bool:
     )
 
 
+def _is_freeform_schema(node: Any) -> bool:
+    """True if ``node`` is a free-form object (`Dict[str, Any]`) OR an array of
+    them (`List[Dict[str, Any]]`). Both render as a shapeless `object`/`object[]`
+    chip with nothing to expand, so both should shed their auto-title."""
+    if _is_freeform_object_schema(node):
+        return True
+    return (
+        isinstance(node, dict)
+        and node.get("type") == "array"
+        and _is_freeform_object_schema(node.get("items", {}))
+    )
+
+
 def _strip_freeform_titles(node: Any) -> None:
     """Recursively delete Pydantic's auto-generated ``title`` from free-form
-    object schemas (`Dict[str, Any]` fields). Pydantic title-cases the field
-    name (``config`` → ``"Config"``), which Mintlify surfaces as a fake type
-    chip (`Config · object | null`) even though no such named type exists and
-    there's nothing to expand. Real component/model titles are untouched — only
-    inline free-form blobs (including the `anyOf: [object, null]` wrapper that
-    `Optional[Dict]` produces) lose their noise title."""
+    fields — `Dict[str, Any]` and `List[Dict[str, Any]]`. Pydantic title-cases
+    the field name (``config`` → ``"Config"``, ``tool_calls`` → ``"Tool Calls"``),
+    which Mintlify surfaces as a fake type chip (`Config · object`,
+    `Tool Calls · object[]`) even though no such named type exists and there's
+    nothing to expand. Real component/model titles are untouched — only inline
+    free-form blobs (including the `anyOf: [<freeform>, null]` wrapper that
+    `Optional[...]` produces) lose their noise title."""
     if isinstance(node, dict):
         if "title" in node:
             branches = node.get("anyOf") or node.get("oneOf") or []
@@ -203,9 +217,9 @@ def _strip_freeform_titles(node: Any) -> None:
                 if not (isinstance(b, dict) and b.get("type") == "null")
             ]
             wraps_freeform = bool(non_null) and all(
-                _is_freeform_object_schema(b) for b in non_null
+                _is_freeform_schema(b) for b in non_null
             )
-            if _is_freeform_object_schema(node) or wraps_freeform:
+            if _is_freeform_schema(node) or wraps_freeform:
                 node.pop("title", None)
         for value in node.values():
             _strip_freeform_titles(value)

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -379,7 +379,7 @@ class TestCaseResult(BaseModel):
     )
     latency_ms: Optional[float] = Field(
         None,
-        description="Response-generation latency in ms for the agent under test (not the judge). Present only for live runs. Null for in-progress and eval-only runs. Float, since external agents may self-report a fractional value",
+        description="Response-generation latency in milliseconds for the agent under test (not the judge). Present only for live runs. Null for in-progress runs. Float, since external agents may self-report a fractional value",
     )
     cost: Optional[float] = Field(
         None,
@@ -408,7 +408,7 @@ class TestRunStatusResponse(BaseModel):
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated response latency in milliseconds: `{p50, p95, p99, count}`. Null for eval-only runs",
+        description="Aggregated response latency in milliseconds: `{p50, p95, p99, count}`",
     )
     cost: Optional[Dict[str, Any]] = Field(
         None,
@@ -2438,7 +2438,7 @@ class ModelResult(BaseModel):
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated latency in milliseconds: `{p50, p95, p99, count}`. Null when calibrate omits it (eval-only/openai) or before this model's metrics are ready",
+        description="Aggregated latency in milliseconds: `{p50, p95, p99, count}`. Null before this model's metrics are ready",
     )
     cost: Optional[Dict[str, Any]] = Field(
         None, description="Aggregated cost `{mean, min, max, count}` (USD). Null when unavailable"

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -47,6 +47,7 @@ from utils import (
     TaskCreateResponse,
     TestTypeLiteral,
     OutputTypeLiteral,
+    AGENT_TYPE_DESCRIPTION,
     AgentTestJobType,
     get_s3_client,
     get_s3_output_config,
@@ -227,7 +228,7 @@ class AgentResponse(BaseModel):
     )
     name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
+        description=AGENT_TYPE_DESCRIPTION
     )
     config: Dict[str, Any] | None = Field(
         None, description="Behavioral config. Null when the agent has none"

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -338,15 +338,15 @@ class JudgeResult(BaseModel):
     )
     match: Optional[bool] = Field(
         None,
-        description="Binary evaluator pass/fail. **Set only for binary evaluators** (else null — `score` is set instead)",
+        description="Pass/fail verdict, for binary evaluators",
     )
     score: Optional[float] = Field(
         None,
-        description="Rating evaluator numeric score. **Set only for rating evaluators** (else null — `match` is set instead)",
+        description="Numeric score, for rating evaluators",
     )
     value_name: Optional[str] = Field(
         None,
-        description="Human-readable label for `match`/`score` resolved against the run's rubric. Falls back to `Correct`/`Wrong` (binary) or the stringified score (rating) when the snapshot lacks named scale entries",
+        description="Readable label for the verdict, from the run's rubric",
     )
     variable_values: Optional[Dict[str, Any]] = Field(
         None,
@@ -380,11 +380,11 @@ class TestCaseResult(BaseModel):
     )
     latency_ms: Optional[float] = Field(
         None,
-        description="Response-generation latency in milliseconds for the agent under test (not the judge). Present only for live runs. Null for in-progress runs. Float, since external agents may self-report a fractional value",
+        description="Response latency in milliseconds for the agent under test, not the judge",
     )
     cost: Optional[float] = Field(
         None,
-        description="Per-case cost in USD, lifted from calibrate's nested `output.cost`. Null when the provider/agent reports none (e.g. `--provider openai`)",
+        description="Cost of this case in USD",
     )
 
 
@@ -399,7 +399,7 @@ class RunEvaluator(BaseModel):
     )
     output_config: Optional[Dict[str, Any]] = Field(
         None,
-        description="Rubric — the scale values, labels, and colors a verdict maps to",
+        description="Rubric: the scale values, labels, and colors a verdict maps to",
     )
     scale_min: Optional[float] = Field(
         None, description="Lowest rating value. Set for rating evaluators"
@@ -819,7 +819,7 @@ class AgentTestsBulkDeleteAll(BaseModel):
         examples=[_EXAMPLE_AGENT_UUID],
     )
     test_uuids: List[str] = Field(
-        description="Tests to soft-delete. Must be non-empty. Only tests linked to this agent in your workspace are deleted — others are skipped",
+        description="Tests to soft-delete. Must be non-empty. Only tests linked to this agent in your workspace are deleted. Others are skipped",
         examples=[[_EXAMPLE_TEST_UUID]],
     )
 

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -708,7 +708,7 @@ async def get_all_test_runs_for_user(
         description="Filter by job type. Omit to return both",
     ),
 ):
-    """List all test runs in your workspace, newest first."""
+    """List all test runs, newest first."""
     jobs = get_agent_test_jobs_for_org(ctx.org_uuid, job_type=type)
 
     # Per-agent counters for naming ("Run 1", "Benchmark 2", …).
@@ -2261,7 +2261,7 @@ async def run_tests_batch(
     request: Optional[BatchRunRequest] = None,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Run agent tests for every agent in your workspace, or for a selected set."""
+    """Run agent tests for every agent, or for a selected set."""
     # Public API (auth via get_org_jwt_or_api_key).
     agent_names = request.agent_names if request else None
 

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -523,7 +523,7 @@ class GlobalTestRunsResponse(BaseModel):
 
 @router.post("", response_model=AgentTestsCreateResponse, summary="Link tests to agent")
 async def create_agent_test_links(agent_tests: AgentTestsCreate):
-    """Link one or more tests to an agent. Already-linked tests are skipped."""
+    """Link one or more tests to an agent. Already-linked tests are skipped"""
     # Verify agent exists
     agent = get_agent(agent_tests.agent_uuid)
     if not agent:
@@ -558,7 +558,7 @@ async def create_agent_test_links(agent_tests: AgentTestsCreate):
 
 @router.get("", response_model=List[AgentTestResponse], summary="List agent-test links")
 async def list_agent_tests():
-    """List which tests are linked to which agents."""
+    """List which tests are linked to which agents"""
     links = get_all_agent_tests()
     return links
 
@@ -574,7 +574,7 @@ async def get_agent_tests_endpoint(
         examples=[_EXAMPLE_AGENT_UUID],
     ),
 ):
-    """List the tests linked to an agent."""
+    """List the tests linked to an agent"""
     # Verify agent exists
     agent = get_agent(agent_uuid)
     if not agent:
@@ -650,7 +650,7 @@ async def get_agent_test_runs(
         examples=[_EXAMPLE_AGENT_UUID],
     ),
 ):
-    """List test runs for an agent, including status and results."""
+    """List test runs for an agent, including status and results"""
     # Verify agent exists
     agent = get_agent(agent_uuid)
     if not agent:
@@ -693,7 +693,7 @@ async def get_all_test_runs_for_user(
         description="Filter by job type. Omit to return both",
     ),
 ):
-    """List all test runs, newest first."""
+    """List all test runs, newest first"""
     jobs = get_agent_test_jobs_for_org(ctx.org_uuid, job_type=type)
 
     # Per-agent counters for naming ("Run 1", "Benchmark 2", …).
@@ -741,7 +741,7 @@ async def get_test_agents(
         examples=[_EXAMPLE_TEST_UUID],
     ),
 ):
-    """List the agents linked to a test."""
+    """List the agents linked to a test"""
     # Verify test exists
     test = get_test(test_uuid)
     if not test:
@@ -753,7 +753,7 @@ async def get_test_agents(
 
 @router.delete("", summary="Unlink test from agent")
 async def delete_agent_test_link(agent_test: AgentTestDelete):
-    """Unlink a test from an agent so it no longer runs for that agent."""
+    """Unlink a test from an agent so it no longer runs for that agent"""
     deleted = remove_test_from_agent(agent_test.agent_uuid, agent_test.test_uuid)
     if not deleted:
         raise HTTPException(status_code=404, detail="Agent-test link not found")
@@ -775,7 +775,7 @@ class AgentTestBulkDelete(BaseModel):
 
 @router.post("/bulk-unlink", summary="Bulk unlink tests from agent")
 async def bulk_delete_agent_test_links(payload: AgentTestBulkDelete):
-    """Unlink multiple tests from an agent."""
+    """Unlink multiple tests from an agent"""
     if not payload.test_uuids:
         raise HTTPException(status_code=400, detail="test_uuids must not be empty")
 
@@ -812,7 +812,7 @@ async def bulk_delete_agent_tests(
     payload: AgentTestsBulkDeleteAll,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete tests linked to an agent, removing their links across every agent."""
+    """Soft-delete tests linked to an agent, removing their links across every agent"""
     # Unlike `/bulk-unlink`, this deletes the test rows (not just links). Only
     # tests in your workspace that are linked to `agent_uuid` are deleted;
     # foreign or unlinked IDs are silently skipped. Deleting a test cascades
@@ -2138,7 +2138,7 @@ async def run_agent_test(
     request: RunTestRequest = ...,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Run an agent's linked tests as a background job, returning a task ID to poll."""
+    """Run an agent's linked tests as a background job, returning a task ID to poll"""
     # Public API (auth via get_org_jwt_or_api_key). Verify the agent exists and
     # belongs to the caller's workspace (404 otherwise).
     agent = get_agent(agent_uuid)
@@ -2246,7 +2246,7 @@ async def run_tests_batch(
     request: Optional[BatchRunRequest] = None,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Run agent tests for every agent, or for a selected set."""
+    """Run agent tests for every agent, or for a selected set"""
     # Public API (auth via get_org_jwt_or_api_key).
     agent_names = request.agent_names if request else None
 
@@ -2333,7 +2333,7 @@ async def update_test_run_visibility(
     body: VisibilityRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Toggle public sharing for a test run."""
+    """Toggle public sharing for a test run"""
     job = _load_owned_agent_test_job(task_id, ctx)
 
     if body.is_public:
@@ -2360,7 +2360,7 @@ async def get_agent_test_run_status(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Poll a test run for its status and evaluation results."""
+    """Poll a test run for its status and evaluation results"""
     # Public API (auth via get_org_jwt_or_api_key); ownership enforced below.
     job = _load_owned_agent_test_job(task_id, ctx)
 
@@ -3011,7 +3011,7 @@ async def run_agent_benchmark(
     request: BenchmarkRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Run a multi-model benchmark on an agent's linked tests as a background job."""
+    """Run a multi-model benchmark on an agent's linked tests as a background job"""
     # Verify agent exists and belongs to the caller's org.
     agent = get_agent(agent_uuid)
     if not agent or agent.get("org_uuid") != ctx.org_uuid:
@@ -3136,7 +3136,7 @@ async def update_benchmark_visibility(
     body: VisibilityRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Toggle public sharing for a benchmark run."""
+    """Toggle public sharing for a benchmark run"""
     job = _load_owned_agent_test_job(task_id, ctx)
 
     if body.is_public:
@@ -3162,7 +3162,7 @@ async def get_benchmark_status(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get the status and results of a benchmark run."""
+    """Get the status and results of a benchmark run"""
     job = _load_owned_agent_test_job(task_id, ctx)
 
     status = job["status"]
@@ -3219,7 +3219,7 @@ async def delete_agent_test_job_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Delete an agent test or benchmark job."""
+    """Delete an agent test or benchmark job"""
     job = get_agent_test_job(job_uuid)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -450,9 +450,6 @@ class TestRunStatusResponse(BaseModel):
     results: Optional[List[TestCaseResult]] = Field(
         None, description="Results for each test case. Null until available"
     )
-    results_s3_prefix: Optional[str] = Field(
-        None, description="S3 key prefix for the raw result artifacts. Null until uploaded"
-    )
     error: bool = Field(False, description="True if the run failed")
     is_public: bool = Field(False, description="Whether the run is shared publicly")
     share_token: Optional[str] = Field(

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -380,7 +380,7 @@ class TestCaseResult(BaseModel):
     )
     latency_ms: Optional[float] = Field(
         None,
-        description="Response latency in milliseconds for the agent under test, not the judge",
+        description="Response latency in milliseconds for the agent under test",
     )
     cost: Optional[float] = Field(
         None,

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -197,7 +197,7 @@ class AgentTestsCreateResponse(BaseModel):
     ids: List[int] = Field(
         description="Link row ids created this call (excludes tests that were already linked)"
     )
-    message: str = Field(description="Human-readable confirmation message")
+    message: str = Field(description="Confirmation message")
 
 
 class TestResponse(BaseModel):
@@ -207,7 +207,7 @@ class TestResponse(BaseModel):
         description="Test ID",
         examples=[_EXAMPLE_TEST_UUID],
     )
-    name: str = Field(description="Human-readable test name")
+    name: str = Field(description="Test name")
     type: TestTypeLiteral = Field(
         description="Test type"
     )
@@ -225,7 +225,7 @@ class AgentResponse(BaseModel):
         description="Agent ID",
         examples=[_EXAMPLE_AGENT_UUID],
     )
-    name: str = Field(description="Human-readable agent name")
+    name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
         description="`agent` (managed defaults) or `connection` (config you supply)"
     )
@@ -2448,7 +2448,7 @@ class ModelResult(BaseModel):
     success: Optional[bool] = Field(
         None, description="Whether this model's run succeeded. Null while queued/processing"
     )
-    message: str = Field(description="Human-readable status/result message for this model")
+    message: str = Field(description="Status/result message for this model")
     total_tests: Optional[int] = Field(None, description="Total test cases for this model. Null until known")
     passed: Optional[int] = Field(None, description="Count of passing cases. Null until done")
     failed: Optional[int] = Field(None, description="Count of failing cases. Null until done")

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -573,7 +573,7 @@ async def create_agent_test_links(agent_tests: AgentTestsCreate):
     "", response_model=List[AgentTestResponse], summary="List agent-test links"
 )
 async def list_agent_tests():
-    """List all agent-test links."""
+    """List which tests are linked to which agents."""
     links = get_all_agent_tests()
     return links
 
@@ -768,7 +768,7 @@ async def get_test_agents(
 
 @router.delete("", summary="Unlink test from agent")
 async def delete_agent_test_link(agent_test: AgentTestDelete):
-    """Unlink a test from an agent."""
+    """Unlink a test from an agent so it no longer runs for that agent."""
     deleted = remove_test_from_agent(agent_test.agent_uuid, agent_test.test_uuid)
     if not deleted:
         raise HTTPException(status_code=404, detail="Agent-test link not found")
@@ -2153,7 +2153,7 @@ async def run_agent_test(
     request: RunTestRequest = ...,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Run tests for an agent as a background job."""
+    """Run an agent's linked tests as a background job, returning a task ID to poll."""
     # Public API (auth via get_org_jwt_or_api_key). Verify the agent exists and
     # belongs to the caller's workspace (404 otherwise).
     agent = get_agent(agent_uuid)
@@ -2375,7 +2375,7 @@ async def get_agent_test_run_status(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Get the status and results of a test run."""
+    """Poll a test run for its status, per-case results, and judge verdicts."""
     # Public API (auth via get_org_jwt_or_api_key); ownership enforced below.
     job = _load_owned_agent_test_job(task_id, ctx)
 

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -209,9 +209,7 @@ class TestResponse(BaseModel):
         examples=[_EXAMPLE_TEST_UUID],
     )
     name: str = Field(description="Name of the test")
-    type: TestTypeLiteral = Field(
-        description="Test type"
-    )
+    type: TestTypeLiteral = Field(description="Test type")
     config: Dict[str, Any] | None = Field(
         None, description="Test configuration. Null when the test has none"
     )
@@ -227,9 +225,7 @@ class AgentResponse(BaseModel):
         examples=[_EXAMPLE_AGENT_UUID],
     )
     name: str = Field(description="Agent name")
-    type: Literal["agent", "connection"] = Field(
-        description=AGENT_TYPE_DESCRIPTION
-    )
+    type: Literal["agent", "connection"] = Field(description=AGENT_TYPE_DESCRIPTION)
     config: Dict[str, Any] | None = Field(
         None, description="Behavioral config. Null when the agent has none"
     )
@@ -252,9 +248,7 @@ class AgentTestRunCreateResponse(BaseModel):
         description="Test run job ID. Poll for status and results",
         examples=[_EXAMPLE_TASK_UUID],
     )
-    status: InitialTaskStatus = Field(
-        description="Current status of the test run"
-    )
+    status: InitialTaskStatus = Field(description="Current status of the test run")
 
 
 class BatchRunRequest(BaseModel):
@@ -279,9 +273,7 @@ class BatchTestRun(BaseModel):
         description="Test run job ID. Poll for status and results",
         examples=[_EXAMPLE_TASK_UUID],
     )
-    status: InitialTaskStatus = Field(
-        description="Initial status of the test run"
-    )
+    status: InitialTaskStatus = Field(description="Initial status of the test run")
 
 
 class BatchTestSkip(BaseModel):
@@ -292,15 +284,11 @@ class BatchTestSkip(BaseModel):
         description="ID of the skipped agent",
         examples=[_EXAMPLE_AGENT_UUID],
     )
-    reason: str = Field(
-        description="Why this agent was not run"
-    )
+    reason: str = Field(description="Why this agent was not run")
 
 
 class BatchTestRunResponse(BaseModel):
-    runs: List[BatchTestRun] = Field(
-        description="Test runs that were launched"
-    )
+    runs: List[BatchTestRun] = Field(description="Test runs that were launched")
     skipped: List[BatchTestSkip] = Field(
         default=[],
         description="Agents that were skipped instead of failing the batch",
@@ -359,9 +347,7 @@ class TestCaseResult(BaseModel):
     test_case_id: Optional[str] = Field(
         None, description="ID of the test case within the run"
     )
-    name: Optional[str] = Field(
-        None, description="Name of the test"
-    )
+    name: Optional[str] = Field(None, description="Name of the test")
     passed: Optional[bool] = Field(
         None, description="Whether the case passed. Present only when done"
     )
@@ -392,9 +378,7 @@ class TestCaseResult(BaseModel):
 class TestRunEvaluator(BaseModel):
     uuid: Optional[str] = Field(None, description="ID of the evaluator")
     name: Optional[str] = Field(None, description="Name of the evaluator")
-    description: Optional[str] = Field(
-        None, description="What the evaluator checks"
-    )
+    description: Optional[str] = Field(None, description="What the evaluator checks")
     output_type: Optional[OutputTypeLiteral] = Field(
         None, description="Verdict shape: pass/fail or a numeric rating"
     )
@@ -420,9 +404,7 @@ class TestRunStatusResponse(BaseModel):
         description="Test run job ID",
         examples=[_EXAMPLE_TASK_UUID],
     )
-    status: TaskStatus = Field(
-        description="Current status of the test run"
-    )
+    status: TaskStatus = Field(description="Current status of the test run")
     total_tests: Optional[int] = Field(
         None, description="Total number of test cases. Null until known"
     )
@@ -468,19 +450,23 @@ class AgentTestRunListItem(BaseModel):
     name: str = Field(
         description="Display name, e.g. `Run {index}` (unit test) or `Benchmark {index}`"
     )
-    status: TaskStatus = Field(
-        description="Job status"
-    )
+    status: TaskStatus = Field(description="Job status")
     type: AgentTestJobType = Field(description="Job type")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
     evaluators: Optional[List[TestRunEvaluator]] = Field(
-        None, description="The evaluators used in this run. See `TestRunStatusResponse.evaluators`"
+        None,
+        description="The evaluators used in this run. See `TestRunStatusResponse.evaluators`",
     )
     total_tests: Optional[int] = Field(
-        None, description="Total test cases (unit-test runs). Null for benchmarks or until known"
+        None,
+        description="Total test cases (unit-test runs). Null for benchmarks or until known",
     )
-    passed: Optional[int] = Field(None, description="Count of passing cases. Null until done")
-    failed: Optional[int] = Field(None, description="Count of failing cases. Null until done")
+    passed: Optional[int] = Field(
+        None, description="Count of passing cases. Null until done"
+    )
+    failed: Optional[int] = Field(
+        None, description="Count of failing cases. Null until done"
+    )
     results: Optional[List[TestCaseResult]] = Field(
         None, description="Per-test-case results for unit-test runs. Null otherwise"
     )
@@ -492,16 +478,19 @@ class AgentTestRunListItem(BaseModel):
         None, description="Aggregated cost for unit-test runs. Null for benchmarks"
     )
     total_tokens: Optional[Dict[str, Any]] = Field(
-        None, description="Aggregated token usage for unit-test runs. Null for benchmarks"
+        None,
+        description="Aggregated token usage for unit-test runs. Null for benchmarks",
     )
     model_results: Optional[List[Dict[str, Any]]] = Field(
         None, description="Per-model results (benchmark runs). Null for unit-test runs"
     )
     leaderboard_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Leaderboard rows comparing models (benchmark runs). Null otherwise"
+        None,
+        description="Leaderboard rows comparing models (benchmark runs). Null otherwise",
     )
     results_s3_prefix: Optional[str] = Field(
-        None, description="S3 key prefix for the raw result artifacts. Null until uploaded"
+        None,
+        description="S3 key prefix for the raw result artifacts. Null until uploaded",
     )
     error: bool = Field(False, description="True if the run failed")
     is_public: bool = Field(False, description="Whether the run is shared publicly")
@@ -532,9 +521,7 @@ class GlobalTestRunsResponse(BaseModel):
     )
 
 
-@router.post(
-    "", response_model=AgentTestsCreateResponse, summary="Link tests to agent"
-)
+@router.post("", response_model=AgentTestsCreateResponse, summary="Link tests to agent")
 async def create_agent_test_links(agent_tests: AgentTestsCreate):
     """Link one or more tests to an agent. Already-linked tests are skipped."""
     # Verify agent exists
@@ -569,9 +556,7 @@ async def create_agent_test_links(agent_tests: AgentTestsCreate):
     )
 
 
-@router.get(
-    "", response_model=List[AgentTestResponse], summary="List agent-test links"
-)
+@router.get("", response_model=List[AgentTestResponse], summary="List agent-test links")
 async def list_agent_tests():
     """List which tests are linked to which agents."""
     links = get_all_agent_tests()
@@ -690,16 +675,16 @@ async def get_agent_test_runs(
         else:
             name = f"Job {len(runs) + 1}"
 
-        run_item = AgentTestRunListItem(
-            **_build_agent_test_run_item_fields(job, name)
-        )
+        run_item = AgentTestRunListItem(**_build_agent_test_run_item_fields(job, name))
         runs.append(run_item)
 
     return AgentTestRunsResponse(runs=runs)
 
 
 @router.get(
-    "/runs", response_model=GlobalTestRunsResponse, summary="List test runs for workspace"
+    "/runs",
+    response_model=GlobalTestRunsResponse,
+    summary="List test runs for workspace",
 )
 async def get_all_test_runs_for_user(
     ctx: OrgContext = Depends(get_current_org),
@@ -1353,9 +1338,7 @@ def _build_evaluators_block_for_test_run(
     block: List[Dict[str, Any]] = []
     for uid, snap in by_uuid.items():
         ev = _get_evaluator_cached_for_enrichment(uid, cache)
-        output_type = snap.get("output_type") or (
-            ev.get("output_type") if ev else None
-        )
+        output_type = snap.get("output_type") or (ev.get("output_type") if ev else None)
         output_config = snap.get("output_config")
         if output_config is None:
             output_config = default_output_config(output_type)
@@ -1507,7 +1490,9 @@ def _enrich_model_results_with_evaluators(
             _enrich_evaluator_summary(mr.get("evaluator_summary"), cache)
 
 
-def _build_evaluator_summary(metrics_data: Optional[dict]) -> Optional[List[Dict[str, Any]]]:
+def _build_evaluator_summary(
+    metrics_data: Optional[dict],
+) -> Optional[List[Dict[str, Any]]]:
     """Extract per-evaluator benchmark aggregates from calibrate metrics.json."""
     if not isinstance(metrics_data, dict):
         return None
@@ -2375,7 +2360,7 @@ async def get_agent_test_run_status(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Poll a test run for its status, per-case results, and judge verdicts."""
+    """Poll a test run for its status and evaluation results."""
     # Public API (auth via get_org_jwt_or_api_key); ownership enforced below.
     job = _load_owned_agent_test_job(task_id, ctx)
 
@@ -2447,17 +2432,26 @@ class BenchmarkRequest(BaseModel):
 class ModelResult(BaseModel):
     model: str = Field(description="Model name these results are for")
     success: Optional[bool] = Field(
-        None, description="Whether this model's run succeeded. Null while queued/processing"
+        None,
+        description="Whether this model's run succeeded. Null while queued/processing",
     )
     message: str = Field(description="Status/result message for this model")
-    total_tests: Optional[int] = Field(None, description="Total test cases for this model. Null until known")
-    passed: Optional[int] = Field(None, description="Count of passing cases. Null until done")
-    failed: Optional[int] = Field(None, description="Count of failing cases. Null until done")
+    total_tests: Optional[int] = Field(
+        None, description="Total test cases for this model. Null until known"
+    )
+    passed: Optional[int] = Field(
+        None, description="Count of passing cases. Null until done"
+    )
+    failed: Optional[int] = Field(
+        None, description="Count of failing cases. Null until done"
+    )
     evaluator_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Aggregate summary per evaluator for this model. Null until done"
+        None,
+        description="Aggregate summary per evaluator for this model. Null until done",
     )
     test_results: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Results for each test case, for this model. Null until available"
+        None,
+        description="Results for each test case, for this model. Null until available",
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
@@ -2479,9 +2473,7 @@ class BenchmarkStatusResponse(BaseModel):
         description="Benchmark run job ID",
         examples=[_EXAMPLE_TASK_UUID],
     )
-    status: TaskStatus = Field(
-        description="Job status"
-    )
+    status: TaskStatus = Field(description="Job status")
     evaluators: Optional[List[TestRunEvaluator]] = Field(
         None,
         description="The evaluators used in this run, shared by every model (all models run the same suite). See `TestRunStatusResponse.evaluators`",
@@ -2493,7 +2485,8 @@ class BenchmarkStatusResponse(BaseModel):
         None, description="Leaderboard rows comparing the models. Null until done"
     )
     results_s3_prefix: Optional[str] = Field(
-        None, description="S3 key prefix for the raw result artifacts. Null until uploaded"
+        None,
+        description="S3 key prefix for the raw result artifacts. Null until uploaded",
     )
     error: bool = Field(False, description="True if the run failed")
     is_public: bool = Field(False, description="Whether the run is shared publicly")
@@ -2652,7 +2645,9 @@ def run_benchmark_task(
         update_agent_test_job(
             task_id,
             status=TaskStatus.IN_PROGRESS.value,
-            results={"model_results": _benchmark_queued_model_results(models, test_names)},
+            results={
+                "model_results": _benchmark_queued_model_results(models, test_names)
+            },
         )
 
         s3 = get_s3_client()
@@ -2858,11 +2853,11 @@ def run_benchmark_task(
                                 model=model,
                                 success=False,
                                 message=f"No output found for model {model}",
-                                test_results=_merge_test_results_by_test_names(
-                                    test_names, []
-                                )
-                                if test_names
-                                else None,
+                                test_results=(
+                                    _merge_test_results_by_test_names(test_names, [])
+                                    if test_names
+                                    else None
+                                ),
                             )
                         )
 
@@ -3109,9 +3104,7 @@ async def run_agent_benchmark(
             "evaluators_by_test_id": evaluators_by_test_id,
         },
         results={
-            "model_results": _benchmark_queued_model_results(
-                request.models, test_names
-            )
+            "model_results": _benchmark_queued_model_results(request.models, test_names)
         },
     )
 

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -153,7 +153,7 @@ class AgentTestsCreate(BaseModel):
     agent_uuid: str = Field(
         min_length=36,
         max_length=36,
-        description="Agent to link tests to. Must be in your workspace.",
+        description="Agent to link tests to.",
         examples=[_EXAMPLE_AGENT_UUID],
     )
     test_uuids: List[str] = Field(
@@ -2147,7 +2147,7 @@ def _launch_agent_test_run(
 )
 async def run_agent_test(
     agent_uuid: str = PathParam(
-        description="The agent to test. Must be in your workspace.",
+        description="The agent to test.",
         examples=[_EXAMPLE_AGENT_UUID],
     ),
     request: RunTestRequest = ...,
@@ -3010,7 +3010,7 @@ def run_benchmark_task(
 )
 async def run_agent_benchmark(
     agent_uuid: str = PathParam(
-        description="Agent to benchmark. Must be in your workspace.",
+        description="Agent to benchmark.",
         examples=[_EXAMPLE_AGENT_UUID],
     ),
     request: BenchmarkRequest = ...,

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -211,7 +211,7 @@ class TestResponse(BaseModel):
         description="Test type"
     )
     config: Dict[str, Any] | None = Field(
-        None, description="Test configuration; null when the test has none"
+        None, description="Test configuration. Null when the test has none"
     )
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
@@ -229,7 +229,7 @@ class AgentResponse(BaseModel):
         description="`agent` (managed defaults) or `connection` (config you supply)"
     )
     config: Dict[str, Any] | None = Field(
-        None, description="Behavioral config; null when the agent has none"
+        None, description="Behavioral config. Null when the agent has none"
     )
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
@@ -308,20 +308,20 @@ class BatchTestRunResponse(BaseModel):
 class ToolCallOutput(BaseModel):
     tool: str = Field(description="Name of the tool the agent called")
     arguments: Optional[Dict[str, Any]] = Field(
-        None, description="Arguments the agent passed to the tool; null if none"
+        None, description="Arguments the agent passed to the tool. Null if none"
     )
     output: Optional[Any] = Field(
         None,
-        description="Tool execution result (any JSON value). Present only for agent-connection tests where the external agent runs the tool and echoes its return value; null for calibrate-agent mode (tools are declared, never executed) or agents that don't echo it",
+        description="Tool execution result (any JSON value). Present only for agent-connection tests where the external agent runs the tool and echoes its return value. Null for calibrate-agent mode (tools are declared, never executed) or agents that don't echo it",
     )
 
 
 class TestOutput(BaseModel):
     response: Optional[str] = Field(
-        None, description="The agent's generated reply; null for tool-call-only cases"
+        None, description="The agent's generated reply. Null for tool-call-only cases"
     )
     tool_calls: Optional[List[ToolCallOutput]] = Field(
-        None, description="Tool calls the agent generated; null when it made none"
+        None, description="Tool calls the agent generated. Null when it made none"
     )
 
 
@@ -330,18 +330,18 @@ class JudgeResult(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="ID of the evaluator that produced this verdict; null for legacy runs or when the evaluator can't be resolved from the snapshot",
+        description="ID of the evaluator that produced this verdict. Null for legacy runs or when the evaluator can't be resolved from the snapshot",
     )
     reasoning: Optional[str] = Field(
         None, description="Judge's rationale for this verdict"
     )
     match: Optional[bool] = Field(
         None,
-        description="Binary evaluator pass/fail. **Set only for binary evaluators** (else null; `score` is set instead)",
+        description="Binary evaluator pass/fail. **Set only for binary evaluators** (else null — `score` is set instead)",
     )
     score: Optional[float] = Field(
         None,
-        description="Rating evaluator numeric score. **Set only for rating evaluators** (else null; `match` is set instead)",
+        description="Rating evaluator numeric score. **Set only for rating evaluators** (else null — `match` is set instead)",
     )
     value_name: Optional[str] = Field(
         None,
@@ -349,7 +349,7 @@ class JudgeResult(BaseModel):
     )
     variable_values: Optional[Dict[str, Any]] = Field(
         None,
-        description="`{{var}}` substitutions used for this evaluator on this test case, frozen at submission time; null when none",
+        description="`{{var}}` substitutions used for this evaluator on this test case, frozen at submission time. Null when none",
     )
 
 
@@ -358,14 +358,14 @@ class TestCaseResult(BaseModel):
         None, description="Identifier of the test case within the run"
     )
     name: Optional[str] = Field(
-        None, description="Test name; present during in-progress and done states"
+        None, description="Test name. Present during in-progress and done states"
     )
     passed: Optional[bool] = Field(
         None, description="Whether the case passed. Present only when done"
     )
     reasoning: Optional[str] = Field(
         None,
-        description="LLM judge reasoning or deterministic tool-call diff; null for passing tool-call tests",
+        description="LLM judge reasoning or deterministic tool-call diff. Null for passing tool-call tests",
     )
     output: Optional[TestOutput] = Field(
         None, description="The agent's output for this case. Present only when done"
@@ -375,11 +375,11 @@ class TestCaseResult(BaseModel):
     )
     judge_results: Optional[List[JudgeResult]] = Field(
         None,
-        description="Per-evaluator verdicts for response/conversation tests; null for tool-call tests or in-progress rows",
+        description="Per-evaluator verdicts for response/conversation tests. Null for tool-call tests or in-progress rows",
     )
     latency_ms: Optional[float] = Field(
         None,
-        description="Response-generation latency in ms for the agent under test (not the judge). Present only for live runs; null for in-progress and eval-only runs. Float, since external agents may self-report a fractional value",
+        description="Response-generation latency in ms for the agent under test (not the judge). Present only for live runs. Null for in-progress and eval-only runs. Float, since external agents may self-report a fractional value",
     )
     cost: Optional[float] = Field(
         None,
@@ -398,13 +398,13 @@ class TestRunStatusResponse(BaseModel):
         description="Current status of the test run"
     )
     total_tests: Optional[int] = Field(
-        None, description="Total number of test cases; null until known"
+        None, description="Total number of test cases. Null until known"
     )
     passed: Optional[int] = Field(
-        None, description="Number of test cases that passed; null until done"
+        None, description="Number of test cases that passed. Null until done"
     )
     failed: Optional[int] = Field(
-        None, description="Number of test cases that failed; null until done"
+        None, description="Number of test cases that failed. Null until done"
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
@@ -423,15 +423,15 @@ class TestRunStatusResponse(BaseModel):
         description="Top-level evaluator block (name/description/output_type/rubric) shared across every `judge_results` row, which references back via `evaluator_uuid` so the rubric isn't duplicated per case",
     )
     results: Optional[List[TestCaseResult]] = Field(
-        None, description="Per-test-case results; null until available"
+        None, description="Per-test-case results. Null until available"
     )
     results_s3_prefix: Optional[str] = Field(
-        None, description="S3 key prefix for the raw result artifacts; null until uploaded"
+        None, description="S3 key prefix for the raw result artifacts. Null until uploaded"
     )
     error: bool = Field(False, description="True if the run failed")
     is_public: bool = Field(False, description="Whether the run is shared publicly")
     share_token: Optional[str] = Field(
-        None, description="Public share token; null unless the run is public"
+        None, description="Public share token. Null unless the run is public"
     )
 
 
@@ -451,39 +451,39 @@ class AgentTestRunListItem(BaseModel):
     type: AgentTestJobType = Field(description="Job type")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
     evaluators: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Top-level evaluator block; see `TestRunStatusResponse.evaluators`"
+        None, description="Top-level evaluator block. See `TestRunStatusResponse.evaluators`"
     )
     total_tests: Optional[int] = Field(
-        None, description="Total test cases (unit-test runs); null for benchmarks or until known"
+        None, description="Total test cases (unit-test runs). Null for benchmarks or until known"
     )
-    passed: Optional[int] = Field(None, description="Count of passing cases; null until done")
-    failed: Optional[int] = Field(None, description="Count of failing cases; null until done")
+    passed: Optional[int] = Field(None, description="Count of passing cases. Null until done")
+    failed: Optional[int] = Field(None, description="Count of failing cases. Null until done")
     results: Optional[List[TestCaseResult]] = Field(
-        None, description="Per-test-case results for unit-test runs; null otherwise"
+        None, description="Per-test-case results for unit-test runs. Null otherwise"
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated latency for unit-test runs; null for benchmarks (per-model on `model_results`)",
+        description="Aggregated latency for unit-test runs. Null for benchmarks (per-model on `model_results`)",
     )
     cost: Optional[Dict[str, Any]] = Field(
-        None, description="Aggregated cost for unit-test runs; null for benchmarks"
+        None, description="Aggregated cost for unit-test runs. Null for benchmarks"
     )
     total_tokens: Optional[Dict[str, Any]] = Field(
-        None, description="Aggregated token usage for unit-test runs; null for benchmarks"
+        None, description="Aggregated token usage for unit-test runs. Null for benchmarks"
     )
     model_results: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Per-model results (benchmark runs); null for unit-test runs"
+        None, description="Per-model results (benchmark runs). Null for unit-test runs"
     )
     leaderboard_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Leaderboard rows comparing models (benchmark runs); null otherwise"
+        None, description="Leaderboard rows comparing models (benchmark runs). Null otherwise"
     )
     results_s3_prefix: Optional[str] = Field(
-        None, description="S3 key prefix for the raw result artifacts; null until uploaded"
+        None, description="S3 key prefix for the raw result artifacts. Null until uploaded"
     )
     error: bool = Field(False, description="True if the run failed")
     is_public: bool = Field(False, description="Whether the run is shared publicly")
     share_token: Optional[str] = Field(
-        None, description="Public share token; null unless the run is public"
+        None, description="Public share token. Null unless the run is public"
     )
 
 
@@ -760,7 +760,7 @@ class AgentTestBulkDelete(BaseModel):
         examples=[_EXAMPLE_AGENT_UUID],
     )
     test_uuids: List[str] = Field(
-        description="Tests to unlink from the agent; must be non-empty",
+        description="Tests to unlink from the agent. Must be non-empty",
         examples=[[_EXAMPLE_TEST_UUID]],
     )
 
@@ -794,7 +794,7 @@ class AgentTestsBulkDeleteAll(BaseModel):
         examples=[_EXAMPLE_AGENT_UUID],
     )
     test_uuids: List[str] = Field(
-        description="Tests to soft-delete; must be non-empty. Only tests linked to this agent in your workspace are deleted — others are skipped",
+        description="Tests to soft-delete. Must be non-empty. Only tests linked to this agent in your workspace are deleted — others are skipped",
         examples=[[_EXAMPLE_TEST_UUID]],
     )
 
@@ -1156,7 +1156,7 @@ def _parse_agent_test_results(results_data: Optional[List[dict]]) -> List[dict]:
     """Parse results.json data into the format expected by the API.
 
     `judge_results` is preserved as the raw calibrate-emitted dict
-    (``{<calibrate_name>: {reasoning, match|score}}``) for response-type tests; it
+    (``{<calibrate_name>: {reasoning, match|score}}``) for response-type tests. It
     is later converted to a structured list (with evaluator UUIDs and current DB
     names) by ``_enrich_test_results_with_evaluators`` at API read time.
     Tool-call tests have no ``judge_results`` from calibrate, so the field is None.
@@ -2045,7 +2045,7 @@ def _agent_connection_unverified(agent: Dict[str, Any]) -> bool:
     """True when a connection-type agent hasn't passed connection verification.
 
     Every test type runs the agent live, so an unverified connection means a run
-    would fail. The single-agent endpoint turns this into a 400; the batch
+    would fail. The single-agent endpoint turns this into a 400. The batch
     endpoints use it to skip-and-report rather than failing the whole batch.
     """
     agent_config = agent.get("config") or {}
@@ -2063,7 +2063,7 @@ def _launch_agent_test_run(
 
     Shared by the single-agent run endpoint and the batch run endpoints. Returns
     ``(task_id, status)``. The caller owns agent-ownership, connection-verified,
-    and non-empty ``tests`` checks; this just snapshots config and dispatches.
+    and non-empty ``tests`` checks. This just snapshots config and dispatches.
     """
     agent_uuid = agent["uuid"]
     org_uuid = agent.get("org_uuid")
@@ -2279,7 +2279,7 @@ def _load_owned_agent_test_job(task_id: str, ctx: OrgContext) -> Dict[str, Any]:
     """Fetch an agent-test job and assert the caller's workspace owns it.
 
     Ownership is derived through the job's parent agent (``agent_test_jobs`` has
-    no workspace column of its own). Returns the job dict on success; raises 404 with
+    no workspace column of its own). Returns the job dict on success. Raises 404 with
     the same generic ``"Task not found"`` detail for the missing / cross-workspace /
     orphaned cases so existence is never leaked. A soft-deleted agent makes its
     runs unreadable here (``get_agent`` filters ``deleted_at``), consistent with
@@ -2300,7 +2300,7 @@ def _load_owned_agent_test_job(task_id: str, ctx: OrgContext) -> Dict[str, Any]:
 
 class VisibilityRequest(BaseModel):
     is_public: bool = Field(
-        description="True to make the run publicly shareable (mints a share token); False to make it private"
+        description="True to make the run publicly shareable (mints a share token). False to make it private"
     )
 
 
@@ -2308,7 +2308,7 @@ class VisibilityResponse(BaseModel):
     is_public: bool = Field(description="Whether the run is now shared publicly")
     share_token: str | None = Field(
         None,
-        description="Share token to build the public URL; null when the run is private",
+        description="Share token to build the public URL. Null when the run is private",
     )
 
 
@@ -2412,7 +2412,7 @@ async def get_agent_test_run_status(
 
 class BenchmarkRequest(BaseModel):
     models: List[str] = Field(
-        description="Model names to benchmark on the same tests; must be non-empty"
+        description="Model names to benchmark on the same tests. Must be non-empty"
     )
     test_uuids: Optional[List[str]] = Field(
         None,
@@ -2424,28 +2424,28 @@ class BenchmarkRequest(BaseModel):
 class ModelResult(BaseModel):
     model: str = Field(description="Model name these results are for")
     success: Optional[bool] = Field(
-        None, description="Whether this model's run succeeded; null while queued/processing"
+        None, description="Whether this model's run succeeded. Null while queued/processing"
     )
     message: str = Field(description="Human-readable status/result message for this model")
-    total_tests: Optional[int] = Field(None, description="Total test cases for this model; null until known")
-    passed: Optional[int] = Field(None, description="Count of passing cases; null until done")
-    failed: Optional[int] = Field(None, description="Count of failing cases; null until done")
+    total_tests: Optional[int] = Field(None, description="Total test cases for this model. Null until known")
+    passed: Optional[int] = Field(None, description="Count of passing cases. Null until done")
+    failed: Optional[int] = Field(None, description="Count of failing cases. Null until done")
     evaluator_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Per-evaluator aggregate summary for this model; null until done"
+        None, description="Per-evaluator aggregate summary for this model. Null until done"
     )
     test_results: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Per-test-case results for this model; null until available"
+        None, description="Per-test-case results for this model. Null until available"
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
         description="Aggregated latency in milliseconds: `{p50, p95, p99, count}`. Null when calibrate omits it (eval-only/openai) or before this model's metrics are ready",
     )
     cost: Optional[Dict[str, Any]] = Field(
-        None, description="Aggregated cost `{mean, min, max, count}` (USD); null when unavailable"
+        None, description="Aggregated cost `{mean, min, max, count}` (USD). Null when unavailable"
     )
     total_tokens: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated token usage `{mean, min, max, count}` (values are `Any` — `mean` may be fractional); null when unavailable",
+        description="Aggregated token usage `{mean, min, max, count}` (values are `Any` — `mean` may be fractional). Null when unavailable",
     )
 
 
@@ -2461,21 +2461,21 @@ class BenchmarkStatusResponse(BaseModel):
     )
     evaluators: Optional[List[Dict[str, Any]]] = Field(
         None,
-        description="Top-level evaluator block shared by every model's results (all models run the same suite); see `TestRunStatusResponse.evaluators`",
+        description="Top-level evaluator block shared by every model's results (all models run the same suite). See `TestRunStatusResponse.evaluators`",
     )
     model_results: Optional[List[ModelResult]] = Field(
-        None, description="Per-model results; null until available"
+        None, description="Per-model results. Null until available"
     )
     leaderboard_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Leaderboard rows comparing the models; null until done"
+        None, description="Leaderboard rows comparing the models. Null until done"
     )
     results_s3_prefix: Optional[str] = Field(
-        None, description="S3 key prefix for the raw result artifacts; null until uploaded"
+        None, description="S3 key prefix for the raw result artifacts. Null until uploaded"
     )
     error: bool = Field(False, description="True if the run failed")
     is_public: bool = Field(False, description="Whether the run is shared publicly")
     share_token: Optional[str] = Field(
-        None, description="Public share token; null unless the run is public"
+        None, description="Public share token. Null unless the run is public"
     )
 
 
@@ -2491,8 +2491,8 @@ def _update_benchmark_intermediate_results(
     Returns the number of models with completed results.
 
     models: display names (original from frontend, e.g. "openai/gpt-4.1")
-    test_names: ordered suite names; pending rows are ``{name: ...}`` only, like unit tests.
-    cli_models: names passed to CLI (may be stripped, e.g. "gpt-4.1"); defaults to models
+    test_names: ordered suite names. Pending rows are ``{name: ...}`` only, like unit tests.
+    cli_models: names passed to CLI (may be stripped, e.g. "gpt-4.1"). Defaults to models
     """
     if cli_models is None:
         cli_models = models

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -313,7 +313,7 @@ class ToolCallOutput(BaseModel):
     )
     output: Optional[Any] = Field(
         None,
-        description="Tool execution result (any JSON value). Present only for agent-connection tests where the external agent runs the tool and echoes its return value. Null for calibrate-agent mode (tools are declared, never executed) or agents that don't echo it",
+        description="Tool execution result (any JSON value). Present only when the agent runs the tool and returns its result",
     )
 
 
@@ -331,7 +331,7 @@ class JudgeResult(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="ID of the evaluator that produced this verdict. Null for legacy runs or when the evaluator can't be resolved from the snapshot",
+        description="ID of the evaluator that produced this verdict",
     )
     reasoning: Optional[str] = Field(
         None, description="Judge's rationale for this verdict"
@@ -350,7 +350,7 @@ class JudgeResult(BaseModel):
     )
     variable_values: Optional[Dict[str, Any]] = Field(
         None,
-        description="`{{var}}` substitutions used for this evaluator on this test case, frozen at submission time. Null when none",
+        description="`{{var}}` substitutions used for this evaluator on this test case",
     )
 
 
@@ -359,14 +359,14 @@ class TestCaseResult(BaseModel):
         None, description="Identifier of the test case within the run"
     )
     name: Optional[str] = Field(
-        None, description="Test name. Present during in-progress and done states"
+        None, description="Test name"
     )
     passed: Optional[bool] = Field(
         None, description="Whether the case passed. Present only when done"
     )
     reasoning: Optional[str] = Field(
         None,
-        description="LLM judge reasoning or deterministic tool-call diff. Null for passing tool-call tests",
+        description="Judge reasoning, or the tool-call diff for tool-call tests",
     )
     output: Optional[TestOutput] = Field(
         None, description="The agent's output for this case. Present only when done"

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -207,7 +207,7 @@ class TestResponse(BaseModel):
         description="Test ID",
         examples=[_EXAMPLE_TEST_UUID],
     )
-    name: str = Field(description="Test name")
+    name: str = Field(description="Name of the test")
     type: TestTypeLiteral = Field(
         description="Test type"
     )
@@ -356,10 +356,10 @@ class JudgeResult(BaseModel):
 
 class TestCaseResult(BaseModel):
     test_case_id: Optional[str] = Field(
-        None, description="Identifier of the test case within the run"
+        None, description="ID of the test case within the run"
     )
     name: Optional[str] = Field(
-        None, description="Test name"
+        None, description="Name of the test"
     )
     passed: Optional[bool] = Field(
         None, description="Whether the case passed. Present only when done"
@@ -389,8 +389,8 @@ class TestCaseResult(BaseModel):
 
 
 class TestRunEvaluator(BaseModel):
-    uuid: Optional[str] = Field(None, description="Evaluator ID")
-    name: Optional[str] = Field(None, description="Evaluator name")
+    uuid: Optional[str] = Field(None, description="ID of the evaluator")
+    name: Optional[str] = Field(None, description="Name of the evaluator")
     description: Optional[str] = Field(
         None, description="What the evaluator checks"
     )

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -227,7 +227,7 @@ class AgentResponse(BaseModel):
     )
     name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` (managed defaults) or `connection` (config you supply)"
+        description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
     )
     config: Dict[str, Any] | None = Field(
         None, description="Behavioral config. Null when the agent has none"

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -408,7 +408,7 @@ class TestRunStatusResponse(BaseModel):
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated response latency `{p50, p95, p99, count}` (ms; `p50` ≈ the old mean). Null for eval-only runs",
+        description="Aggregated response latency in milliseconds: `{p50, p95, p99, count}`. Null for eval-only runs",
     )
     cost: Optional[Dict[str, Any]] = Field(
         None,
@@ -2438,7 +2438,7 @@ class ModelResult(BaseModel):
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated latency `{p50, p95, p99, count}` (ms; `p50` ≈ the old mean). Null when calibrate omits it (eval-only/openai) or before this model's metrics are ready",
+        description="Aggregated latency in milliseconds: `{p50, p95, p99, count}`. Null when calibrate omits it (eval-only/openai) or before this model's metrics are ready",
     )
     cost: Optional[Dict[str, Any]] = Field(
         None, description="Aggregated cost `{mean, min, max, count}` (USD); null when unavailable"

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -412,11 +412,11 @@ class TestRunStatusResponse(BaseModel):
     )
     cost: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated cost `{mean, min, max, count}` (USD). Null when no case reported a cost (e.g. openai provider)",
+        description="Aggregated cost `{mean, min, max, count}` (USD)",
     )
     total_tokens: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated token usage `{mean, min, max, count}` (values are `Any` — `mean` may be fractional). Null when no case reported usage",
+        description="Aggregated token usage `{mean, min, max, count}`",
     )
     evaluators: Optional[List[Dict[str, Any]]] = Field(
         None,
@@ -2441,11 +2441,11 @@ class ModelResult(BaseModel):
         description="Aggregated latency in milliseconds: `{p50, p95, p99, count}`. Null before this model's metrics are ready",
     )
     cost: Optional[Dict[str, Any]] = Field(
-        None, description="Aggregated cost `{mean, min, max, count}` (USD). Null when unavailable"
+        None, description="Aggregated cost `{mean, min, max, count}` (USD)"
     )
     total_tokens: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated token usage `{mean, min, max, count}` (values are `Any` — `mean` may be fractional). Null when unavailable",
+        description="Aggregated token usage `{mean, min, max, count}`",
     )
 
 

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -46,6 +46,7 @@ from utils import (
     InitialTaskStatus,
     TaskCreateResponse,
     TestTypeLiteral,
+    OutputTypeLiteral,
     AgentTestJobType,
     get_s3_client,
     get_s3_output_config,
@@ -375,7 +376,7 @@ class TestCaseResult(BaseModel):
     )
     judge_results: Optional[List[JudgeResult]] = Field(
         None,
-        description="Per-evaluator verdicts for response/conversation tests. Null for tool-call tests or in-progress rows",
+        description="One verdict per evaluator, for response and conversation tests. Null for tool-call tests or rows still running",
     )
     latency_ms: Optional[float] = Field(
         None,
@@ -384,6 +385,30 @@ class TestCaseResult(BaseModel):
     cost: Optional[float] = Field(
         None,
         description="Per-case cost in USD, lifted from calibrate's nested `output.cost`. Null when the provider/agent reports none (e.g. `--provider openai`)",
+    )
+
+
+class RunEvaluator(BaseModel):
+    uuid: Optional[str] = Field(None, description="Evaluator ID")
+    name: Optional[str] = Field(None, description="Evaluator name")
+    description: Optional[str] = Field(
+        None, description="What the evaluator checks"
+    )
+    output_type: Optional[OutputTypeLiteral] = Field(
+        None, description="Verdict shape: pass/fail or a numeric rating"
+    )
+    output_config: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Rubric — the scale values, labels, and colors a verdict maps to",
+    )
+    scale_min: Optional[float] = Field(
+        None, description="Lowest rating value. Set for rating evaluators"
+    )
+    scale_max: Optional[float] = Field(
+        None, description="Highest rating value. Set for rating evaluators"
+    )
+    version_number: Optional[int] = Field(
+        None, description="Evaluator version this run used"
     )
 
 
@@ -418,12 +443,12 @@ class TestRunStatusResponse(BaseModel):
         None,
         description="Aggregated token usage `{mean, min, max, count}`",
     )
-    evaluators: Optional[List[Dict[str, Any]]] = Field(
+    evaluators: Optional[List[RunEvaluator]] = Field(
         None,
-        description="Top-level evaluator block (name/description/output_type/rubric) shared across every `judge_results` row, which references back via `evaluator_uuid` so the rubric isn't duplicated per case",
+        description="The evaluators used in this run. Each verdict in `judge_results` links to one of these by `evaluator_uuid`",
     )
     results: Optional[List[TestCaseResult]] = Field(
-        None, description="Per-test-case results. Null until available"
+        None, description="Results for each test case. Null until available"
     )
     results_s3_prefix: Optional[str] = Field(
         None, description="S3 key prefix for the raw result artifacts. Null until uploaded"
@@ -450,8 +475,8 @@ class AgentTestRunListItem(BaseModel):
     )
     type: AgentTestJobType = Field(description="Job type")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
-    evaluators: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Top-level evaluator block. See `TestRunStatusResponse.evaluators`"
+    evaluators: Optional[List[RunEvaluator]] = Field(
+        None, description="The evaluators used in this run. See `TestRunStatusResponse.evaluators`"
     )
     total_tests: Optional[int] = Field(
         None, description="Total test cases (unit-test runs). Null for benchmarks or until known"
@@ -2431,10 +2456,10 @@ class ModelResult(BaseModel):
     passed: Optional[int] = Field(None, description="Count of passing cases. Null until done")
     failed: Optional[int] = Field(None, description="Count of failing cases. Null until done")
     evaluator_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Per-evaluator aggregate summary for this model. Null until done"
+        None, description="Aggregate summary per evaluator for this model. Null until done"
     )
     test_results: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Per-test-case results for this model. Null until available"
+        None, description="Results for each test case, for this model. Null until available"
     )
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
@@ -2459,9 +2484,9 @@ class BenchmarkStatusResponse(BaseModel):
     status: TaskStatus = Field(
         description="Job status"
     )
-    evaluators: Optional[List[Dict[str, Any]]] = Field(
+    evaluators: Optional[List[RunEvaluator]] = Field(
         None,
-        description="Top-level evaluator block shared by every model's results (all models run the same suite). See `TestRunStatusResponse.evaluators`",
+        description="The evaluators used in this run, shared by every model (all models run the same suite). See `TestRunStatusResponse.evaluators`",
     )
     model_results: Optional[List[ModelResult]] = Field(
         None, description="Per-model results. Null until available"

--- a/src/routers/agent_tests.py
+++ b/src/routers/agent_tests.py
@@ -388,7 +388,7 @@ class TestCaseResult(BaseModel):
     )
 
 
-class RunEvaluator(BaseModel):
+class TestRunEvaluator(BaseModel):
     uuid: Optional[str] = Field(None, description="Evaluator ID")
     name: Optional[str] = Field(None, description="Evaluator name")
     description: Optional[str] = Field(
@@ -443,7 +443,7 @@ class TestRunStatusResponse(BaseModel):
         None,
         description="Aggregated token usage `{mean, min, max, count}`",
     )
-    evaluators: Optional[List[RunEvaluator]] = Field(
+    evaluators: Optional[List[TestRunEvaluator]] = Field(
         None,
         description="The evaluators used in this run. Each verdict in `judge_results` links to one of these by `evaluator_uuid`",
     )
@@ -472,7 +472,7 @@ class AgentTestRunListItem(BaseModel):
     )
     type: AgentTestJobType = Field(description="Job type")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
-    evaluators: Optional[List[RunEvaluator]] = Field(
+    evaluators: Optional[List[TestRunEvaluator]] = Field(
         None, description="The evaluators used in this run. See `TestRunStatusResponse.evaluators`"
     )
     total_tests: Optional[int] = Field(
@@ -2481,7 +2481,7 @@ class BenchmarkStatusResponse(BaseModel):
     status: TaskStatus = Field(
         description="Job status"
     )
-    evaluators: Optional[List[RunEvaluator]] = Field(
+    evaluators: Optional[List[TestRunEvaluator]] = Field(
         None,
         description="The evaluators used in this run, shared by every model (all models run the same suite). See `TestRunStatusResponse.evaluators`",
     )

--- a/src/routers/agent_tools.py
+++ b/src/routers/agent_tools.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from sqlite3 import IntegrityError
 
 from auth_utils import get_current_org, OrgContext
+from utils import AGENT_TYPE_DESCRIPTION
 from db import (
     add_tool_to_agent,
     remove_tool_from_agent,
@@ -98,7 +99,7 @@ class AgentResponse(BaseModel):
     )
     name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
+        description=AGENT_TYPE_DESCRIPTION
     )
     config: Dict[str, Any] | None = Field(
         None, description="Behavioral config. Null when the agent has none"

--- a/src/routers/agent_tools.py
+++ b/src/routers/agent_tools.py
@@ -98,7 +98,7 @@ class AgentResponse(BaseModel):
     )
     name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` applies managed defaults. `connection` stores the config you supply as-is"
+        description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
     )
     config: Dict[str, Any] | None = Field(
         None, description="Behavioral config. Null when the agent has none"

--- a/src/routers/agent_tools.py
+++ b/src/routers/agent_tools.py
@@ -83,7 +83,7 @@ class ToolResponse(BaseModel):
     name: str = Field(description="Human-readable tool name")
     description: str = Field(description="What the tool does")
     config: Dict[str, Any] | None = Field(
-        None, description="Tool configuration; null when the tool has none"
+        None, description="Tool configuration. Null when the tool has none"
     )
     created_at: str = Field(description="When the tool was created (ISO 8601 UTC)")
     updated_at: str = Field(description="When the tool was last updated (ISO 8601 UTC)")
@@ -98,10 +98,10 @@ class AgentResponse(BaseModel):
     )
     name: str = Field(description="Human-readable agent name")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` applies managed defaults; `connection` stores the config you supply as-is"
+        description="`agent` applies managed defaults. `connection` stores the config you supply as-is"
     )
     config: Dict[str, Any] | None = Field(
-        None, description="Behavioral config; null when the agent has none"
+        None, description="Behavioral config. Null when the agent has none"
     )
     created_at: str = Field(description="When the agent was created (ISO 8601 UTC)")
     updated_at: str = Field(description="When the agent was last updated (ISO 8601 UTC)")

--- a/src/routers/agent_tools.py
+++ b/src/routers/agent_tools.py
@@ -129,7 +129,7 @@ async def create_agent_tool_links(
     agent_tools: AgentToolsCreate,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Link one or more tools to an agent. Already-linked tools are skipped."""
+    """Link one or more tools to an agent. Already-linked tools are skipped"""
     _require_owned_agent(agent_tools.agent_uuid, ctx.org_uuid)
     for tool_uuid in agent_tools.tool_uuids:
         _require_owned_tool(tool_uuid, ctx.org_uuid)
@@ -157,7 +157,7 @@ async def create_agent_tool_links(
     "", response_model=List[AgentToolResponse], summary="List agent-tool links"
 )
 async def list_agent_tools(ctx: OrgContext = Depends(get_current_org)):
-    """List which tools are linked to which agents."""
+    """List which tools are linked to which agents"""
     return get_all_agent_tools(org_uuid=ctx.org_uuid)
 
 
@@ -173,7 +173,7 @@ async def get_agent_tools(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List the tools linked to an agent."""
+    """List the tools linked to an agent"""
     _require_owned_agent(agent_uuid, ctx.org_uuid)
     return get_tools_for_agent(agent_uuid)
 
@@ -190,7 +190,7 @@ async def get_tool_agents(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List the agents a tool is linked to."""
+    """List the agents a tool is linked to"""
     _require_owned_tool(tool_uuid, ctx.org_uuid)
     return get_agents_for_tool(tool_uuid)
 
@@ -199,7 +199,7 @@ async def get_tool_agents(
 async def delete_agent_tool_link(
     agent_tool: AgentToolDelete, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Unlink a tool from an agent so the agent can no longer call it."""
+    """Unlink a tool from an agent so the agent can no longer call it"""
     _require_owned_agent(agent_tool.agent_uuid, ctx.org_uuid)
     deleted = remove_tool_from_agent(agent_tool.agent_uuid, agent_tool.tool_uuid)
     if not deleted:

--- a/src/routers/agent_tools.py
+++ b/src/routers/agent_tools.py
@@ -70,7 +70,7 @@ class AgentToolsCreateResponse(BaseModel):
     ids: List[int] = Field(
         description="Link row IDs created this call (excludes tools that were already linked)"
     )
-    message: str = Field(description="Human-readable confirmation message")
+    message: str = Field(description="Confirmation message")
 
 
 class ToolResponse(BaseModel):
@@ -80,7 +80,7 @@ class ToolResponse(BaseModel):
         description="ID of the tool",
         examples=[_EXAMPLE_ID],
     )
-    name: str = Field(description="Human-readable tool name")
+    name: str = Field(description="Tool name")
     description: str = Field(description="What the tool does")
     config: Dict[str, Any] | None = Field(
         None, description="Tool configuration. Null when the tool has none"
@@ -96,7 +96,7 @@ class AgentResponse(BaseModel):
         description="ID of the agent",
         examples=[_EXAMPLE_ID],
     )
-    name: str = Field(description="Human-readable agent name")
+    name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
         description="`agent` applies managed defaults. `connection` stores the config you supply as-is"
     )

--- a/src/routers/agent_tools.py
+++ b/src/routers/agent_tools.py
@@ -157,7 +157,7 @@ async def create_agent_tool_links(
     "", response_model=List[AgentToolResponse], summary="List agent-tool links"
 )
 async def list_agent_tools(ctx: OrgContext = Depends(get_current_org)):
-    """List all agent-tool links in your workspace."""
+    """List all agent-tool links."""
     return get_all_agent_tools(org_uuid=ctx.org_uuid)
 
 

--- a/src/routers/agent_tools.py
+++ b/src/routers/agent_tools.py
@@ -157,7 +157,7 @@ async def create_agent_tool_links(
     "", response_model=List[AgentToolResponse], summary="List agent-tool links"
 )
 async def list_agent_tools(ctx: OrgContext = Depends(get_current_org)):
-    """List all agent-tool links."""
+    """List which tools are linked to which agents."""
     return get_all_agent_tools(org_uuid=ctx.org_uuid)
 
 
@@ -199,7 +199,7 @@ async def get_tool_agents(
 async def delete_agent_tool_link(
     agent_tool: AgentToolDelete, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Unlink a tool from an agent."""
+    """Unlink a tool from an agent so the agent can no longer call it."""
     _require_owned_agent(agent_tool.agent_uuid, ctx.org_uuid)
     deleted = remove_tool_from_agent(agent_tool.agent_uuid, agent_tool.tool_uuid)
     if not deleted:

--- a/src/routers/agent_tools.py
+++ b/src/routers/agent_tools.py
@@ -26,7 +26,7 @@ class AgentToolsCreate(BaseModel):
     agent_uuid: str = Field(
         min_length=36,
         max_length=36,
-        description="The agent to link tools to. Must be in your workspace.",
+        description="The agent to link tools to.",
         examples=[_EXAMPLE_ID],
     )
     tool_uuids: List[str] = Field(
@@ -39,7 +39,7 @@ class AgentToolDelete(BaseModel):
     agent_uuid: str = Field(
         min_length=36,
         max_length=36,
-        description="The agent to unlink a tool from. Must be in your workspace.",
+        description="The agent to unlink a tool from.",
         examples=[_EXAMPLE_ID],
     )
     tool_uuid: str = Field(
@@ -168,7 +168,7 @@ async def list_agent_tools(ctx: OrgContext = Depends(get_current_org)):
 )
 async def get_agent_tools(
     agent_uuid: str = Path(
-        description="The agent whose linked tools to list. Must be in your workspace.",
+        description="The agent whose linked tools to list.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -185,7 +185,7 @@ async def get_agent_tools(
 )
 async def get_tool_agents(
     tool_uuid: str = Path(
-        description="The tool whose linked agents to list. Must be in your workspace.",
+        description="The tool whose linked agents to list.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -215,7 +215,7 @@ _VERIFICATION_CONFIG_KEYS = (
 
 
 def _strip_verification_fields(
-    config: Optional[Dict[str, Any]]
+    config: Optional[Dict[str, Any]],
 ) -> Optional[Dict[str, Any]]:
     """Remove server-owned verification flags from a caller-supplied config dict.
 
@@ -233,6 +233,44 @@ def _strip_verification_fields(
     return config
 
 
+# Full agent-config schema, shared by create + update so it renders identically.
+# Free-form on purpose (see the type-decision note): the shape is a discriminated
+# union by `type` plus open extension keys, so it's documented, not enforced.
+_AGENT_CONFIG_DESCRIPTION = """Agent behavioral config. The keys depend on `type`.
+
+**`type=agent`** (built inside Calibrate):
+- `system_prompt` (string): the agent's instructions
+- `llm.model` (string): `provider/model`, e.g. `openai/gpt-4.1` or `google/gemini-2.5-flash`
+- `stt.provider` (string): `deepgram`, `openai`, `cartesia`, `elevenlabs`, `google`, `sarvam`, or `smallest`
+- `tts.provider` (string): `cartesia`, `openai`, `google`, `elevenlabs`, `sarvam`, or `smallest`
+- `settings.agent_speaks_first` (bool), `settings.max_assistant_turns` (int)
+- `system_tools.end_call` (bool, optional): let the agent end the call
+- `data_extraction_fields` (array, optional): `[{name, type, description, required}]`
+
+```json
+{
+  "system_prompt": "You are a helpful support agent.",
+  "llm": {"model": "openai/gpt-4.1"},
+  "stt": {"provider": "deepgram"},
+  "tts": {"provider": "elevenlabs"},
+  "settings": {"agent_speaks_first": true, "max_assistant_turns": 50}
+}
+```
+
+**`type=connection`** (your own HTTP endpoint):
+- `agent_url` (string, required): public HTTPS endpoint the agent is called at
+- `agent_headers` (object, optional): headers sent on each request, e.g. auth
+- `benchmark_provider` (string, optional): `openrouter` (default), `openai`, `google`, `anthropic`, `meta-llama`, `mistralai`, `deepseek`, `x-ai`, `cohere`, `qwen`, or `ai21`
+
+```json
+{
+  "agent_url": "https://api.example.com/agent",
+  "agent_headers": {"Authorization": "Bearer <token>"},
+  "benchmark_provider": "openrouter"
+}
+```"""
+
+
 class AgentCreate(BaseModel):
     name: str = Field(description="Agent name, unique within the workspace")
     type: Literal["agent", "connection"] = Field(
@@ -241,7 +279,8 @@ class AgentCreate(BaseModel):
     )
     config: Optional[Dict[str, Any]] = Field(
         None,
-        description="Behavioral config (system_prompt, llm, stt, tts, settings, …). Deep-merged over defaults for `type=agent`. Stored as-is for `type=connection` (must contain `agent_url`). Omit for `type=agent` to use defaults",
+        description=_AGENT_CONFIG_DESCRIPTION
+        + "\n\nFor `type=agent`, omitted keys inherit managed defaults (omit `config` entirely to use all defaults). For `type=connection`, `config` is stored as-is and must contain `agent_url`.",
     )
 
 
@@ -251,7 +290,8 @@ class AgentUpdate(BaseModel):
     )
     config: Optional[Dict[str, Any]] = Field(
         None,
-        description="New config for the agent. Omit to leave unchanged. For `type=connection` agents, changing `agent_url` or `agent_headers` resets the connection and benchmark verification flags",
+        description=_AGENT_CONFIG_DESCRIPTION
+        + "\n\nReplaces the stored config (no deep-merge). Omit to leave unchanged. For `type=connection`, changing `agent_url` or `agent_headers` resets the connection and benchmark verification flags.",
     )
     connection_verified: Optional[bool] = Field(
         None,
@@ -272,11 +312,11 @@ class AgentResponse(BaseModel):
     )
     name: str = Field(description="Name of the agent")
     type: Literal["agent", "connection"] = Field(description=AGENT_TYPE_DESCRIPTION)
-    config: Optional[Dict[str, Any]] = Field(
-        None, description="Agent configuration"
-    )
+    config: Optional[Dict[str, Any]] = Field(None, description="Agent configuration")
     created_at: str = Field(description="When the agent was created (ISO 8601 UTC)")
-    updated_at: str = Field(description="When the agent was last updated (ISO 8601 UTC)")
+    updated_at: str = Field(
+        description="When the agent was last updated (ISO 8601 UTC)"
+    )
 
 
 class AgentCreateResponse(BaseModel):
@@ -344,9 +384,7 @@ class VerifyConnectionResponse(BaseModel):
     success: bool = Field(
         description="True if the agent responded successfully to the verification probe"
     )
-    error: Optional[str] = Field(
-        None, description="Failure reason. Null on success"
-    )
+    error: Optional[str] = Field(None, description="Failure reason. Null on success")
     sample_response: Optional[Dict[str, Any]] = Field(
         None,
         description="Sample output returned by the agent during verification. Null when unavailable",
@@ -509,7 +547,7 @@ async def create_agent_endpoint(
     summary="List agents",
 )
 async def list_agents(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
-    """List your agents, each with its type and config."""
+    """Get the list of all your agents."""
     # Public API. Auth via get_org_jwt_or_api_key (JWT for the web app, API key
     # for CI); the run/poll and /resolve endpoints accept the same key, so CI can
     # enumerate agent UUIDs without knowing names up front.

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -291,7 +291,7 @@ class AgentUpdate(BaseModel):
     config: Optional[Dict[str, Any]] = Field(
         None,
         description=_AGENT_CONFIG_DESCRIPTION
-        + "\n\nReplaces the stored config (no deep-merge). Omit to leave unchanged. For `type=connection`, changing `agent_url` or `agent_headers` resets the connection and benchmark verification flags.",
+        + "\n\nReplaces the stored config. Omit to leave unchanged. For `type=connection`, changing `agent_url` or `agent_headers` resets the connection and benchmark verification flags.",
     )
     connection_verified: Optional[bool] = Field(
         None,
@@ -494,7 +494,7 @@ async def resolve_agent_names(
     request: ResolveAgentNamesRequest,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Look up agent IDs by name, to reference agents in other calls."""
+    """Get the IDs for your agents by their names."""
     # Public API. Auth via get_org_jwt_or_api_key (JWT for the web app, API key
     # for CI). Maps human-friendly names to the UUIDs the run/poll endpoints expect.
     agents = get_all_agents(org_uuid=ctx.org_uuid)
@@ -520,7 +520,7 @@ async def resolve_agent_names(
 async def create_agent_endpoint(
     agent: AgentCreate, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create an agent to test, either one built inside Calibrate or a connection to your own endpoint."""
+    """Create an agent to test inside Calibrate or connect your existing agent to Calibrate."""
     if agent.type == "agent":
         merged_config = _deep_merge(_default_agent_config(), agent.config or {})
     else:
@@ -568,7 +568,7 @@ async def get_agent_endpoint(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Get one agent by ID, including its config and connection status."""
+    """Get one agent by its ID"""
     agent = get_agent(agent_uuid)
     if not agent or agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")
@@ -589,7 +589,7 @@ async def update_agent_endpoint(
     agent: AgentUpdate = ...,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Update an agent's config, e.g. to change its model or repoint a connection to a new endpoint."""
+    """Update an agent's configuration"""
     existing_agent = get_agent(agent_uuid)
     if not existing_agent or existing_agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -482,7 +482,7 @@ async def resolve_agent_names(
 async def create_agent_endpoint(
     agent: AgentCreate, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create a new agent in your workspace. For `type=agent`, defaults are deep-merged with any config you supply."""
+    """Create a new agent."""
     if agent.type == "agent":
         merged_config = _deep_merge(_default_agent_config(), agent.config or {})
     else:
@@ -509,7 +509,7 @@ async def create_agent_endpoint(
     summary="List agents",
 )
 async def list_agents(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
-    """List all agents in your workspace."""
+    """List all agents."""
     # Public API. Auth via get_org_jwt_or_api_key (JWT for the web app, API key
     # for CI); the run/poll and /resolve endpoints accept the same key, so CI can
     # enumerate agent UUIDs without knowing names up front.
@@ -530,7 +530,7 @@ async def get_agent_endpoint(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Get an agent in your workspace."""
+    """Get an agent."""
     agent = get_agent(agent_uuid)
     if not agent or agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")
@@ -607,7 +607,7 @@ async def delete_agent_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete an agent in your workspace."""
+    """Soft-delete an agent."""
     existing_agent = get_agent(agent_uuid)
     if not existing_agent or existing_agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -237,7 +237,7 @@ class AgentCreate(BaseModel):
     name: str = Field(description="Human-readable agent name, unique within the workspace")
     type: Literal["agent", "connection"] = Field(
         "agent",
-        description="`agent` applies managed defaults deep-merged under any supplied `config`. `connection` stores the config you supply as-is (must eventually contain `agent_url`)",
+        description="`agent` (built inside Calibrate) applies managed defaults deep-merged under any supplied `config`. `connection` (your existing agent, via its own endpoint) stores the config you supply as-is (must eventually contain `agent_url`)",
     )
     config: Optional[Dict[str, Any]] = Field(
         None,
@@ -272,7 +272,7 @@ class AgentResponse(BaseModel):
     )
     name: str = Field(description="Human-readable name of the agent")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` (managed defaults) or `connection` (your own endpoint)"
+        description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
     )
     config: Optional[Dict[str, Any]] = Field(
         None, description="Agent configuration"

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -234,7 +234,7 @@ def _strip_verification_fields(
 
 
 class AgentCreate(BaseModel):
-    name: str = Field(description="Human-readable agent name, unique within the workspace")
+    name: str = Field(description="Agent name, unique within the workspace")
     type: Literal["agent", "connection"] = Field(
         "agent",
         description="`agent` (built inside Calibrate) applies managed defaults deep-merged under any supplied `config`. `connection` (your existing agent, via its own endpoint) stores the config you supply as-is (must eventually contain `agent_url`)",
@@ -270,7 +270,7 @@ class AgentResponse(BaseModel):
         description="ID of the agent",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     )
-    name: str = Field(description="Human-readable name of the agent")
+    name: str = Field(description="Name of the agent")
     type: Literal["agent", "connection"] = Field(
         description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
     )
@@ -288,7 +288,7 @@ class AgentCreateResponse(BaseModel):
         description="ID of the newly created agent",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     )
-    message: str = Field(description="Human-readable confirmation message")
+    message: str = Field(description="Confirmation message")
 
 
 class AgentDuplicateRequest(BaseModel):
@@ -304,7 +304,7 @@ class AgentDuplicateResponse(BaseModel):
         description="ID of the newly created duplicate agent",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     )
-    message: str = Field(description="Human-readable confirmation message")
+    message: str = Field(description="Confirmation message")
 
 
 class ResolveAgentNamesRequest(BaseModel):

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -255,11 +255,11 @@ class AgentUpdate(BaseModel):
     )
     connection_verified: Optional[bool] = Field(
         None,
-        description="Directly set the `connection_verified` flag inside config. Omit to leave it untouched",
+        description="Set the connection verification flag for a `type=connection` agent. Omit to leave it untouched",
     )
     benchmark_models_verified: Optional[Dict[str, Any]] = Field(
         None,
-        description="Directly set the per-model benchmark verification map inside config. Omit to leave it untouched",
+        description="Set the per-model benchmark verification map for a `type=connection` agent. Omit to leave it untouched",
     )
 
 

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -291,7 +291,8 @@ class AgentUpdate(BaseModel):
     config: Optional[Dict[str, Any]] = Field(
         None,
         description=_AGENT_CONFIG_DESCRIPTION
-        + "\n\nReplaces the stored config. Omit to leave unchanged. For `type=connection`, changing `agent_url` or `agent_headers` resets the connection and benchmark verification flags.",
+        + "\n\nReplaces the stored config. Omit to leave unchanged."
+        + "\n\nFor `type=connection`, changing `agent_url` or `agent_headers` resets the connection and benchmark verification flags.",
     )
     connection_verified: Optional[bool] = Field(
         None,
@@ -400,7 +401,7 @@ async def verify_agent_connection_presave(
     request: VerifyConnectionRequest,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Verify an agent connection before saving an agent. Nothing is persisted."""
+    """Verify an agent connection before saving an agent. Nothing is persisted"""
     if not request.agent_url:
         raise HTTPException(status_code=400, detail="agent_url is required")
 
@@ -426,7 +427,7 @@ async def verify_agent_connection(
     request: VerifyConnectionRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Verify a saved agent's connection and persist the result when successful."""
+    """Verify a saved agent's connection and persist the result when successful"""
     agent = get_agent(agent_uuid)
     if not agent or agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")
@@ -494,7 +495,7 @@ async def resolve_agent_names(
     request: ResolveAgentNamesRequest,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Get the IDs for your agents by their names."""
+    """Get the IDs for your agents by their names"""
     # Public API. Auth via get_org_jwt_or_api_key (JWT for the web app, API key
     # for CI). Maps human-friendly names to the UUIDs the run/poll endpoints expect.
     agents = get_all_agents(org_uuid=ctx.org_uuid)
@@ -520,7 +521,7 @@ async def resolve_agent_names(
 async def create_agent_endpoint(
     agent: AgentCreate, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create an agent to test inside Calibrate or connect your existing agent to Calibrate."""
+    """Create an agent to test inside Calibrate or connect your existing agent to Calibrate"""
     if agent.type == "agent":
         merged_config = _deep_merge(_default_agent_config(), agent.config or {})
     else:
@@ -547,7 +548,7 @@ async def create_agent_endpoint(
     summary="List agents",
 )
 async def list_agents(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
-    """Get the list of all your agents."""
+    """Get the list of all your agents"""
     # Public API. Auth via get_org_jwt_or_api_key (JWT for the web app, API key
     # for CI); the run/poll and /resolve endpoints accept the same key, so CI can
     # enumerate agent UUIDs without knowing names up front.
@@ -645,7 +646,7 @@ async def delete_agent_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete an agent."""
+    """Soft-delete an agent"""
     existing_agent = get_agent(agent_uuid)
     if not existing_agent or existing_agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")
@@ -669,7 +670,7 @@ async def duplicate_agent_endpoint(
     request: AgentDuplicateRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Duplicate an agent along with its linked tools and tests. Verification flags are not copied."""
+    """Duplicate an agent along with its linked tools and tests. Verification flags are not copied"""
     original_agent = get_agent(agent_uuid)
     if not original_agent or original_agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, HTTPException, Depends, Path
 from pydantic import BaseModel, Field
 from calibrate_agent.connections import TextAgentConnection
 
-from utils import env_bool, env_int, env_str
+from utils import env_bool, env_int, env_str, AGENT_TYPE_DESCRIPTION
 
 from db import (
     create_agent,
@@ -237,11 +237,11 @@ class AgentCreate(BaseModel):
     name: str = Field(description="Agent name, unique within the workspace")
     type: Literal["agent", "connection"] = Field(
         "agent",
-        description="`agent` (built inside Calibrate) applies managed defaults deep-merged under any supplied `config`. `connection` (your existing agent, via its own endpoint) stores the config you supply as-is (must eventually contain `agent_url`)",
+        description=AGENT_TYPE_DESCRIPTION,
     )
     config: Optional[Dict[str, Any]] = Field(
         None,
-        description="Behavioral config (system_prompt, llm, stt, tts, settings, …). Deep-merged over defaults for `type=agent`. Stored as-is for `type=connection`. Omit for `type=agent` to use defaults",
+        description="Behavioral config (system_prompt, llm, stt, tts, settings, …). Deep-merged over defaults for `type=agent`. Stored as-is for `type=connection` (must contain `agent_url`). Omit for `type=agent` to use defaults",
     )
 
 
@@ -251,7 +251,7 @@ class AgentUpdate(BaseModel):
     )
     config: Optional[Dict[str, Any]] = Field(
         None,
-        description="Replacement config, stored as-is (no deep-merge on update). Changing `agent_url` or `agent_headers` resets all connection/benchmark verification flags. Omit to leave config unchanged",
+        description="New config for the agent. Omit to leave unchanged. For `type=connection` agents, changing `agent_url` or `agent_headers` resets the connection and benchmark verification flags",
     )
     connection_verified: Optional[bool] = Field(
         None,
@@ -271,9 +271,7 @@ class AgentResponse(BaseModel):
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     )
     name: str = Field(description="Name of the agent")
-    type: Literal["agent", "connection"] = Field(
-        description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
-    )
+    type: Literal["agent", "connection"] = Field(description=AGENT_TYPE_DESCRIPTION)
     config: Optional[Dict[str, Any]] = Field(
         None, description="Agent configuration"
     )
@@ -553,7 +551,7 @@ async def update_agent_endpoint(
     agent: AgentUpdate = ...,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Update an agent's name and/or config. Changing `agent_url` or `agent_headers` resets connection and benchmark verification flags."""
+    """Update an agent's name and/or config."""
     existing_agent = get_agent(agent_uuid)
     if not existing_agent or existing_agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -193,7 +193,7 @@ def _default_agent_config() -> Dict[str, Any]:
 def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
     """Recursively merge `override` into a copy of `base`. Caller wins per key.
 
-    Dict-vs-dict at the same key recurses; anything else (scalar, list, None)
+    Dict-vs-dict at the same key recurses. Anything else (scalar, list, None)
     in `override` replaces the corresponding `base` value entirely.
     """
     result = copy.deepcopy(base)
@@ -237,11 +237,11 @@ class AgentCreate(BaseModel):
     name: str = Field(description="Human-readable agent name, unique within the workspace")
     type: Literal["agent", "connection"] = Field(
         "agent",
-        description="`agent` applies managed defaults deep-merged under any supplied `config`; `connection` stores the config you supply as-is (must eventually contain `agent_url`)",
+        description="`agent` applies managed defaults deep-merged under any supplied `config`. `connection` stores the config you supply as-is (must eventually contain `agent_url`)",
     )
     config: Optional[Dict[str, Any]] = Field(
         None,
-        description="Behavioral config (system_prompt, llm, stt, tts, settings, …). Deep-merged over defaults for `type=agent`; stored as-is for `type=connection`. Omit for `type=agent` to use defaults",
+        description="Behavioral config (system_prompt, llm, stt, tts, settings, …). Deep-merged over defaults for `type=agent`. Stored as-is for `type=connection`. Omit for `type=agent` to use defaults",
     )
 
 
@@ -326,7 +326,7 @@ class ResolveAgentNamesResponse(BaseModel):
 class VerifyConnectionRequest(BaseModel):
     agent_url: Optional[str] = Field(
         None,
-        description="Public HTTP(S) agent endpoint to verify. **Required for the pre-save endpoint** (no agent ID); ignored by the saved-agent endpoint, which reads `agent_url` from the stored config",
+        description="Public HTTP(S) agent endpoint to verify. **Required for the pre-save endpoint** (no agent ID). Ignored by the saved-agent endpoint, which reads `agent_url` from the stored config",
     )
     agent_headers: Optional[Dict[str, str]] = Field(
         None,
@@ -334,7 +334,7 @@ class VerifyConnectionRequest(BaseModel):
     )
     model: Optional[str] = Field(
         None,
-        description="Model to verify. Omit for a basic connection check; provide it for a model-specific check required before benchmarking that model",
+        description="Model to verify. Omit for a basic connection check. Provide it for a model-specific check required before benchmarking that model",
     )
     messages: Optional[List[Dict[str, str]]] = Field(
         None,
@@ -347,11 +347,11 @@ class VerifyConnectionResponse(BaseModel):
         description="True if the agent responded successfully to the verification probe"
     )
     error: Optional[str] = Field(
-        None, description="Failure reason; null on success"
+        None, description="Failure reason. Null on success"
     )
     sample_response: Optional[Dict[str, Any]] = Field(
         None,
-        description="Sample output returned by the agent during verification; null when unavailable",
+        description="Sample output returned by the agent during verification. Null when unavailable",
     )
 
 

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -551,7 +551,7 @@ async def update_agent_endpoint(
     agent: AgentUpdate = ...,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Update an agent's name and/or config."""
+    """Update an agent."""
     existing_agent = get_agent(agent_uuid)
     if not existing_agent or existing_agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -456,7 +456,7 @@ async def resolve_agent_names(
     request: ResolveAgentNamesRequest,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Resolve agent names to their IDs."""
+    """Look up agent IDs by name, to reference agents in other calls."""
     # Public API. Auth via get_org_jwt_or_api_key (JWT for the web app, API key
     # for CI). Maps human-friendly names to the UUIDs the run/poll endpoints expect.
     agents = get_all_agents(org_uuid=ctx.org_uuid)
@@ -482,7 +482,7 @@ async def resolve_agent_names(
 async def create_agent_endpoint(
     agent: AgentCreate, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create a new agent."""
+    """Create an agent to test, either one built inside Calibrate or a connection to your own endpoint."""
     if agent.type == "agent":
         merged_config = _deep_merge(_default_agent_config(), agent.config or {})
     else:
@@ -509,7 +509,7 @@ async def create_agent_endpoint(
     summary="List agents",
 )
 async def list_agents(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
-    """List all agents."""
+    """List your agents, each with its type and config."""
     # Public API. Auth via get_org_jwt_or_api_key (JWT for the web app, API key
     # for CI); the run/poll and /resolve endpoints accept the same key, so CI can
     # enumerate agent UUIDs without knowing names up front.
@@ -530,7 +530,7 @@ async def get_agent_endpoint(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Get an agent."""
+    """Get one agent by ID, including its config and connection status."""
     agent = get_agent(agent_uuid)
     if not agent or agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")
@@ -551,7 +551,7 @@ async def update_agent_endpoint(
     agent: AgentUpdate = ...,
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Update an agent."""
+    """Update an agent's config, e.g. to change its model or repoint a connection to a new endpoint."""
     existing_agent = get_agent(agent_uuid)
     if not existing_agent or existing_agent.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/src/routers/agents.py
+++ b/src/routers/agents.py
@@ -382,7 +382,7 @@ async def verify_agent_connection_presave(
 )
 async def verify_agent_connection(
     agent_uuid: str = Path(
-        description="The agent whose connection to verify. Must be in your workspace.",
+        description="The agent whose connection to verify.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     request: VerifyConnectionRequest = ...,
@@ -525,7 +525,7 @@ async def list_agents(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
 )
 async def get_agent_endpoint(
     agent_uuid: str = Path(
-        description="The agent to retrieve. Must be in your workspace.",
+        description="The agent to retrieve.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
@@ -545,7 +545,7 @@ async def get_agent_endpoint(
 )
 async def update_agent_endpoint(
     agent_uuid: str = Path(
-        description="The agent to update. Must be in your workspace.",
+        description="The agent to update.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     agent: AgentUpdate = ...,
@@ -602,7 +602,7 @@ async def update_agent_endpoint(
 @router.delete("/{agent_uuid}", summary="Delete agent")
 async def delete_agent_endpoint(
     agent_uuid: str = Path(
-        description="The agent to delete. Must be in your workspace.",
+        description="The agent to delete.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -625,7 +625,7 @@ async def delete_agent_endpoint(
 )
 async def duplicate_agent_endpoint(
     agent_uuid: str = Path(
-        description="The agent to duplicate. Must be in your workspace.",
+        description="The agent to duplicate.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     request: AgentDuplicateRequest = ...,

--- a/src/routers/annotation_agreement.py
+++ b/src/routers/annotation_agreement.py
@@ -44,7 +44,7 @@ async def agreement_trend(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get human-vs-human agreement trends for your workspace and per-evaluator human alignment."""
+    """Get human-vs-human agreement trends and per-evaluator human alignment."""
     if task_id:
         task = get_annotation_task(task_id)
         if not task or task.get("org_uuid") != ctx.org_uuid:

--- a/src/routers/annotation_agreement.py
+++ b/src/routers/annotation_agreement.py
@@ -44,7 +44,7 @@ async def agreement_trend(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get human-vs-human agreement trends and per-evaluator human alignment."""
+    """Get human-vs-human agreement trends and per-evaluator human alignment"""
     if task_id:
         task = get_annotation_task(task_id)
         if not task or task.get("org_uuid") != ctx.org_uuid:
@@ -128,7 +128,7 @@ async def evaluator_agreement_trend(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get human-vs-evaluator agreement trends for one evaluator, broken down by version and task."""
+    """Get human-vs-evaluator agreement trends for one evaluator, broken down by version and task"""
     evaluator = get_evaluator(evaluator_uuid)
     if not evaluator:
         raise HTTPException(status_code=404, detail="Evaluator not found")

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -141,7 +141,7 @@ _EXAMPLE_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 class AnnotationTaskCreate(BaseModel):
     name: str = Field(description="Human-readable task name, unique within your workspace")
     type: AnnotationTaskTypeLiteral = Field(
-        description="Task type; governs item payload shape and applicable evaluators"
+        description="Task type. Governs item payload shape and applicable evaluators"
     )
     description: Optional[str] = Field(
         None, description="Free-text task description. Omit for none"
@@ -186,11 +186,11 @@ class AnnotationTaskResponse(BaseModel):
     # empty (use the dedicated /items and /jobs endpoints for those views).
     items: List[Dict[str, Any]] = Field(
         default=[],
-        description="Task items with per-item agreement stats. Populated on the single-task fetch only; empty on the list endpoint",
+        description="Task items with per-item agreement stats. Populated on the single-task fetch only. Empty on the list endpoint",
     )
     jobs: List[Dict[str, Any]] = Field(
         default=[],
-        description="Labelling jobs for the task. Populated on the single-task fetch only; empty on the list endpoint",
+        description="Labelling jobs for the task. Populated on the single-task fetch only. Empty on the list endpoint",
     )
 
 
@@ -443,7 +443,7 @@ async def reorder_task_evaluators(
 ):
     """Reorder evaluators linked to a task.
 
- The request must list every currently linked evaluator ID in the desired order; this endpoint reorders only and does not link or unlink evaluators."""
+ The request must list every currently linked evaluator ID in the desired order. This endpoint reorders only and does not link or unlink evaluators."""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     try:
         reorder_evaluators_for_annotation_task(task_uuid, payload.evaluator_ids)
@@ -503,7 +503,7 @@ class AnnotatedItemsCheckRequest(BaseModel):
         examples=[_EXAMPLE_ID],
     )
     names: List[str] = Field(
-        description="Item names in upload row order (`payload.name`); the response reports back by row index"
+        description="Item names in upload row order (`payload.name`). The response reports back by row index"
     )
 
 
@@ -918,10 +918,10 @@ def _resolve_target_item_ids(
       (same field/match rule as the summary endpoint's `?q=`). The explicit
       `item_ids` list is ignored — `select_all` is the source of truth so
       stale checkboxes can't sneak through.
-    - `select_all=False`: returns `item_ids` verbatim; `q` is ignored.
+    - `select_all=False`: returns `item_ids` verbatim. `q` is ignored.
 
     Pass `items` to reuse an already-loaded task item list (avoids a second
-    `get_annotation_items_for_task` round-trip); omitted ⇒ fetched lazily and
+    `get_annotation_items_for_task` round-trip). Omitted ⇒ fetched lazily and
     only when `select_all=True`.
 
     Returns the raw resolved list (may be empty). Callers decide whether
@@ -945,7 +945,7 @@ def _resolve_target_item_ids(
 class BulkDeleteItemsRequest(BaseModel):
     item_ids: List[str] = Field(
         default=[],
-        description="Item IDs to delete. **Required (non-empty) when `select_all=false`**; ignored when `select_all=true`",
+        description="Item IDs to delete. **Required (non-empty) when `select_all=false`**. Ignored when `select_all=true`",
     )
     select_all: bool = Field(
         False,
@@ -1035,7 +1035,7 @@ class CreateJobsRequest(BaseModel):
     )
     item_ids: List[str] = Field(
         default=[],
-        description="Item IDs to assign. **Required (non-empty) when `select_all=false`**; ignored when `select_all=true`",
+        description="Item IDs to assign. **Required (non-empty) when `select_all=false`**. Ignored when `select_all=true`",
     )
     select_all: bool = Field(
         False,
@@ -1047,7 +1047,7 @@ class CreateJobsRequest(BaseModel):
     )
     evaluator_ids: Optional[List[str]] = Field(
         None,
-        description="Optional subset of the task's linked evaluators to show in these jobs (must be a subset of the live links; empty list ⇒ 400). Applies to every annotator's job. Omit (`None`) to snapshot every linked evaluator",
+        description="Optional subset of the task's linked evaluators to show in these jobs (must be a subset of the live links. Empty list ⇒ 400). Applies to every annotator's job. Omit (`None`) to snapshot every linked evaluator",
     )
 
 
@@ -1251,7 +1251,7 @@ async def delete_annotation_job_endpoint(
 
 class AnnotationJobVisibilityRequest(BaseModel):
     is_public: bool = Field(
-        description="`true` opts the job into a read-only public viewer link; `false` disables it"
+        description="`true` opts the job into a read-only public viewer link. `false` disables it"
     )
 
 
@@ -1259,7 +1259,7 @@ class AnnotationJobVisibilityResponse(BaseModel):
     is_public: bool = Field(description="Current public-viewer state after the toggle")
     view_token: Optional[str] = Field(
         None,
-        description="Read-only viewer token for the public labelling job viewer. Present when public; null when disabled",
+        description="Read-only viewer token for the public labelling job viewer. Present when public. Null when disabled",
     )
 
 
@@ -1401,11 +1401,11 @@ class EvaluatorRunStartRequest(BaseModel):
     )
     item_ids: List[str] = Field(
         default=[],
-        description="Item IDs to run on. **Required (non-empty) when `select_all=false`**; ignored when `select_all=true`",
+        description="Item IDs to run on. **Required (non-empty) when `select_all=false`**. Ignored when `select_all=true`",
     )
     select_all: bool = Field(
         False,
-        description="When `true`, run on every item in the task (optionally filtered by `q`); the live set is snapshotted at submission time",
+        description="When `true`, run on every item in the task (optionally filtered by `q`). The live set is snapshotted at submission time",
     )
     q: Optional[str] = Field(
         None,
@@ -2089,7 +2089,7 @@ async def delete_evaluator_run_job(
 
 class EvaluatorRunVisibilityRequest(BaseModel):
     is_public: bool = Field(
-        description="`true` enables a public share link for the completed run; `false` disables it"
+        description="`true` enables a public share link for the completed run. `false` disables it"
     )
 
 
@@ -2097,7 +2097,7 @@ class EvaluatorRunVisibilityResponse(BaseModel):
     is_public: bool = Field(description="Current public-sharing state after the toggle")
     share_token: Optional[str] = Field(
         None,
-        description="Public share token for the run. Present when public; `null` when disabled. Reused across off→on cycles",
+        description="Public share token for the run. Present when public. `null` when disabled. Reused across off→on cycles",
     )
 
 

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -170,7 +170,7 @@ class AnnotationTaskResponse(BaseModel):
     )
     name: str = Field(description="Task name")
     type: AnnotationTaskTypeLiteral = Field(
-        description="Task type (`stt | tts | llm | llm-general | conversation`)"
+        description="Task type. Governs item payload shape and applicable evaluators"
     )
     description: Optional[str] = Field(None, description="Free-text task description, if any")
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -243,7 +243,7 @@ async def create_annotation_task_endpoint(
     payload: AnnotationTaskCreate,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an annotation task in your workspace."""
+    """Create an annotation task."""
     if payload.evaluator_ids:
         for evaluator_id in payload.evaluator_ids:
             _ensure_owned_evaluator(evaluator_id, ctx.org_uuid)
@@ -270,7 +270,7 @@ async def create_annotation_task_endpoint(
 
 @router.get("", response_model=List[AnnotationTaskResponse], summary="List annotation tasks")
 async def list_annotation_tasks(ctx: OrgContext = Depends(get_current_org)):
-    """List annotation tasks in your workspace with linked evaluators."""
+    """List annotation tasks with linked evaluators."""
     tasks = get_all_annotation_tasks(org_uuid=ctx.org_uuid)
     for task in tasks:
         task["evaluators"] = get_evaluators_for_annotation_task(task["uuid"])
@@ -356,7 +356,7 @@ async def delete_annotation_task_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete an annotation task in your workspace."""
+    """Soft-delete an annotation task."""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     deleted = delete_annotation_task(task_uuid)
     if not deleted:

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -215,7 +215,7 @@ class EvaluatorLinkRequest(BaseModel):
 
 class EvaluatorOrderRequest(BaseModel):
     evaluator_ids: List[str] = Field(
-        description="Full ordered list of currently-linked evaluator IDs. **Must match the active linked set exactly** — this endpoint reorders, it does not link/unlink. Send `[]` only when the task has no linked evaluators"
+        description="Full ordered list of currently-linked evaluator IDs. **Must match the active linked set exactly.** This endpoint reorders, it does not link/unlink. Send `[]` only when the task has no linked evaluators"
     )
 
 
@@ -465,7 +465,7 @@ class AnnotationItemPayload(BaseModel):
     )
     annotations: Optional[Dict[str, Any]] = Field(
         None,
-        description="Optional human annotations to seed with the item, keyed by evaluator ID (each must be currently linked to the task). Each value is `{'value': <bool|number|string>, 'reasoning'?: str}` for every output_type — binary uses a bool in `value`, rating a number. Only the keys `value`/`score`/`rating`/`label`/`binary` count toward agreement aggregates. **When any item carries this, `BulkItemsRequest.annotator_id` is required.**",
+        description="Optional human annotations to seed with the item, keyed by evaluator ID (each must be currently linked to the task). Each value is `{'value': <bool|number|string>, 'reasoning'?: str}` for every output_type. Binary uses a bool in `value`, rating a number. Only the keys `value`/`score`/`rating`/`label`/`binary` count toward agreement aggregates. **When any item carries this, `BulkItemsRequest.annotator_id` is required.**",
     )
 
 
@@ -1031,7 +1031,7 @@ async def list_item_annotations(
 
 class CreateJobsRequest(BaseModel):
     annotator_ids: List[str] = Field(
-        description="Annotator IDs to assign — one labelling job per annotator. Must be non-empty and in your workspace"
+        description="Annotator IDs to assign, one labelling job per annotator. Must be non-empty and in your workspace"
     )
     item_ids: List[str] = Field(
         default=[],

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -280,7 +280,7 @@ async def list_annotation_tasks(ctx: OrgContext = Depends(get_current_org)):
 @router.get("/{task_uuid}", response_model=AnnotationTaskResponse, summary="Get annotation task")
 async def get_annotation_task_endpoint(
     task_uuid: str = Path(
-        description="Task to retrieve. Must be in your workspace.",
+        description="Task to retrieve.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -321,7 +321,7 @@ async def get_annotation_task_endpoint(
 @router.put("/{task_uuid}", response_model=AnnotationTaskResponse, summary="Update annotation task")
 async def update_annotation_task_endpoint(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: AnnotationTaskUpdate = ...,
@@ -351,7 +351,7 @@ async def update_annotation_task_endpoint(
 @router.delete("/{task_uuid}", summary="Delete annotation task")
 async def delete_annotation_task_endpoint(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -370,7 +370,7 @@ async def delete_annotation_task_endpoint(
 @router.get("/{task_uuid}/evaluators", summary="List task evaluators")
 async def list_task_evaluators(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -419,7 +419,7 @@ async def list_task_evaluators(
 @router.post("/{task_uuid}/evaluators", summary="Link evaluator to task")
 async def link_evaluator_to_task(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: EvaluatorLinkRequest = ...,
@@ -435,7 +435,7 @@ async def link_evaluator_to_task(
 @router.put("/{task_uuid}/evaluators/order", summary="Reorder task evaluators")
 async def reorder_task_evaluators(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: EvaluatorOrderRequest = ...,
@@ -477,7 +477,7 @@ class BulkItemsRequest(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="Annotator to attribute seeded annotations to. **Required when any item carries annotations.** Must be in your workspace",
+        description="Annotator to attribute seeded annotations to. **Required when any item carries annotations.**",
         examples=[_EXAMPLE_ID],
     )
 
@@ -485,7 +485,7 @@ class BulkItemsRequest(BaseModel):
 @router.get("/{task_uuid}/items", summary="List task items")
 async def list_task_items(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -510,7 +510,7 @@ class AnnotatedItemsCheckRequest(BaseModel):
 @router.post("/{task_uuid}/items/annotated-check", summary="Check annotated items")
 async def check_annotated_items(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: AnnotatedItemsCheckRequest = ...,
@@ -562,7 +562,7 @@ async def check_annotated_items(
 @router.post("/{task_uuid}/items", summary="Bulk create items")
 async def bulk_create_items(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: BulkItemsRequest = ...,
@@ -842,7 +842,7 @@ class BulkUpdateItemsRequest(BaseModel):
 @router.put("/{task_uuid}/items", summary="Bulk update items")
 async def bulk_update_items(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: BulkUpdateItemsRequest = ...,
@@ -960,7 +960,7 @@ class BulkDeleteItemsRequest(BaseModel):
 @router.delete("/{task_uuid}/items", summary="Bulk delete items")
 async def bulk_delete_items(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: BulkDeleteItemsRequest = ...,
@@ -989,7 +989,7 @@ async def bulk_delete_items(
 @router.get("/{task_uuid}/items/{item_uuid}", summary="Get item")
 async def get_item(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     item_uuid: str = Path(
@@ -1009,7 +1009,7 @@ async def get_item(
 @router.get("/{task_uuid}/items/{item_uuid}/annotations", summary="List item annotations")
 async def list_item_annotations(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     item_uuid: str = Path(
@@ -1054,7 +1054,7 @@ class CreateJobsRequest(BaseModel):
 @router.get("/{task_uuid}/jobs", summary="List labelling jobs")
 async def list_task_jobs(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -1067,7 +1067,7 @@ async def list_task_jobs(
 @router.post("/{task_uuid}/jobs", summary="Create labelling jobs")
 async def create_jobs(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: CreateJobsRequest = ...,
@@ -1186,7 +1186,7 @@ async def create_jobs(
 @router.get("/{task_uuid}/jobs/{job_uuid}", summary="Get labelling job")
 async def get_annotation_job_endpoint(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     job_uuid: str = Path(
@@ -1213,7 +1213,7 @@ class BulkDeleteJobsRequest(BaseModel):
 @router.delete("/{task_uuid}/jobs", summary="Bulk delete labelling jobs")
 async def bulk_delete_annotation_jobs_endpoint(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: BulkDeleteJobsRequest = ...,
@@ -1230,7 +1230,7 @@ async def bulk_delete_annotation_jobs_endpoint(
 @router.delete("/{task_uuid}/jobs/{job_uuid}", summary="Delete labelling job")
 async def delete_annotation_job_endpoint(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     job_uuid: str = Path(
@@ -1270,7 +1270,7 @@ class AnnotationJobVisibilityResponse(BaseModel):
 )
 async def update_annotation_job_visibility_endpoint(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     job_uuid: str = Path(
@@ -1336,7 +1336,7 @@ class AnnotationUpsertRequest(BaseModel):
 @router.post("/{task_uuid}/annotations", summary="Upsert annotation")
 async def upsert_annotation_endpoint(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: AnnotationUpsertRequest = ...,
@@ -1416,7 +1416,7 @@ class EvaluatorRunStartRequest(BaseModel):
 @router.post("/{task_uuid}/evaluator-runs", summary="Run evaluators on items")
 async def start_evaluator_run(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: EvaluatorRunStartRequest = ...,
@@ -1752,7 +1752,7 @@ def _shape_eval_job_for_response(job: Dict[str, Any]) -> Dict[str, Any]:
 @router.get("/{task_uuid}/evaluator-runs", summary="List evaluator runs")
 async def list_evaluator_run_jobs(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -2007,7 +2007,7 @@ def _human_agreement_for_run(
 @router.get("/{task_uuid}/evaluator-runs/{job_uuid}", summary="Get evaluator run")
 async def get_evaluator_run_job(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     job_uuid: str = Path(
@@ -2050,7 +2050,7 @@ async def get_evaluator_run_job(
 @router.delete("/{task_uuid}/evaluator-runs/{job_uuid}", summary="Delete evaluator run")
 async def delete_evaluator_run_job(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     job_uuid: str = Path(
@@ -2108,7 +2108,7 @@ class EvaluatorRunVisibilityResponse(BaseModel):
 )
 async def update_evaluator_run_visibility(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     job_uuid: str = Path(
@@ -2146,7 +2146,7 @@ async def update_evaluator_run_visibility(
 @router.get("/{task_uuid}/items/{item_uuid}/evaluator-runs", summary="List item evaluator runs")
 async def list_item_evaluator_runs(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     item_uuid: str = Path(
@@ -2201,7 +2201,7 @@ def _evaluator_alignment_block(
 @router.get("/{task_uuid}/agreement", summary="Get task agreement")
 async def task_agreement(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     bucket: str = Query(
@@ -2245,7 +2245,7 @@ async def task_agreement(
 @router.get("/{task_uuid}/summary", summary="Get task summary")
 async def task_summary(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     item_id: Optional[str] = Query(
@@ -2639,7 +2639,7 @@ async def task_summary(
 @router.delete("/{task_uuid}/evaluators/{evaluator_uuid}", summary="Unlink evaluator from task")
 async def unlink_evaluator_from_task(
     task_uuid: str = Path(
-        description="Annotation task to act on. Must be in your workspace.",
+        description="Annotation task to act on.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     evaluator_uuid: str = Path(

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -243,7 +243,7 @@ async def create_annotation_task_endpoint(
     payload: AnnotationTaskCreate,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an annotation task for annotators to label items against evaluators."""
+    """Create an annotation task for annotators to label items against evaluators"""
     if payload.evaluator_ids:
         for evaluator_id in payload.evaluator_ids:
             _ensure_owned_evaluator(evaluator_id, ctx.org_uuid)
@@ -270,7 +270,7 @@ async def create_annotation_task_endpoint(
 
 @router.get("", response_model=List[AnnotationTaskResponse], summary="List annotation tasks")
 async def list_annotation_tasks(ctx: OrgContext = Depends(get_current_org)):
-    """List annotation tasks with linked evaluators."""
+    """List annotation tasks with linked evaluators"""
     tasks = get_all_annotation_tasks(org_uuid=ctx.org_uuid)
     for task in tasks:
         task["evaluators"] = get_evaluators_for_annotation_task(task["uuid"])
@@ -285,7 +285,7 @@ async def get_annotation_task_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one annotation task with linked evaluators, items, and labelling jobs."""
+    """Get one annotation task with linked evaluators, items, and labelling jobs"""
     task = _ensure_owned_task(task_uuid, ctx.org_uuid)
     evaluators = _enrich_evaluators_with_live_version(
         get_evaluators_for_annotation_task(task_uuid)
@@ -327,7 +327,7 @@ async def update_annotation_task_endpoint(
     payload: AnnotationTaskUpdate = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update an annotation task, a labelling task for annotators."""
+    """Update an annotation task, a labelling task for annotators"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     with ensure_name_unique(
         "annotation_tasks",
@@ -356,7 +356,7 @@ async def delete_annotation_task_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete an annotation task."""
+    """Soft-delete an annotation task"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     deleted = delete_annotation_task(task_uuid)
     if not deleted:
@@ -375,7 +375,7 @@ async def list_task_evaluators(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List evaluators linked to this task in full detail, ordered by display position."""
+    """List evaluators linked to this task in full detail, ordered by display position"""
     # Lazy import to avoid a circular module-load between the two router
     # files (annotation_tasks ↔ evaluators).
     from routers.evaluators import (
@@ -425,7 +425,7 @@ async def link_evaluator_to_task(
     payload: EvaluatorLinkRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Link an evaluator to a task, appending it to the display order."""
+    """Link an evaluator to a task, appending it to the display order"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     _ensure_owned_evaluator(payload.evaluator_id, ctx.org_uuid)
     add_evaluator_to_annotation_task(task_uuid, payload.evaluator_id)
@@ -443,7 +443,7 @@ async def reorder_task_evaluators(
 ):
     """Reorder evaluators linked to a task.
 
- The request must list every currently linked evaluator ID in the desired order. This endpoint reorders only and does not link or unlink evaluators."""
+ The request must list every currently linked evaluator ID in the desired order. This endpoint reorders only and does not link or unlink evaluators"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     try:
         reorder_evaluators_for_annotation_task(task_uuid, payload.evaluator_ids)
@@ -490,7 +490,7 @@ async def list_task_items(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List non-deleted items in a task."""
+    """List non-deleted items in a task"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     return get_annotation_items_for_task(task_uuid)
 
@@ -516,7 +516,7 @@ async def check_annotated_items(
     payload: AnnotatedItemsCheckRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Check which proposed item names already exist and whether the annotator has labelled them."""
+    """Check which proposed item names already exist and whether the annotator has labelled them"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     if not payload.names:
         raise HTTPException(status_code=400, detail="names must be non-empty")
@@ -568,7 +568,7 @@ async def bulk_create_items(
     payload: BulkItemsRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Bulk-create annotation items in a task, optionally seeding human annotations."""
+    """Bulk-create annotation items in a task, optionally seeding human annotations"""
     task = _ensure_owned_task(task_uuid, ctx.org_uuid)
     if not payload.items:
         raise HTTPException(status_code=400, detail="items must be non-empty")
@@ -848,7 +848,7 @@ async def bulk_update_items(
     payload: BulkUpdateItemsRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Bulk-update item payloads in a task."""
+    """Bulk-update item payloads in a task"""
     task = _ensure_owned_task(task_uuid, ctx.org_uuid)
     if not payload.updates:
         raise HTTPException(status_code=400, detail="updates must be non-empty")
@@ -966,7 +966,7 @@ async def bulk_delete_items(
     payload: BulkDeleteItemsRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete items in a task, using explicit IDs or a select-all filter."""
+    """Soft-delete items in a task, using explicit IDs or a select-all filter"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     target_ids = _resolve_target_item_ids(
         task_uuid,
@@ -998,7 +998,7 @@ async def get_item(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one item in a task."""
+    """Get one item in a task"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     item = get_annotation_item(item_uuid)
     if not item or item.get("task_id") != task_uuid:
@@ -1018,7 +1018,7 @@ async def list_item_annotations(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List human annotations for one item across every labelling job."""
+    """List human annotations for one item across every labelling job"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     item = get_annotation_item(item_uuid)
     if not item or item.get("task_id") != task_uuid:
@@ -1059,7 +1059,7 @@ async def list_task_jobs(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List labelling jobs for a task."""
+    """List labelling jobs for a task"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     return get_jobs_for_task(task_uuid)
 
@@ -1073,7 +1073,7 @@ async def create_jobs(
     payload: CreateJobsRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Assign items to annotators, creating one labelling job per annotator."""
+    """Assign items to annotators, creating one labelling job per annotator"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     if not payload.annotator_ids:
         raise HTTPException(
@@ -1195,7 +1195,7 @@ async def get_annotation_job_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one labelling job with its frozen item snapshot."""
+    """Get one labelling job with its frozen item snapshot"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     job = get_annotation_job(job_uuid)
     if not job or job.get("task_id") != task_uuid:
@@ -1219,7 +1219,7 @@ async def bulk_delete_annotation_jobs_endpoint(
     payload: BulkDeleteJobsRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete labelling jobs in a task."""
+    """Soft-delete labelling jobs in a task"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     if not payload.job_uuids:
         raise HTTPException(status_code=400, detail="job_uuids must be non-empty")
@@ -1239,7 +1239,7 @@ async def delete_annotation_job_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete one labelling job in a task."""
+    """Soft-delete one labelling job in a task"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     job = get_annotation_job(job_uuid)
     if not job or job.get("task_id") != task_uuid:
@@ -1280,7 +1280,7 @@ async def update_annotation_job_visibility_endpoint(
     body: AnnotationJobVisibilityRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Toggle a read-only public viewer link for a completed labelling job."""
+    """Toggle a read-only public viewer link for a completed labelling job"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     job = get_annotation_job(job_uuid)
     if not job or job.get("task_id") != task_uuid:
@@ -1342,7 +1342,7 @@ async def upsert_annotation_endpoint(
     payload: AnnotationUpsertRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Upsert one human annotation on a labelling job."""
+    """Upsert one human annotation on a labelling job"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     job = get_annotation_job(payload.job_id)
     if not job or job.get("task_id") != task_uuid:
@@ -1422,7 +1422,7 @@ async def start_evaluator_run(
     payload: EvaluatorRunStartRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Run evaluators on task items as a background job."""
+    """Run evaluators on task items as a background job"""
     task = _ensure_owned_task(task_uuid, ctx.org_uuid)
     if task.get("type") not in SUPPORTED_EVAL_TASK_TYPES:
         raise HTTPException(
@@ -1757,7 +1757,7 @@ async def list_evaluator_run_jobs(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List evaluator-run jobs for a task."""
+    """List evaluator-run jobs for a task"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     jobs = get_generic_jobs_for_task(task_uuid, ANNOTATION_EVAL_JOB_TYPE)
 
@@ -2016,7 +2016,7 @@ async def get_evaluator_run_job(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one evaluator-run job with results and human-agreement summary."""
+    """Get one evaluator-run job with results and human-agreement summary"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     job = get_job(job_uuid, org_uuid=ctx.org_uuid)
     if (
@@ -2059,7 +2059,7 @@ async def delete_evaluator_run_job(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete an evaluator-run job and its run results."""
+    """Soft-delete an evaluator-run job and its run results"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     job = get_job(job_uuid, org_uuid=ctx.org_uuid)
     if (
@@ -2118,7 +2118,7 @@ async def update_evaluator_run_visibility(
     body: EvaluatorRunVisibilityRequest = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Toggle public sharing for a completed evaluator-run job."""
+    """Toggle public sharing for a completed evaluator-run job"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     job = get_job(job_uuid, org_uuid=ctx.org_uuid)
     if (
@@ -2155,7 +2155,7 @@ async def list_item_evaluator_runs(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List evaluator runs for one item."""
+    """List evaluator runs for one item"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     item = get_annotation_item(item_uuid)
     if not item or item.get("task_id") != task_uuid:
@@ -2214,7 +2214,7 @@ async def task_agreement(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get human-vs-human and human-vs-evaluator agreement metrics for a task."""
+    """Get human-vs-human and human-vs-evaluator agreement metrics for a task"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     annotations = get_annotations_for_task(task_uuid)
     linked = get_evaluators_for_annotation_task(task_uuid)
@@ -2261,7 +2261,7 @@ async def task_summary(
     sort: _SummarySort = Depends(),
     pagination: PaginationParams = Depends(),
 ):
-    """Get a paginated summary table of items, evaluator runs, and human annotations for a task."""
+    """Get a paginated summary table of items, evaluator runs, and human annotations for a task"""
     task = _ensure_owned_task(task_uuid, ctx.org_uuid)
     items = get_annotation_items_for_task(task_uuid)
     evaluators = get_evaluators_for_annotation_task(task_uuid)
@@ -2648,7 +2648,7 @@ async def unlink_evaluator_from_task(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Unlink an evaluator from a task without changing existing job snapshots."""
+    """Unlink an evaluator from a task without changing existing job snapshots"""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     removed = remove_evaluator_from_annotation_task(task_uuid, evaluator_uuid)
     if not removed:

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -327,7 +327,7 @@ async def update_annotation_task_endpoint(
     payload: AnnotationTaskUpdate = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update an annotation task's name and description. Task type is immutable."""
+    """Update an annotation task."""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     with ensure_name_unique(
         "annotation_tasks",

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -243,7 +243,7 @@ async def create_annotation_task_endpoint(
     payload: AnnotationTaskCreate,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an annotation task."""
+    """Create an annotation task for annotators to label items against evaluators."""
     if payload.evaluator_ids:
         for evaluator_id in payload.evaluator_ids:
             _ensure_owned_evaluator(evaluator_id, ctx.org_uuid)
@@ -327,7 +327,7 @@ async def update_annotation_task_endpoint(
     payload: AnnotationTaskUpdate = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update an annotation task."""
+    """Update an annotation task, a labelling task for annotators."""
     _ensure_owned_task(task_uuid, ctx.org_uuid)
     with ensure_name_unique(
         "annotation_tasks",

--- a/src/routers/annotation_tasks.py
+++ b/src/routers/annotation_tasks.py
@@ -139,7 +139,7 @@ _EXAMPLE_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 
 
 class AnnotationTaskCreate(BaseModel):
-    name: str = Field(description="Human-readable task name, unique within your workspace")
+    name: str = Field(description="Task name, unique within your workspace")
     type: AnnotationTaskTypeLiteral = Field(
         description="Task type. Governs item payload shape and applicable evaluators"
     )
@@ -168,7 +168,7 @@ class AnnotationTaskResponse(BaseModel):
         description="Task ID",
         examples=[_EXAMPLE_ID],
     )
-    name: str = Field(description="Human-readable task name")
+    name: str = Field(description="Task name")
     type: AnnotationTaskTypeLiteral = Field(
         description="Task type (`stt | tts | llm | llm-general | conversation`)"
     )
@@ -201,7 +201,7 @@ class AnnotationTaskCreateResponse(BaseModel):
         description="ID of the newly created task",
         examples=[_EXAMPLE_ID],
     )
-    message: str = Field(description="Human-readable success message")
+    message: str = Field(description="Success message")
 
 
 class EvaluatorLinkRequest(BaseModel):

--- a/src/routers/annotators.py
+++ b/src/routers/annotators.py
@@ -122,7 +122,7 @@ async def list_annotators(ctx: OrgContext = Depends(get_current_org)):
 @router.get("/{annotator_uuid}", summary="Get annotator")
 async def get_annotator_endpoint(
     annotator_uuid: str = Path(
-        description="Annotator to retrieve. Must be in your workspace.",
+        description="Annotator to retrieve.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     bucket: str = Query(
@@ -174,7 +174,7 @@ async def get_annotator_endpoint(
 @router.put("/{annotator_uuid}", response_model=AnnotatorResponse, summary="Update annotator")
 async def update_annotator_endpoint(
     annotator_uuid: str = Path(
-        description="Annotator to update. Must be in your workspace.",
+        description="Annotator to update.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     payload: AnnotatorUpdate = ...,
@@ -201,7 +201,7 @@ async def update_annotator_endpoint(
 @router.delete("/{annotator_uuid}", summary="Delete annotator")
 async def delete_annotator_endpoint(
     annotator_uuid: str = Path(
-        description="Annotator to delete. Must be in your workspace.",
+        description="Annotator to delete.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/annotators.py
+++ b/src/routers/annotators.py
@@ -80,7 +80,7 @@ async def create_annotator_endpoint(
     payload: AnnotatorCreate,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an annotator, a human labeller who can be assigned annotation tasks."""
+    """Create an annotator, a human labeller who can be assigned annotation tasks"""
     try:
         with ensure_name_unique(
             "annotators", payload.name, ctx.org_uuid, entity="Annotator"
@@ -97,7 +97,7 @@ async def create_annotator_endpoint(
 
 @router.get("", response_model=List[AnnotatorResponse], summary="List annotators")
 async def list_annotators(ctx: OrgContext = Depends(get_current_org)):
-    """List annotators with job counts and agreement stats."""
+    """List annotators with job counts and agreement stats"""
     annotators = get_all_annotators(org_uuid=ctx.org_uuid)
     if not annotators:
         return []
@@ -135,7 +135,7 @@ async def get_annotator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one annotator with assigned jobs and an agreement trend series."""
+    """Get one annotator with assigned jobs and an agreement trend series"""
     annotator = _ensure_owned_annotator(annotator_uuid, ctx.org_uuid)
 
     jobs = get_jobs_for_annotator_detailed(annotator_uuid)
@@ -180,7 +180,7 @@ async def update_annotator_endpoint(
     payload: AnnotatorUpdate = ...,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update an annotator's name."""
+    """Update an annotator's name"""
     _ensure_owned_annotator(annotator_uuid, ctx.org_uuid)
     try:
         with ensure_name_unique(
@@ -206,7 +206,7 @@ async def delete_annotator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete an annotator."""
+    """Soft-delete an annotator"""
     _ensure_owned_annotator(annotator_uuid, ctx.org_uuid)
     deleted = delete_annotator(annotator_uuid)
     if not deleted:

--- a/src/routers/annotators.py
+++ b/src/routers/annotators.py
@@ -80,7 +80,7 @@ async def create_annotator_endpoint(
     payload: AnnotatorCreate,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an annotator in your workspace."""
+    """Create an annotator."""
     try:
         with ensure_name_unique(
             "annotators", payload.name, ctx.org_uuid, entity="Annotator"
@@ -97,7 +97,7 @@ async def create_annotator_endpoint(
 
 @router.get("", response_model=List[AnnotatorResponse], summary="List annotators")
 async def list_annotators(ctx: OrgContext = Depends(get_current_org)):
-    """List annotators in your workspace with job counts and agreement stats."""
+    """List annotators with job counts and agreement stats."""
     annotators = get_all_annotators(org_uuid=ctx.org_uuid)
     if not annotators:
         return []
@@ -206,7 +206,7 @@ async def delete_annotator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete an annotator in your workspace."""
+    """Soft-delete an annotator."""
     _ensure_owned_annotator(annotator_uuid, ctx.org_uuid)
     deleted = delete_annotator(annotator_uuid)
     if not deleted:

--- a/src/routers/annotators.py
+++ b/src/routers/annotators.py
@@ -27,7 +27,7 @@ _EXAMPLE_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 
 
 class AnnotatorCreate(BaseModel):
-    name: str = Field(description="Human-readable annotator name, unique within your workspace")
+    name: str = Field(description="Annotator name, unique within your workspace")
 
 
 class AnnotatorUpdate(BaseModel):
@@ -43,7 +43,7 @@ class AnnotatorResponse(BaseModel):
         description="Annotator ID",
         examples=[_EXAMPLE_ID],
     )
-    name: str = Field(description="Human-readable annotator name")
+    name: str = Field(description="Annotator name")
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
     jobs_count: Optional[int] = Field(
@@ -65,7 +65,7 @@ class AnnotatorCreateResponse(BaseModel):
         description="ID of the newly created annotator",
         examples=[_EXAMPLE_ID],
     )
-    message: str = Field(description="Human-readable success message")
+    message: str = Field(description="Success message")
 
 
 def _ensure_owned_annotator(annotator_uuid: str, org_uuid: str):

--- a/src/routers/annotators.py
+++ b/src/routers/annotators.py
@@ -80,7 +80,7 @@ async def create_annotator_endpoint(
     payload: AnnotatorCreate,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an annotator."""
+    """Create an annotator, a human labeller who can be assigned annotation tasks."""
     try:
         with ensure_name_unique(
             "annotators", payload.name, ctx.org_uuid, entity="Annotator"

--- a/src/routers/api_keys.py
+++ b/src/routers/api_keys.py
@@ -106,7 +106,7 @@ async def create_key(
     request: CreateApiKeyRequest,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an API key for programmatic access to the API."""
+    """Create an API key for programmatic access to the API"""
     raw_key, key_prefix = generate_api_key()
     row = create_api_key(
         org_uuid=ctx.org_uuid,
@@ -121,7 +121,7 @@ async def create_key(
 
 @router.get("", response_model=List[ApiKeyResponse], summary="List API keys")
 async def list_keys(ctx: OrgContext = Depends(get_current_org)):
-    """List active API keys."""
+    """List active API keys"""
     return [ApiKeyResponse.from_row(k) for k in list_api_keys_for_org(ctx.org_uuid)]
 
 
@@ -133,7 +133,7 @@ async def revoke_key(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Revoke an API key so it can no longer authenticate requests."""
+    """Revoke an API key so it can no longer authenticate requests"""
     if get_api_key(key_uuid, ctx.org_uuid) is None:
         raise HTTPException(status_code=404, detail="API key not found")
     soft_delete_api_key(key_uuid, ctx.org_uuid)

--- a/src/routers/api_keys.py
+++ b/src/routers/api_keys.py
@@ -67,7 +67,7 @@ class ApiKeyResponse(BaseModel):
     )
     name: str = Field(description="Human-readable label for the key")
     last_four: str = Field(
-        description="Last four characters of the key — the only fragment kept after creation"
+        description="Last four characters of the key"
     )
     masked_key: str = Field(
         description="Masked display form of the key for listings"
@@ -95,7 +95,7 @@ class ApiKeyResponse(BaseModel):
 
 class CreateApiKeyResponse(ApiKeyResponse):
     key: str = Field(
-        description="The API key. **Returned exactly once at creation** — store it now. It cannot be retrieved again"
+        description="The API key. **Returned exactly once at creation.** Store it now. It cannot be retrieved again"
     )
 
 

--- a/src/routers/api_keys.py
+++ b/src/routers/api_keys.py
@@ -106,7 +106,7 @@ async def create_key(
     request: CreateApiKeyRequest,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an API key for your workspace."""
+    """Create an API key."""
     raw_key, key_prefix = generate_api_key()
     row = create_api_key(
         org_uuid=ctx.org_uuid,
@@ -121,7 +121,7 @@ async def create_key(
 
 @router.get("", response_model=List[ApiKeyResponse], summary="List API keys")
 async def list_keys(ctx: OrgContext = Depends(get_current_org)):
-    """List active API keys in your workspace."""
+    """List active API keys."""
     return [ApiKeyResponse.from_row(k) for k in list_api_keys_for_org(ctx.org_uuid)]
 
 
@@ -133,7 +133,7 @@ async def revoke_key(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Revoke an API key in your workspace."""
+    """Revoke an API key."""
     if get_api_key(key_uuid, ctx.org_uuid) is None:
         raise HTTPException(status_code=404, detail="API key not found")
     soft_delete_api_key(key_uuid, ctx.org_uuid)

--- a/src/routers/api_keys.py
+++ b/src/routers/api_keys.py
@@ -32,7 +32,7 @@ class CreateApiKeyRequest(BaseModel):
         ...,
         min_length=1,
         max_length=200,
-        description="Human-readable label shown in your key listings",
+        description="Label shown in your key listings",
     )
 
 
@@ -65,7 +65,7 @@ class ApiKeyResponse(BaseModel):
         max_length=36,
         description="API key ID",
     )
-    name: str = Field(description="Human-readable label for the key")
+    name: str = Field(description="Label for the key")
     last_four: str = Field(
         description="Last four characters of the key"
     )

--- a/src/routers/api_keys.py
+++ b/src/routers/api_keys.py
@@ -106,7 +106,7 @@ async def create_key(
     request: CreateApiKeyRequest,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create an API key."""
+    """Create an API key for programmatic access to the API."""
     raw_key, key_prefix = generate_api_key()
     row = create_api_key(
         org_uuid=ctx.org_uuid,
@@ -133,7 +133,7 @@ async def revoke_key(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Revoke an API key."""
+    """Revoke an API key so it can no longer authenticate requests."""
     if get_api_key(key_uuid, ctx.org_uuid) is None:
         raise HTTPException(status_code=404, detail="API key not found")
     soft_delete_api_key(key_uuid, ctx.org_uuid)

--- a/src/routers/api_keys.py
+++ b/src/routers/api_keys.py
@@ -74,7 +74,7 @@ class ApiKeyResponse(BaseModel):
     )
     last_used_at: Optional[str] = Field(
         None,
-        description="When the key last authenticated a request; `null` if never used",
+        description="When the key last authenticated a request. `null` if never used",
     )
     created_at: str = Field(description="When the key was created (ISO 8601 UTC)")
     updated_at: str = Field(description="When the key was last updated (ISO 8601 UTC)")
@@ -95,7 +95,7 @@ class ApiKeyResponse(BaseModel):
 
 class CreateApiKeyResponse(ApiKeyResponse):
     key: str = Field(
-        description="The API key. **Returned exactly once at creation** — store it now; it cannot be retrieved again"
+        description="The API key. **Returned exactly once at creation** — store it now. It cannot be retrieved again"
     )
 
 

--- a/src/routers/api_keys.py
+++ b/src/routers/api_keys.py
@@ -1,7 +1,7 @@
 """API keys for programmatic access to your workspace.
 
 Each key is scoped to your active workspace. The raw key is returned exactly
-once at creation; later reads show only a masked display form.
+once at creation. Later reads show only a masked display form.
 """
 
 import re

--- a/src/routers/api_keys.py
+++ b/src/routers/api_keys.py
@@ -128,7 +128,7 @@ async def list_keys(ctx: OrgContext = Depends(get_current_org)):
 @router.delete("/{key_uuid}", status_code=204, summary="Revoke API key")
 async def revoke_key(
     key_uuid: str = Path(
-        description="The API key to revoke. Must be in your workspace.",
+        description="The API key to revoke.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -41,7 +41,7 @@ class LoginResponse(BaseModel):
     access_token: str = Field(
         description="JWT to send as `Authorization: Bearer <token>` on later requests"
     )
-    token_type: str = Field("bearer", description="Token scheme — always `bearer`")
+    token_type: str = Field("bearer", description="Always `bearer`")
     user: UserResponse = Field(description="Your profile")
     message: str = Field(description="Status message")
 

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -85,7 +85,7 @@ async def verify_google_token(id_token: str) -> dict:
 
 @router.post("/google", response_model=LoginResponse, summary="Log in with Google")
 async def google_login(request: GoogleLoginRequest):
-    """Log in with Google and receive a JWT plus your profile."""
+    """Log in with Google and receive a JWT plus your profile"""
     # Verify the Google token
     token_info = await verify_google_token(request.id_token)
 
@@ -140,7 +140,7 @@ class CredentialLoginRequest(BaseModel):
 
 @router.post("/signup", response_model=LoginResponse, summary="Sign up with email and password")
 async def signup(request: SignupRequest):
-    """Create an account with email and password and receive a JWT plus your profile."""
+    """Create an account with email and password and receive a JWT plus your profile"""
     # 409 if email already has a password; invite stub rows (no password yet) are hydrated in place.
     # A row may already exist as a stub created by an org invite (no
     # password_hash set). `create_user_with_password` hydrates that stub in
@@ -186,7 +186,7 @@ async def signup(request: SignupRequest):
 
 @router.post("/login", response_model=LoginResponse, summary="Log in with email and password")
 async def login(request: CredentialLoginRequest):
-    """Log in with email and password and receive a JWT plus your profile."""
+    """Log in with email and password and receive a JWT plus your profile"""
     user = get_user_by_email(request.email)
     if not user or not user.get("password_hash"):
         raise HTTPException(status_code=401, detail="Invalid email or password")

--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -196,7 +196,7 @@ async def list_datasets(
 @router.get("/{dataset_id}", response_model=DatasetDetailResponse, summary="Get dataset")
 async def get_dataset_detail(
     dataset_id: str = Path(
-        description="The dataset to retrieve. Must be in your workspace.",
+        description="The dataset to retrieve.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -224,7 +224,7 @@ async def get_dataset_detail(
 async def rename_dataset(
     request: DatasetRenameRequest,
     dataset_id: str = Path(
-        description="The dataset to rename. Must be in your workspace.",
+        description="The dataset to rename.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -248,7 +248,7 @@ async def rename_dataset(
 @router.delete("/{dataset_id}", status_code=204, summary="Delete dataset")
 async def remove_dataset(
     dataset_id: str = Path(
-        description="The dataset to delete. Must be in your workspace.",
+        description="The dataset to delete.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -270,7 +270,7 @@ async def remove_dataset(
 async def add_items(
     items: List[DatasetItemIn],
     dataset_id: str = Path(
-        description="The dataset to add items to. Must be in your workspace.",
+        description="The dataset to add items to.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -303,7 +303,7 @@ async def add_items(
 async def update_item(
     request: DatasetItemUpdate,
     dataset_id: str = Path(
-        description="The dataset containing the item. Must be in your workspace.",
+        description="The dataset containing the item.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     item_uuid: str = Path(
@@ -354,7 +354,7 @@ async def update_item(
 )
 async def remove_item(
     dataset_id: str = Path(
-        description="The dataset containing the item. Must be in your workspace.",
+        description="The dataset containing the item.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     item_uuid: str = Path(

--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -155,7 +155,7 @@ async def create_new_dataset(
     request: DatasetCreateRequest,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create a new empty dataset in your workspace. Add items separately."""
+    """Create a new empty dataset. Add items separately."""
     dataset_uuid = create_dataset(
         name=request.name,
         dataset_type=request.dataset_type,
@@ -173,7 +173,7 @@ async def list_datasets(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List all datasets for your workspace, optionally filtered by type."""
+    """List all datasets, optionally filtered by type."""
     if dataset_type and dataset_type not in ("stt", "tts"):
         raise HTTPException(
             status_code=400, detail="dataset_type must be 'stt' or 'tts'"

--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -312,7 +312,7 @@ async def update_item(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a dataset item."""
+    """Update a dataset item's audio or ground-truth text."""
     row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
     if not row:
         raise HTTPException(status_code=404, detail="Dataset not found")
@@ -363,7 +363,7 @@ async def remove_item(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Delete a dataset item."""
+    """Delete a dataset item from its dataset."""
     row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
     if not row:
         raise HTTPException(status_code=404, detail="Dataset not found")

--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -155,7 +155,7 @@ async def create_new_dataset(
     request: DatasetCreateRequest,
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Create a new empty dataset. Add items separately."""
+    """Create a new empty dataset. Add items separately"""
     dataset_uuid = create_dataset(
         name=request.name,
         dataset_type=request.dataset_type,
@@ -173,7 +173,7 @@ async def list_datasets(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List all datasets, optionally filtered by type."""
+    """List all datasets, optionally filtered by type"""
     if dataset_type and dataset_type not in ("stt", "tts"):
         raise HTTPException(
             status_code=400, detail="dataset_type must be 'stt' or 'tts'"
@@ -201,7 +201,7 @@ async def get_dataset_detail(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get a dataset with all of its items."""
+    """Get a dataset with all of its items"""
     row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
     if not row:
         raise HTTPException(status_code=404, detail="Dataset not found")
@@ -229,7 +229,7 @@ async def rename_dataset(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Rename a dataset."""
+    """Rename a dataset"""
     row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
     if not row:
         raise HTTPException(status_code=404, detail="Dataset not found")
@@ -253,7 +253,7 @@ async def remove_dataset(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Delete a dataset and all of its items."""
+    """Delete a dataset and all of its items"""
     row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
     if not row:
         raise HTTPException(status_code=404, detail="Dataset not found")
@@ -275,7 +275,7 @@ async def add_items(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Append items to a dataset."""
+    """Append items to a dataset"""
     if not items:
         raise HTTPException(status_code=400, detail="items list cannot be empty")
     if len(items) > 1000:
@@ -312,7 +312,7 @@ async def update_item(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a dataset item's audio or ground-truth text."""
+    """Update a dataset item's audio or ground-truth text"""
     row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
     if not row:
         raise HTTPException(status_code=404, detail="Dataset not found")
@@ -363,7 +363,7 @@ async def remove_item(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Delete a dataset item from its dataset."""
+    """Delete a dataset item from its dataset"""
     row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
     if not row:
         raise HTTPException(status_code=404, detail="Dataset not found")

--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -34,7 +34,7 @@ _EXAMPLE_ITEM_UUID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 
 
 class DatasetCreateRequest(BaseModel):
-    name: str = Field(description="Human-readable dataset name, unique within the workspace")
+    name: str = Field(description="Dataset name, unique within the workspace")
     dataset_type: Literal["stt", "tts"] = Field(
         description="`stt` items carry audio + ground-truth text. `tts` items carry text only"
     )
@@ -90,7 +90,7 @@ class DatasetResponse(BaseModel):
         description="Dataset ID",
         examples=[_EXAMPLE_DATASET_UUID],
     )
-    name: str = Field(description="Human-readable dataset name")
+    name: str = Field(description="Dataset name")
     dataset_type: str = Field(description="Dataset type (`stt` or `tts`)")
     item_count: int = Field(description="Number of items in the dataset")
     eval_count: int = Field(description="Number of evaluation jobs that used this dataset")

--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -36,7 +36,7 @@ _EXAMPLE_ITEM_UUID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 class DatasetCreateRequest(BaseModel):
     name: str = Field(description="Human-readable dataset name, unique within the workspace")
     dataset_type: Literal["stt", "tts"] = Field(
-        description="`stt` items carry audio + ground-truth text; `tts` items carry text only"
+        description="`stt` items carry audio + ground-truth text. `tts` items carry text only"
     )
 
 
@@ -47,17 +47,17 @@ class DatasetRenameRequest(BaseModel):
 class DatasetItemIn(BaseModel):
     audio_path: Optional[str] = Field(
         None,
-        description="Audio location as an `s3://bucket/key` URI. **Required for STT datasets; must be omitted for TTS datasets**",
+        description="Audio location as an `s3://bucket/key` URI. **Required for STT datasets. Must be omitted for TTS datasets**",
     )
     text: str = Field(
-        description="For STT, the ground-truth transcript; for TTS, the text to synthesize"
+        description="For STT, the ground-truth transcript. For TTS, the text to synthesize"
     )
 
 
 class DatasetItemUpdate(BaseModel):
     audio_path: Optional[str] = Field(
         None,
-        description="New audio `s3://bucket/key` URI. Omit the field to leave audio unchanged; **STT requires a value, TTS forbids one**",
+        description="New audio `s3://bucket/key` URI. Omit the field to leave audio unchanged. **STT requires a value, TTS forbids one**",
     )
     text: Optional[str] = Field(
         None, description="New item text. Omit to leave text unchanged"

--- a/src/routers/datasets.py
+++ b/src/routers/datasets.py
@@ -312,7 +312,7 @@ async def update_item(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a dataset item's text and/or audio."""
+    """Update a dataset item."""
     row = get_dataset(dataset_id, org_uuid=ctx.org_uuid)
     if not row:
         raise HTTPException(status_code=404, detail="Dataset not found")

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -499,7 +499,7 @@ async def update_evaluator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update an evaluator."""
+    """Update an evaluator, the judge used to grade outputs."""
     existing = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _owner_check(existing, ctx.org_uuid)
     if payload.name is not None:

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -361,7 +361,7 @@ def _evaluator_response(evaluator: Dict[str, Any]) -> EvaluatorResponse:
 async def create_evaluator_endpoint(
     payload: EvaluatorCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a custom evaluator along with its first version, which is set live."""
+    """Create a custom evaluator along with its first version, which is set live"""
     _ensure_unique_evaluator_name(payload.name, ctx.org_uuid)
     with name_uniqueness_guard("Evaluator"):
         evaluator_uuid = create_evaluator(
@@ -423,7 +423,7 @@ async def get_default_prompt(
     ),
     _user_id: str = Depends(get_current_user_id),
 ):
-    """Get the canonical default prompt and suggested config for prefilling the create-evaluator form."""
+    """Get the canonical default prompt and suggested config for prefilling the create-evaluator form"""
     if purpose not in DEFAULT_PROMPTS_BY_PURPOSE:
         raise HTTPException(status_code=404, detail=f"Unknown purpose: {purpose}")
     p = DEFAULT_PROMPTS_BY_PURPOSE[purpose]
@@ -454,7 +454,7 @@ async def list_evaluators(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List evaluators visible, each with its inlined live version."""
+    """List your evaluators"""
     evaluators = get_all_evaluators(
         org_uuid=ctx.org_uuid,
         include_defaults=include_defaults,
@@ -472,7 +472,7 @@ async def get_evaluator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one evaluator with its full version history."""
+    """Get one evaluator with its full version history"""
     evaluator = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     base = _evaluator_response(evaluator)
     output_type = evaluator.get("output_type", "binary")
@@ -499,7 +499,7 @@ async def update_evaluator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update an evaluator, the judge used to grade outputs."""
+    """Update an evaluator, the judge used to grade outputs"""
     existing = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _owner_check(existing, ctx.org_uuid)
     if payload.name is not None:
@@ -532,7 +532,7 @@ async def delete_evaluator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a custom evaluator."""
+    """Soft-delete a custom evaluator"""
     existing = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _owner_check(existing, ctx.org_uuid)
     if not delete_evaluator(evaluator_uuid):
@@ -549,7 +549,7 @@ async def duplicate_evaluator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Copy any visible evaluator (including a seeded default) into a new editable custom evaluator that you own."""
+    """Copy any visible evaluator (including a seeded default) into a new editable custom evaluator that you own"""
     _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _ensure_unique_evaluator_name(payload.name, ctx.org_uuid)
     with name_uniqueness_guard("Evaluator"):
@@ -578,7 +578,7 @@ async def list_versions(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List an evaluator's full version history, oldest first."""
+    """List an evaluator's full version history, oldest first"""
     evaluator = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     # Pass `output_type` so binary versions stored with a null
     # output_config surface the Correct/Wrong default — consistent with
@@ -599,7 +599,7 @@ async def create_version(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Add a new version to a custom evaluator."""
+    """Add a new version to a custom evaluator"""
     existing = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _owner_check(existing, ctx.org_uuid)
     cfg = payload.output_config.model_dump(exclude_none=True) if payload.output_config else None
@@ -631,7 +631,7 @@ async def mark_live(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Set which version is the evaluator's live version."""
+    """Set which version is the evaluator's live version"""
     existing = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _owner_check(existing, ctx.org_uuid)
     ok = set_evaluator_live_version(evaluator_uuid, payload.version_uuid)
@@ -665,7 +665,7 @@ async def preview_prompt(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Render a version's system prompt with the supplied variables and return the resolved text."""
+    """Render a version's system prompt with the supplied variables and return the resolved text"""
     evaluator = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     version_uuid = payload.version_uuid or evaluator.get("live_version_id")
     if not version_uuid:

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -467,7 +467,7 @@ async def list_evaluators(
 @router.get("/{evaluator_uuid}", response_model=EvaluatorDetailResponse, summary="Get evaluator")
 async def get_evaluator_endpoint(
     evaluator_uuid: str = Path(
-        description="Evaluator to retrieve. Must be in your workspace.",
+        description="Evaluator to retrieve.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -494,7 +494,7 @@ async def get_evaluator_endpoint(
 async def update_evaluator_endpoint(
     payload: EvaluatorUpdate,
     evaluator_uuid: str = Path(
-        description="Evaluator to update. Must be in your workspace.",
+        description="Evaluator to update.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -527,7 +527,7 @@ async def update_evaluator_endpoint(
 @router.delete("/{evaluator_uuid}", summary="Delete evaluator")
 async def delete_evaluator_endpoint(
     evaluator_uuid: str = Path(
-        description="Evaluator to delete. Must be in your workspace.",
+        description="Evaluator to delete.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -573,7 +573,7 @@ async def duplicate_evaluator_endpoint(
 @router.get("/{evaluator_uuid}/versions", response_model=List[EvaluatorVersionResponse], summary="List evaluator versions")
 async def list_versions(
     evaluator_uuid: str = Path(
-        description="Evaluator whose versions to list. Must be in your workspace.",
+        description="Evaluator whose versions to list.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -594,7 +594,7 @@ async def list_versions(
 async def create_version(
     payload: EvaluatorVersionCreateRequest,
     evaluator_uuid: str = Path(
-        description="Evaluator to add a version to. Must be in your workspace.",
+        description="Evaluator to add a version to.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -626,7 +626,7 @@ async def create_version(
 async def mark_live(
     payload: SetLiveVersionRequest,
     evaluator_uuid: str = Path(
-        description="Evaluator whose live version to set. Must be in your workspace.",
+        description="Evaluator whose live version to set.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -660,7 +660,7 @@ class PromptPreviewRequest(BaseModel):
 async def preview_prompt(
     payload: PromptPreviewRequest,
     evaluator_uuid: str = Path(
-        description="Evaluator whose prompt to preview. Must be in your workspace.",
+        description="Evaluator whose prompt to preview.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -66,7 +66,7 @@ class OutputConfig(BaseModel):
 
 class VariableSpec(BaseModel):
     name: str = Field(description="`{{placeholder}}` name used in the system prompt (immutable across versions)")
-    description: Optional[str] = Field(None, description="Human-readable description of the variable. Omit if self-evident")
+    description: Optional[str] = Field(None, description="Description of the variable. Omit if self-evident")
     default: Optional[str] = Field(None, description="Default value used when you omit this variable. Omit for no default")
 
 
@@ -98,7 +98,7 @@ class EvaluatorVersionCreateRequest(EvaluatorVersionCreate):
 
 class EvaluatorCreate(BaseModel):
     name: str = Field(..., min_length=1, description="Evaluator name, unique within your workspace")
-    description: Optional[str] = Field(None, description="Human-readable description. Omit to leave blank")
+    description: Optional[str] = Field(None, description="Description. Omit to leave blank")
     evaluator_type: EvaluatorTypeLiteral = Field(
         "llm",
         description="Semantic category: `tts` judges TTS audio, `stt` one transcript, `llm` a reply with history, `llm-general` a standalone input->output pair, `conversation` a full conversation",
@@ -157,7 +157,7 @@ class EvaluatorVersionResponse(BaseModel):
     output_config: Optional[Dict[str, Any]] = Field(
         None, description="Rubric for this version. Binary versions fall back to the default Correct/Wrong scale"
     )
-    variables: Optional[List[Dict[str, Any]]] = Field(None, description="Declared prompt variables, or null if none")
+    variables: Optional[List[Dict[str, Any]]] = Field(None, description="Declared prompt variables")
     created_at: str = Field(description="Version creation timestamp (ISO 8601 UTC)")
 
 
@@ -179,7 +179,7 @@ class EvaluatorResponseBase(BaseModel):
         examples=[_EXAMPLE_EVALUATOR_UUID],
     )
     name: str = Field(description="Evaluator name")
-    description: Optional[str] = Field(None, description="Human-readable description, or null")
+    description: Optional[str] = Field(None, description="What the evaluator checks")
     evaluator_type: EvaluatorTypeLiteral = Field(
         description="Semantic category"
     )
@@ -412,7 +412,7 @@ class DefaultPromptResponse(BaseModel):
     data_type: DataTypeLiteral = Field(description="Suggested medium")
     kind: Literal["single", "side_by_side"] = Field(description="Suggested scoring mode")
     output_type: Literal["binary", "rating"] = Field(description="Suggested output shape")
-    output_config: Optional[Dict[str, Any]] = Field(None, description="Suggested rubric, or null")
+    output_config: Optional[Dict[str, Any]] = Field(None, description="Suggested rubric")
     variables: List[Dict[str, Any]] = Field(default=[], description="Suggested prompt variables (empty if none)")
 
 

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -499,7 +499,7 @@ async def update_evaluator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update an evaluator's name, description, and classification fields."""
+    """Update an evaluator."""
     existing = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _owner_check(existing, ctx.org_uuid)
     if payload.name is not None:

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -71,7 +71,7 @@ class VariableSpec(BaseModel):
 
 
 class EvaluatorVersionCreate(BaseModel):
-    """Version-level config — prompt, model, variables, and the rubric (output_config).
+    """Version-level config: prompt, model, variables, and the rubric (output_config).
 
  The rubric is version-owned so links that pin a version (tests, simulations) get
  reproducible judge prompts even if the evaluator's live version is later changed.
@@ -167,7 +167,7 @@ class EvaluatorResponseBase(BaseModel):
  `live_version_id` is the FK pointer to the current live version. List
  views inline the full version on `live_version` because there's no
  `versions[]` to look it up in. Detail views skip the inlined block and
- expose `versions[]` instead — clients resolve the live version by
+ expose `versions[]` instead. Clients resolve the live version by
  matching `live_version_id` to a version entry's `uuid` (avoids
  duplicating the same version payload twice in the same response).
  """
@@ -398,7 +398,7 @@ async def create_evaluator_endpoint(
 class DefaultPromptResponse(BaseModel):
     """Canonical default prompt for a given purpose. Used by the frontend to prefill the
  create-evaluator form. The `name` field is null for `purpose=conversation` because there's
- no seeded conversation evaluator — the prompt is just a template."""
+ no seeded conversation evaluator. The prompt is just a template."""
 
     purpose: Literal["llm", "llm-general", "stt", "tts", "conversation"] = Field(
         description="Evaluation purpose this default prompt targets"

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -361,7 +361,7 @@ def _evaluator_response(evaluator: Dict[str, Any]) -> EvaluatorResponse:
 async def create_evaluator_endpoint(
     payload: EvaluatorCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a custom evaluator in your workspace along with its first version, which is set live."""
+    """Create a custom evaluator along with its first version, which is set live."""
     _ensure_unique_evaluator_name(payload.name, ctx.org_uuid)
     with name_uniqueness_guard("Evaluator"):
         evaluator_uuid = create_evaluator(
@@ -454,7 +454,7 @@ async def list_evaluators(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List evaluators visible in your workspace, each with its inlined live version."""
+    """List evaluators visible, each with its inlined live version."""
     evaluators = get_all_evaluators(
         org_uuid=ctx.org_uuid,
         include_defaults=include_defaults,
@@ -532,7 +532,7 @@ async def delete_evaluator_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a custom evaluator in your workspace."""
+    """Soft-delete a custom evaluator."""
     existing = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _owner_check(existing, ctx.org_uuid)
     if not delete_evaluator(evaluator_uuid):
@@ -599,7 +599,7 @@ async def create_version(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Add a new version to a custom evaluator in your workspace."""
+    """Add a new version to a custom evaluator."""
     existing = _visible_or_404(get_evaluator(evaluator_uuid), ctx.org_uuid)
     _owner_check(existing, ctx.org_uuid)
     cfg = payload.output_config.model_dump(exclude_none=True) if payload.output_config else None

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -78,10 +78,10 @@ class EvaluatorVersionCreate(BaseModel):
  """
 
     judge_model: str = Field(description="Model that runs the judge (e.g. an OpenRouter model slug)")
-    system_prompt: str = Field(description="Judge system prompt; may contain `{{variable}}` placeholders")
+    system_prompt: str = Field(description="Judge system prompt. May contain `{{variable}}` placeholders")
     output_config: Optional[OutputConfig] = Field(
         None,
-        description="Rubric definition. **Required for `output_type=rating`**; omit for `binary` to use the default Correct/Wrong scale",
+        description="Rubric definition. **Required for `output_type=rating`**. Omit for `binary` to use the default Correct/Wrong scale",
     )
     variables: Optional[List[VariableSpec]] = Field(
         None, description="Declared prompt variables. Omit if the prompt has no `{{placeholders}}`"
@@ -104,15 +104,15 @@ class EvaluatorCreate(BaseModel):
         description="Semantic category: `tts` judges TTS audio, `stt` one transcript, `llm` a reply with history, `llm-general` a standalone input->output pair, `conversation` a full conversation",
     )
     data_type: DataTypeLiteral = Field(
-        "text", description="Medium the judge consumes; the only field gating audio routing"
+        "text", description="Medium the judge consumes. The only field gating audio routing"
     )
     kind: Literal["single", "side_by_side"] = Field(
-        "single", description="`single` judges one output; `side_by_side` compares two and picks a winner"
+        "single", description="`single` judges one output. `side_by_side` compares two and picks a winner"
     )
     output_type: Literal["binary", "rating"] = Field(
-        "binary", description="`binary` = pass/fail; `rating` = numeric scale (requires `version.output_config.scale`)"
+        "binary", description="`binary` = pass/fail. `rating` = numeric scale (requires `version.output_config.scale`)"
     )
-    version: EvaluatorVersionCreate = Field(description="Initial version (prompt, model, rubric, variables); set as live on creation")
+    version: EvaluatorVersionCreate = Field(description="Initial version (prompt, model, rubric, variables). Set as live on creation")
 
     @model_validator(mode="after")
     def _validate_output(self):
@@ -155,7 +155,7 @@ class EvaluatorVersionResponse(BaseModel):
     judge_model: str = Field(description="Model that runs the judge for this version")
     system_prompt: str = Field(description="Judge system prompt, with `{{variable}}` placeholders unrendered")
     output_config: Optional[Dict[str, Any]] = Field(
-        None, description="Rubric for this version; binary versions fall back to the default Correct/Wrong scale"
+        None, description="Rubric for this version. Binary versions fall back to the default Correct/Wrong scale"
     )
     variables: Optional[List[Dict[str, Any]]] = Field(None, description="Declared prompt variables, or null if none")
     created_at: str = Field(description="Version creation timestamp (ISO 8601 UTC)")
@@ -190,15 +190,15 @@ class EvaluatorResponseBase(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="Creator user ID; null for seeded defaults visible in your workspace but not editable by you",
+        description="Creator user ID. Null for seeded defaults visible in your workspace but not editable by you",
         examples=[_EXAMPLE_USER_UUID],
     )
-    slug: Optional[str] = Field(None, description="Stable slug for seeded defaults; null for custom evaluators")
+    slug: Optional[str] = Field(None, description="Stable slug for seeded defaults. Null for custom evaluators")
     live_version_id: Optional[str] = Field(
         None,
         min_length=36,
         max_length=36,
-        description="ID of the current live version; null if none is set",
+        description="ID of the current live version. Null if none is set",
         examples=[_EXAMPLE_VERSION_UUID],
     )
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")
@@ -209,7 +209,7 @@ class EvaluatorResponse(EvaluatorResponseBase):
     # List shape: no `versions[]` here, so we inline the live version for
     # the FE.
     live_version: Optional[EvaluatorVersionResponse] = Field(
-        None, description="Full live version inlined for list views; null if the evaluator has no live version"
+        None, description="Full live version inlined for list views. Null if the evaluator has no live version"
     )
 
 
@@ -221,7 +221,7 @@ class EvaluatorDetailResponse(EvaluatorResponseBase):
     # scanning `versions[]` by uuid.
     versions: List[EvaluatorVersionResponse] = Field(description="Full version history, oldest first")
     live_version_index: Optional[int] = Field(
-        None, description="Array position of the live version within `versions[]`; null if unset or unresolved"
+        None, description="Array position of the live version within `versions[]`. Null if unset or unresolved"
     )
 
 
@@ -404,7 +404,7 @@ class DefaultPromptResponse(BaseModel):
         description="Evaluation purpose this default prompt targets"
     )
     name: Optional[str] = Field(
-        None, description="Seeded evaluator name; null for `conversation` (template only, no seeded evaluator)"
+        None, description="Seeded evaluator name. Null for `conversation` (template only, no seeded evaluator)"
     )
     system_prompt: str = Field(description="Suggested judge system prompt for prefilling the create form")
     judge_model: str = Field(description="Suggested judge model")

--- a/src/routers/evaluators.py
+++ b/src/routers/evaluators.py
@@ -49,7 +49,7 @@ class OutputScaleEntry(BaseModel):
     value: Any = Field(
         description="Scale point value: `bool` for `binary` (2 entries), numeric for `rating` (N>=2 entries)"
     )
-    name: str = Field(description="Short human-readable label for this scale point")
+    name: str = Field(description="Short label for this scale point")
     description: Optional[str] = Field(
         None,
         description="Rubric text for this level, injected into the judge prompt. Omit to leave this level undescribed",

--- a/src/routers/jobs.py
+++ b/src/routers/jobs.py
@@ -71,7 +71,7 @@ async def list_jobs(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List jobs, newest first."""
+    """List jobs, newest first"""
     db_job_type = JOB_TYPE_MAP.get(job_type) if job_type else None
 
     jobs = get_all_jobs(org_uuid=ctx.org_uuid, job_type=db_job_type)
@@ -114,7 +114,7 @@ async def delete_job_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Delete a job, stopping it first if it is still running."""
+    """Delete a job, stopping it first if it is still running"""
     job = get_job(job_uuid, org_uuid=ctx.org_uuid)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")

--- a/src/routers/jobs.py
+++ b/src/routers/jobs.py
@@ -37,17 +37,17 @@ class JobListItem(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="Source dataset ID; `null` when the dataset has since been deleted",
+        description="Source dataset ID. `null` when the dataset has since been deleted",
     )
     dataset_name: Optional[str] = Field(
         None,
-        description="Source dataset name; `null` when the dataset has since been deleted",
+        description="Source dataset name. `null` when the dataset has since been deleted",
     )
     details: Optional[Dict[str, Any]] = Field(
-        None, description="Job configuration and runtime metadata; `null` if unset"
+        None, description="Job configuration and runtime metadata. `null` if unset"
     )
     results: Optional[Dict[str, Any]] = Field(
-        None, description="Job output payload; `null` until the job produces results"
+        None, description="Job output payload. `null` until the job produces results"
     )
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
@@ -67,7 +67,7 @@ JOB_TYPE_MAP = {
 @router.get("", response_model=JobsListResponse, summary="List jobs")
 async def list_jobs(
     job_type: Optional[JobType] = Query(
-        None, description="Filter jobs by type; omit for all types"
+        None, description="Filter jobs by type. Omit for all types"
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):

--- a/src/routers/jobs.py
+++ b/src/routers/jobs.py
@@ -71,7 +71,7 @@ async def list_jobs(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List jobs for your workspace, newest first."""
+    """List jobs, newest first."""
     db_job_type = JOB_TYPE_MAP.get(job_type) if job_type else None
 
     jobs = get_all_jobs(org_uuid=ctx.org_uuid, job_type=db_job_type)

--- a/src/routers/org_limits.py
+++ b/src/routers/org_limits.py
@@ -75,7 +75,7 @@ class OrgLimitsCreateResponse(BaseModel):
 
 @router.get("/me/max-rows-per-eval", summary="Get own max rows per eval")
 async def get_max_rows_per_eval(ctx: OrgContext = Depends(get_current_org)):
-    """Get the max rows per eval for your workspace."""
+    """Get the max rows per eval."""
     # Falls back to DEFAULT_MAX_ROWS_PER_EVAL when no workspace-specific limit is set.
     limits = get_org_limits(ctx.org_uuid)
     if limits and "max_rows_per_eval" in limits.get("limits", {}):

--- a/src/routers/org_limits.py
+++ b/src/routers/org_limits.py
@@ -75,7 +75,7 @@ class OrgLimitsCreateResponse(BaseModel):
 
 @router.get("/me/max-rows-per-eval", summary="Get own max rows per eval")
 async def get_max_rows_per_eval(ctx: OrgContext = Depends(get_current_org)):
-    """Get the max rows per eval."""
+    """Get the max rows per eval"""
     # Falls back to DEFAULT_MAX_ROWS_PER_EVAL when no workspace-specific limit is set.
     limits = get_org_limits(ctx.org_uuid)
     if limits and "max_rows_per_eval" in limits.get("limits", {}):
@@ -87,7 +87,7 @@ async def get_max_rows_per_eval(ctx: OrgContext = Depends(get_current_org)):
 async def create_org_limits_endpoint(
     data: OrgLimitsCreate, user_id: str = Depends(require_superadmin)
 ):
-    """Create limits for a workspace. Superadmin only."""
+    """Create limits for a workspace. Superadmin only"""
     # 404 if workspace missing; 409 if limits already exist (use PUT to update).
     if not get_organization(data.org_uuid):
         raise HTTPException(status_code=404, detail="Organization not found")
@@ -117,7 +117,7 @@ async def get_org_limits_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get limits for a workspace you belong to."""
+    """Get limits for a workspace you belong to"""
     if get_member_role(target_org_uuid, ctx.user_id) is None and not is_superadmin_user(ctx.user_id):
         raise HTTPException(status_code=404, detail="Organization limits not found")
     limits = get_org_limits(target_org_uuid)
@@ -135,7 +135,7 @@ async def update_org_limits_endpoint(
     data: OrgLimitsUpdate = ...,
     user_id: str = Depends(require_superadmin),
 ):
-    """Update limits for a workspace. Superadmin only."""
+    """Update limits for a workspace. Superadmin only"""
     updated = update_org_limits(org_uuid=target_org_uuid, limits=data.limits)
     if not updated:
         raise HTTPException(status_code=404, detail="Organization limits not found")
@@ -150,7 +150,7 @@ async def delete_org_limits_endpoint(
     ),
     user_id: str = Depends(require_superadmin),
 ):
-    """Delete limits for a workspace, reverting it to the server default. Superadmin only."""
+    """Delete limits for a workspace, reverting it to the server default. Superadmin only"""
     deleted = delete_org_limits(target_org_uuid)
     if not deleted:
         raise HTTPException(status_code=404, detail="Organization limits not found")

--- a/src/routers/organizations.py
+++ b/src/routers/organizations.py
@@ -40,7 +40,7 @@ class OrganizationResponse(BaseModel):
     )
     member_role: Optional[MemberRoleLiteral] = Field(
         None,
-        description="Your role in this workspace; `null` when not resolved",
+        description="Your role in this workspace. `null` when not resolved",
     )
     created_at: str = Field(description="When the workspace was created (ISO 8601 UTC)")
     updated_at: str = Field(description="When the workspace was last updated (ISO 8601 UTC)")
@@ -58,7 +58,7 @@ class AddMemberRequest(BaseModel):
     email: str = Field(
         ...,
         min_length=3,
-        description="Email of the person to add; a stub account is created if they have not signed up yet",
+        description="Email of the person to add. A stub account is created if they have not signed up yet",
     )
 
 

--- a/src/routers/organizations.py
+++ b/src/routers/organizations.py
@@ -92,7 +92,7 @@ def _require_membership(org_uuid: str, user_id: str) -> str:
 
 @router.get("", response_model=List[OrganizationResponse], summary="List workspaces")
 async def list_orgs(user_id: str = Depends(get_current_user_id)):
-    """List every workspace you are an active member of."""
+    """List every workspace you are an active member of"""
     return [OrganizationResponse(**o) for o in list_organizations_for_user(user_id)]
 
 
@@ -101,7 +101,7 @@ async def create_org(
     request: CreateOrganizationRequest,
     user_id: str = Depends(get_current_user_id),
 ):
-    """Create a new (non-personal) workspace with you as owner."""
+    """Create a new (non-personal) workspace with you as owner"""
     org_uuid = create_organization(name=request.name, owner_user_id=user_id)
     org = get_organization(org_uuid)
     return OrganizationResponse(**org, member_role="owner")
@@ -116,7 +116,7 @@ async def rename_org(
     request: UpdateOrganizationRequest = ...,
     user_id: str = Depends(get_current_user_id),
 ):
-    """Rename a workspace you belong to."""
+    """Rename a workspace you belong to"""
     role = _require_membership(org_uuid, user_id)
     update_organization_name(org_uuid, request.name)
     org = get_organization(org_uuid)
@@ -131,7 +131,7 @@ async def list_members(
     ),
     user_id: str = Depends(get_current_user_id),
 ):
-    """List members of a workspace you belong to."""
+    """List members of a workspace you belong to"""
     _require_membership(org_uuid, user_id)
     return [MemberResponse(**m) for m in list_organization_members(org_uuid)]
 
@@ -150,7 +150,7 @@ async def add_member(
     request: AddMemberRequest = ...,
     user_id: str = Depends(get_current_user_id),
 ):
-    """Add a member to a workspace as admin."""
+    """Add a member to a workspace as admin"""
     # Stub accounts are hydrated when the invitee signs up; they then see this workspace immediately.
     _require_membership(org_uuid, user_id)
     try:
@@ -179,7 +179,7 @@ async def remove_member(
     ),
     user_id: str = Depends(get_current_user_id),
 ):
-    """Remove a member from a workspace. Owners cannot be removed."""
+    """Remove a member from a workspace. Owners cannot be removed"""
     _require_membership(org_uuid, user_id)
     try:
         removed = remove_organization_member(org_uuid, target_user_id)

--- a/src/routers/personas.py
+++ b/src/routers/personas.py
@@ -88,7 +88,7 @@ async def create_persona_endpoint(
 
 @router.get("", response_model=List[PersonaResponse], summary="List personas")
 async def list_personas(ctx: OrgContext = Depends(get_current_org)):
-    """List all personas."""
+    """List your personas, each with its config."""
     personas = get_all_personas(org_uuid=ctx.org_uuid)
     return personas
 
@@ -101,7 +101,7 @@ async def get_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get a persona."""
+    """Get one persona by ID, including its config."""
     persona = get_persona(persona_uuid)
     if not persona or persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")
@@ -117,7 +117,7 @@ async def update_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a persona."""
+    """Update a persona, a simulated user profile used in simulations."""
     existing_persona = get_persona(persona_uuid)
     if not existing_persona or existing_persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")

--- a/src/routers/personas.py
+++ b/src/routers/personas.py
@@ -117,7 +117,7 @@ async def update_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a persona's fields. Only the provided fields change; omitted fields are left as-is."""
+    """Update a persona's fields. Only the provided fields change. Omitted fields are left as-is."""
     existing_persona = get_persona(persona_uuid)
     if not existing_persona or existing_persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")

--- a/src/routers/personas.py
+++ b/src/routers/personas.py
@@ -117,7 +117,7 @@ async def update_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a persona's fields. Only the provided fields change. Omitted fields are left as-is."""
+    """Update a persona."""
     existing_persona = get_persona(persona_uuid)
     if not existing_persona or existing_persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")

--- a/src/routers/personas.py
+++ b/src/routers/personas.py
@@ -72,7 +72,7 @@ class PersonaCreateResponse(BaseModel):
 async def create_persona_endpoint(
     persona: PersonaCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a new persona in your workspace."""
+    """Create a new persona."""
     with ensure_name_unique("personas", persona.name, ctx.org_uuid, entity="Persona"):
         persona_uuid = create_persona(
             name=persona.name,
@@ -88,7 +88,7 @@ async def create_persona_endpoint(
 
 @router.get("", response_model=List[PersonaResponse], summary="List personas")
 async def list_personas(ctx: OrgContext = Depends(get_current_org)):
-    """List all personas in your workspace."""
+    """List all personas."""
     personas = get_all_personas(org_uuid=ctx.org_uuid)
     return personas
 
@@ -101,7 +101,7 @@ async def get_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get a persona in your workspace."""
+    """Get a persona."""
     persona = get_persona(persona_uuid)
     if not persona or persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")
@@ -151,7 +151,7 @@ async def delete_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a persona in your workspace."""
+    """Soft-delete a persona."""
     existing_persona = get_persona(persona_uuid)
     if not existing_persona or existing_persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")

--- a/src/routers/personas.py
+++ b/src/routers/personas.py
@@ -72,7 +72,7 @@ class PersonaCreateResponse(BaseModel):
 async def create_persona_endpoint(
     persona: PersonaCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a new persona."""
+    """Create a new persona"""
     with ensure_name_unique("personas", persona.name, ctx.org_uuid, entity="Persona"):
         persona_uuid = create_persona(
             name=persona.name,
@@ -88,7 +88,7 @@ async def create_persona_endpoint(
 
 @router.get("", response_model=List[PersonaResponse], summary="List personas")
 async def list_personas(ctx: OrgContext = Depends(get_current_org)):
-    """List your personas, each with its config."""
+    """List your personas"""
     personas = get_all_personas(org_uuid=ctx.org_uuid)
     return personas
 
@@ -101,7 +101,7 @@ async def get_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one persona by ID, including its config."""
+    """Get one persona by ID"""
     persona = get_persona(persona_uuid)
     if not persona or persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")
@@ -117,7 +117,7 @@ async def update_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a persona, a simulated user profile used in simulations."""
+    """Update a persona, a simulated user profile used in simulations"""
     existing_persona = get_persona(persona_uuid)
     if not existing_persona or existing_persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")
@@ -151,7 +151,7 @@ async def delete_persona_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a persona."""
+    """Soft-delete a persona"""
     existing_persona = get_persona(persona_uuid)
     if not existing_persona or existing_persona.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Persona not found")

--- a/src/routers/personas.py
+++ b/src/routers/personas.py
@@ -19,7 +19,7 @@ _EXAMPLE_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 
 
 class PersonaCreate(BaseModel):
-    name: str = Field(description="Human-readable persona name, unique within the workspace")
+    name: str = Field(description="Persona name, unique within the workspace")
     description: Optional[str] = Field(
         None, description="Free-text description of the persona. Omit to leave unset"
     )
@@ -47,7 +47,7 @@ class PersonaResponse(BaseModel):
         description="ID of the persona",
         examples=[_EXAMPLE_ID],
     )
-    name: str = Field(description="Human-readable persona name")
+    name: str = Field(description="Persona name")
     description: Optional[str] = Field(
         None, description="Free-text description, or null if unset"
     )
@@ -65,7 +65,7 @@ class PersonaCreateResponse(BaseModel):
         description="ID of the newly created persona",
         examples=[_EXAMPLE_ID],
     )
-    message: str = Field(description="Human-readable success message")
+    message: str = Field(description="Success message")
 
 
 @router.post("", response_model=PersonaCreateResponse, summary="Create persona")

--- a/src/routers/personas.py
+++ b/src/routers/personas.py
@@ -96,7 +96,7 @@ async def list_personas(ctx: OrgContext = Depends(get_current_org)):
 @router.get("/{persona_uuid}", response_model=PersonaResponse, summary="Get persona")
 async def get_persona_endpoint(
     persona_uuid: str = Path(
-        description="The persona to retrieve. Must be in your workspace.",
+        description="The persona to retrieve.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -112,7 +112,7 @@ async def get_persona_endpoint(
 async def update_persona_endpoint(
     persona: PersonaUpdate,
     persona_uuid: str = Path(
-        description="The persona to update. Must be in your workspace.",
+        description="The persona to update.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -146,7 +146,7 @@ async def update_persona_endpoint(
 @router.delete("/{persona_uuid}", summary="Delete persona")
 async def delete_persona_endpoint(
     persona_uuid: str = Path(
-        description="The persona to delete. Must be in your workspace.",
+        description="The persona to delete.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -1,7 +1,7 @@
 """Public endpoints for shared eval and run results.
 
 View STT/TTS runs, agent tests, benchmarks, simulations, and annotation
-results via share links — no sign-in required. Annotator labelling jobs use
+results via share links, no sign-in required. Annotator labelling jobs use
 a separate token for read-write access.
 """
 

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -94,22 +94,22 @@ class PublicSTTResponse(BaseModel):
         examples=[_EXAMPLE_TASK_UUID],
     )
     status: TaskStatus = Field(description="Job status")
-    language: Optional[str] = Field(None, description="Evaluated language code; `null` if unset")
+    language: Optional[str] = Field(None, description="Evaluated language code. `null` if unset")
     dataset_id: Optional[str] = Field(
         None,
         min_length=36,
         max_length=36,
-        description="Source dataset ID; `null` if unavailable",
+        description="Source dataset ID. `null` if unavailable",
         examples=[_EXAMPLE_DATASET_UUID],
     )
-    dataset_name: Optional[str] = Field(None, description="Source dataset name; `null` if unavailable")
+    dataset_name: Optional[str] = Field(None, description="Source dataset name. `null` if unavailable")
     provider_results: Optional[List[ProviderResult]] = Field(
-        None, description="Per-provider transcription results and metrics; `null` until available"
+        None, description="Per-provider transcription results and metrics. `null` until available"
     )
     leaderboard_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Ranked provider comparison; `null` if not yet computed"
+        None, description="Ranked provider comparison. `null` if not yet computed"
     )
-    error: Optional[str] = Field(None, description="Failure message; `null` on success")
+    error: Optional[str] = Field(None, description="Failure message. `null` on success")
 
 
 class PublicTTSResponse(BaseModel):
@@ -120,22 +120,22 @@ class PublicTTSResponse(BaseModel):
         examples=[_EXAMPLE_TASK_UUID],
     )
     status: TaskStatus = Field(description="Job status")
-    language: Optional[str] = Field(None, description="Evaluated language code; `null` if unset")
+    language: Optional[str] = Field(None, description="Evaluated language code. `null` if unset")
     dataset_id: Optional[str] = Field(
         None,
         min_length=36,
         max_length=36,
-        description="Source dataset ID; `null` if unavailable",
+        description="Source dataset ID. `null` if unavailable",
         examples=[_EXAMPLE_DATASET_UUID],
     )
-    dataset_name: Optional[str] = Field(None, description="Source dataset name; `null` if unavailable")
+    dataset_name: Optional[str] = Field(None, description="Source dataset name. `null` if unavailable")
     provider_results: Optional[List[ProviderResult]] = Field(
-        None, description="Per-provider synthesis results and metrics; `null` until available"
+        None, description="Per-provider synthesis results and metrics. `null` until available"
     )
     leaderboard_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Ranked provider comparison; `null` if not yet computed"
+        None, description="Ranked provider comparison. `null` if not yet computed"
     )
-    error: Optional[str] = Field(None, description="Failure message; `null` on success")
+    error: Optional[str] = Field(None, description="Failure message. `null` on success")
 
 
 class PublicTestRunResponse(BaseModel):
@@ -146,18 +146,18 @@ class PublicTestRunResponse(BaseModel):
         examples=[_EXAMPLE_TASK_UUID],
     )
     status: TaskStatus = Field(description="Run status")
-    total_tests: Optional[int] = Field(None, description="Total test cases in the run; `null` until known")
-    passed: Optional[int] = Field(None, description="Test cases that passed; `null` until computed")
-    failed: Optional[int] = Field(None, description="Test cases that failed; `null` until computed")
+    total_tests: Optional[int] = Field(None, description="Total test cases in the run. `null` until known")
+    passed: Optional[int] = Field(None, description="Test cases that passed. `null` until computed")
+    failed: Optional[int] = Field(None, description="Test cases that failed. `null` until computed")
     # Top-level evaluator block — name/description/output_type/rubric
     # shared across every judge_results row. Rows reference back via
     # `evaluator_uuid` so the rubric isn't duplicated per test case.
     evaluators: Optional[List[Dict[str, Any]]] = Field(
         None,
-        description="Shared evaluator definitions (name, description, output type, rubric); rows reference these by evaluator ID",
+        description="Shared evaluator definitions (name, description, output type, rubric). Rows reference these by evaluator ID",
     )
     results: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Per-test-case results; `null` until the run produces them"
+        None, description="Per-test-case results. `null` until the run produces them"
     )
     # Aggregated latency/cost/total_tokens: {mean, min, max, count}. Values are
     # `Any` — don't assume int: total_tokens is per-run an int but its aggregate
@@ -165,15 +165,15 @@ class PublicTestRunResponse(BaseModel):
     # or token usage reported).
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated latency (`{p50, p95, p99, count}`); `null` for eval-only runs or when not reported",
+        description="Aggregated latency (`{p50, p95, p99, count}`). `null` for eval-only runs or when not reported",
     )
     cost: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated cost in USD (`{mean, min, max, count}`); `null` when no cost is reported",
+        description="Aggregated cost in USD (`{mean, min, max, count}`). `null` when no cost is reported",
     )
     total_tokens: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated token usage (`{mean, min, max, count}`); `null` when not reported",
+        description="Aggregated token usage (`{mean, min, max, count}`). `null` when not reported",
     )
     error: bool = Field(False, description="`true` if the run failed")
 
@@ -190,13 +190,13 @@ class PublicBenchmarkResponse(BaseModel):
     # test_results inside model_results[] (all models run the same suite).
     evaluators: Optional[List[Dict[str, Any]]] = Field(
         None,
-        description="Shared evaluator definitions referenced by every model's results; `null` until available",
+        description="Shared evaluator definitions referenced by every model's results. `null` until available",
     )
     model_results: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Per-model test results (all models run the same suite); `null` until available"
+        None, description="Per-model test results (all models run the same suite). `null` until available"
     )
     leaderboard_summary: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Ranked model comparison; `null` if not yet computed"
+        None, description="Ranked model comparison. `null` if not yet computed"
     )
     error: bool = Field(False, description="`true` if the run failed")
 
@@ -212,16 +212,16 @@ class PublicSimulationRunResponse(BaseModel):
     status: TaskStatus = Field(description="Run status")
     type: SimulationRunType = Field(description="Simulation type")
     updated_at: str = Field(description="When the run was last updated (ISO 8601 UTC)")
-    total_simulations: Optional[int] = Field(None, description="Number of simulations in the run; `null` until known")
-    metrics: Optional[Dict[str, Any]] = Field(None, description="Aggregated run metrics; `null` until computed")
+    total_simulations: Optional[int] = Field(None, description="Number of simulations in the run. `null` until known")
+    metrics: Optional[Dict[str, Any]] = Field(None, description="Aggregated run metrics. `null` until computed")
     simulation_results: Optional[List[Dict[str, Any]]] = Field(
         None,
-        description="Per-simulation results; voice runs include freshly presigned audio URLs. `null` until available",
+        description="Per-simulation results. Voice runs include freshly presigned audio URLs. `null` until available",
     )
     evaluators: Optional[List[SimulationEvaluatorRef]] = Field(
-        None, description="Evaluators applied to the run; `null` if none"
+        None, description="Evaluators applied to the run. `null` if none"
     )
-    error: Optional[str] = Field(None, description="Failure message; `null` on success")
+    error: Optional[str] = Field(None, description="Failure message. `null` on success")
 
 
 class PublicAnnotationEvalTaskRef(BaseModel):
@@ -235,7 +235,7 @@ class PublicAnnotationEvalTaskRef(BaseModel):
     type: AnnotationTaskTypeLiteral = Field(
         description="Annotation task type"
     )
-    description: Optional[str] = Field(None, description="Task description; `null` if unset")
+    description: Optional[str] = Field(None, description="Task description. `null` if unset")
 
 
 class PublicAnnotationEvalResponse(BaseModel):
@@ -251,10 +251,10 @@ class PublicAnnotationEvalResponse(BaseModel):
         description="Annotation evaluator-run job ID",
         examples=[_EXAMPLE_JOB_UUID],
     )
-    status: AnnotationStatus = Field(description="Run status; share links only expose completed runs")
-    created_at: Optional[str] = Field(None, description="When the run was created (ISO 8601 UTC); `null` if unset")
-    completed_at: Optional[str] = Field(None, description="When the run finished (ISO 8601 UTC); `null` if unset")
-    updated_at: Optional[str] = Field(None, description="When the run was last updated (ISO 8601 UTC); `null` if unset")
+    status: AnnotationStatus = Field(description="Run status. Share links only expose completed runs")
+    created_at: Optional[str] = Field(None, description="When the run was created (ISO 8601 UTC). `null` if unset")
+    completed_at: Optional[str] = Field(None, description="When the run finished (ISO 8601 UTC). `null` if unset")
+    updated_at: Optional[str] = Field(None, description="When the run was last updated (ISO 8601 UTC). `null` if unset")
     task: PublicAnnotationEvalTaskRef = Field(description="Parent annotation task summary")
     # `details` mirrors the authenticated GET shape so a shared FE component
     # can read `job.details?.evaluators` against either endpoint without
@@ -262,28 +262,28 @@ class PublicAnnotationEvalResponse(BaseModel):
     # fields (pid, pgid, s3_prefix, user_id) are intentionally stripped.
     details: Optional[Dict[str, Any]] = Field(
         None,
-        description="Safe-to-share job metadata; operational fields are stripped",
+        description="Safe-to-share job metadata. Operational fields are stripped",
     )
     # Top-level mirrors retained for the existing public consumers that
     # were already reading them. Both shapes carry the same data.
     evaluators: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Evaluator definitions applied in the run; `null` if none"
+        None, description="Evaluator definitions applied in the run. `null` if none"
     )
-    item_count: Optional[int] = Field(None, description="Number of items evaluated; `null` if unknown")
-    items: Optional[List[Dict[str, Any]]] = Field(None, description="Evaluated items; `null` if none")
+    item_count: Optional[int] = Field(None, description="Number of items evaluated. `null` if unknown")
+    items: Optional[List[Dict[str, Any]]] = Field(None, description="Evaluated items. `null` if none")
     runs: Optional[List[Dict[str, Any]]] = Field(
         None,
-        description="Per-item evaluator run rows; each keys back into `evaluators[]` by evaluator and version ID",
+        description="Per-item evaluator run rows. Each keys back into `evaluators[]` by evaluator and version ID",
     )
     human_agreement: Optional[Dict[str, Any]] = Field(
-        None, description="Human-vs-evaluator agreement metrics; `null` if unavailable"
+        None, description="Human-vs-evaluator agreement metrics. `null` if unavailable"
     )
-    error: Optional[str] = Field(None, description="Failure message; `null` on success")
+    error: Optional[str] = Field(None, description="Failure message. `null` on success")
 
 
 class PublicDefaultEvaluatorVersionResponse(BaseModel):
     output_config: Optional[Dict[str, Any]] = Field(
-        None, description="Rubric config (scale values/labels/descriptions/colors); `null` if unset"
+        None, description="Rubric config (scale values/labels/descriptions/colors). `null` if unset"
     )
 
 
@@ -295,13 +295,13 @@ class PublicDefaultEvaluatorResponse(BaseModel):
         examples=[_EXAMPLE_EVALUATOR_UUID],
     )
     name: str = Field(description="Evaluator display name")
-    description: Optional[str] = Field(None, description="Evaluator description; `null` if unset")
+    description: Optional[str] = Field(None, description="Evaluator description. `null` if unset")
     evaluator_type: EvaluatorTypeLiteral = Field(
         description="Semantic category"
     )
     output_type: OutputTypeLiteral = Field(description="Output shape")
     live_version: Optional[PublicDefaultEvaluatorVersionResponse] = Field(
-        None, description="Public-safe fields of the live version; `null` if none is set"
+        None, description="Public-safe fields of the live version. `null` if none is set"
     )
 
 
@@ -454,7 +454,7 @@ async def get_public_default_evaluators(
     share_token: str = Query(..., min_length=1, description="Share token that grants access to the linked run"),
     types: Optional[str] = Query(
         None,
-        description="Evaluator types to include, comma-separated (`stt`, `tts`, `llm`, `llm-general`, `conversation`); omit for all",
+        description="Evaluator types to include, comma-separated (`stt`, `tts`, `llm`, `llm-general`, `conversation`). Omit for all",
     ),
 ):
     """List default evaluator metadata when you have a valid share token."""
@@ -900,11 +900,11 @@ class PublicAnnotationEntry(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="Evaluator ID this judgement is for; `null` marks a row-level overall annotation",
+        description="Evaluator ID this judgement is for. `null` marks a row-level overall annotation",
         examples=[_EXAMPLE_EVALUATOR_UUID],
     )
     value: Optional[Dict[str, Any]] = Field(
-        None, description="Judgement payload (shape depends on the evaluator's output type); `null` to clear"
+        None, description="Judgement payload (shape depends on the evaluator's output type). `null` to clear"
     )
 
 

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -916,7 +916,7 @@ class PublicAnnotationUpsertRequest(BaseModel):
         examples=[_EXAMPLE_ITEM_UUID],
     )
     annotations: List[PublicAnnotationEntry] = Field(
-        description="Judgements to save — one entry per evaluator, plus optionally one row-level entry"
+        description="Judgements to save, one entry per evaluator, plus optionally one row-level entry"
     )
 
 

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -165,7 +165,7 @@ class PublicTestRunResponse(BaseModel):
     # or token usage reported).
     latency_ms: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated latency (`{p50, p95, p99, count}`). `null` for eval-only runs or when not reported",
+        description="Aggregated latency (`{p50, p95, p99, count}`). `null` when not reported",
     )
     cost: Optional[Dict[str, Any]] = Field(
         None,

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -169,11 +169,11 @@ class PublicTestRunResponse(BaseModel):
     )
     cost: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated cost in USD (`{mean, min, max, count}`). `null` when no cost is reported",
+        description="Aggregated cost in USD (`{mean, min, max, count}`)",
     )
     total_tokens: Optional[Dict[str, Any]] = Field(
         None,
-        description="Aggregated token usage (`{mean, min, max, count}`). `null` when not reported",
+        description="Aggregated token usage (`{mean, min, max, count}`)",
     )
     error: bool = Field(False, description="`true` if the run failed")
 

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -457,7 +457,7 @@ async def get_public_default_evaluators(
         description="Evaluator types to include, comma-separated (`stt`, `tts`, `llm`, `llm-general`, `conversation`). Omit for all",
     ),
 ):
-    """List default evaluator metadata when you have a valid share token."""
+    """List default evaluator metadata when you have a valid share token"""
     _ensure_valid_public_share_token(share_token)
     requested_types = _parse_evaluator_types(types)
 
@@ -475,7 +475,7 @@ async def get_public_default_evaluators(
 async def get_public_stt(
     share_token: str = Path(description="Share token for the STT run"),
 ):
-    """Get a shared STT evaluation result."""
+    """Get a shared STT evaluation result"""
     job = get_job_by_share_token(share_token, job_type="stt-eval")
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
@@ -547,7 +547,7 @@ async def get_public_stt(
 async def get_public_tts(
     share_token: str = Path(description="Share token for the TTS run"),
 ):
-    """Get a shared TTS evaluation result."""
+    """Get a shared TTS evaluation result"""
     job = get_job_by_share_token(share_token, job_type="tts-eval")
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
@@ -604,7 +604,7 @@ async def get_public_tts(
 async def get_public_test_run(
     share_token: str = Path(description="Share token for the LLM test run"),
 ):
-    """Get a shared LLM test run result."""
+    """Get a shared LLM test run result"""
     job = get_agent_test_job_by_share_token(share_token, job_type="llm-unit-test")
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
@@ -644,7 +644,7 @@ async def get_public_test_run(
 async def get_public_benchmark(
     share_token: str = Path(description="Share token for the LLM benchmark run"),
 ):
-    """Get a shared LLM benchmark result."""
+    """Get a shared LLM benchmark result"""
     job = get_agent_test_job_by_share_token(share_token, job_type="llm-benchmark")
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
@@ -679,7 +679,7 @@ async def get_public_benchmark(
 async def get_public_simulation_run(
     share_token: str = Path(description="Share token for the simulation run"),
 ):
-    """Get a shared simulation run result."""
+    """Get a shared simulation run result"""
     job = get_simulation_job_by_share_token(share_token)
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
@@ -726,7 +726,7 @@ async def get_public_simulation_run(
 async def get_public_annotation_eval(
     share_token: str = Path(description="Share token for the annotation evaluator-run job"),
 ):
-    """Get a shared annotation evaluator-run result."""
+    """Get a shared annotation evaluator-run result"""
     # Only `done` runs are exposed; in-flight or failed runs return 404.
     job = get_job_by_share_token(share_token, job_type=ANNOTATION_EVAL_JOB_TYPE)
     if not job:
@@ -879,7 +879,7 @@ def _build_annotation_job_payload(
 def get_public_annotation_job_view(
     view_token: str = Path(description="Read-only view token for the annotation job"),
 ):
-    """Get a read-only view of an annotator's labelling job."""
+    """Get a read-only view of an annotator's labelling job"""
     job = get_annotation_job_by_view_token(view_token)
     if not job:
         raise HTTPException(status_code=404, detail="Not found")
@@ -890,7 +890,7 @@ def get_public_annotation_job_view(
 def get_public_annotation_job(
     token: str = Path(description="Annotator token for the labelling job"),
 ):
-    """Get everything you need to render an annotator's labelling job page."""
+    """Get everything you need to render an annotator's labelling job page"""
     job = _resolve_public_annotation_job(token)
     return _build_annotation_job_payload(job, read_only=False)
 
@@ -925,7 +925,7 @@ def upsert_public_annotations(
     token: str = Path(description="Annotator token for the labelling job"),
     payload: PublicAnnotationUpsertRequest = ...,
 ):
-    """Save all judgements for one item in a single request."""
+    """Save all judgements for one item in a single request"""
     # First save moves the job from `pending` to `in_progress`; all slots filled moves it to `completed`.
     job = _resolve_public_annotation_job(token)
     if not payload.annotations:

--- a/src/routers/public.py
+++ b/src/routers/public.py
@@ -210,7 +210,7 @@ class PublicSimulationRunResponse(BaseModel):
     )
     name: str = Field(description="Display name for the run, e.g. `Run 1`")
     status: TaskStatus = Field(description="Run status")
-    type: SimulationRunType = Field(description="Simulation type")
+    type: SimulationRunType = Field(description="Run mode")
     updated_at: str = Field(description="When the run was last updated (ISO 8601 UTC)")
     total_simulations: Optional[int] = Field(None, description="Number of simulations in the run. `null` until known")
     metrics: Optional[Dict[str, Any]] = Field(None, description="Aggregated run metrics. `null` until computed")

--- a/src/routers/scenarios.py
+++ b/src/routers/scenarios.py
@@ -107,7 +107,7 @@ async def update_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a scenario's fields. Only the provided fields change. Omitted fields are left as-is."""
+    """Update a scenario."""
     existing_scenario = get_scenario(scenario_uuid)
     if not existing_scenario or existing_scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")

--- a/src/routers/scenarios.py
+++ b/src/routers/scenarios.py
@@ -19,7 +19,7 @@ _EXAMPLE_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 
 
 class ScenarioCreate(BaseModel):
-    name: str = Field(description="Human-readable scenario name, unique within the workspace")
+    name: str = Field(description="Scenario name, unique within the workspace")
     description: Optional[str] = Field(
         None, description="Free-text description of the scenario. Omit to leave unset"
     )
@@ -41,7 +41,7 @@ class ScenarioResponse(BaseModel):
         description="ID of the scenario",
         examples=[_EXAMPLE_ID],
     )
-    name: str = Field(description="Human-readable scenario name")
+    name: str = Field(description="Scenario name")
     description: Optional[str] = Field(
         None, description="Free-text description, or null if unset"
     )
@@ -56,7 +56,7 @@ class ScenarioCreateResponse(BaseModel):
         description="ID of the newly created scenario",
         examples=[_EXAMPLE_ID],
     )
-    message: str = Field(description="Human-readable success message")
+    message: str = Field(description="Success message")
 
 
 @router.post("", response_model=ScenarioCreateResponse, summary="Create scenario")

--- a/src/routers/scenarios.py
+++ b/src/routers/scenarios.py
@@ -63,7 +63,7 @@ class ScenarioCreateResponse(BaseModel):
 async def create_scenario_endpoint(
     scenario: ScenarioCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a new scenario in your workspace."""
+    """Create a new scenario."""
     with ensure_name_unique("scenarios", scenario.name, ctx.org_uuid, entity="Scenario"):
         scenario_uuid = create_scenario(
             name=scenario.name,
@@ -78,7 +78,7 @@ async def create_scenario_endpoint(
 
 @router.get("", response_model=List[ScenarioResponse], summary="List scenarios")
 async def list_scenarios(ctx: OrgContext = Depends(get_current_org)):
-    """List all scenarios in your workspace."""
+    """List all scenarios."""
     scenarios = get_all_scenarios(org_uuid=ctx.org_uuid)
     return scenarios
 
@@ -91,7 +91,7 @@ async def get_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get a scenario in your workspace."""
+    """Get a scenario."""
     scenario = get_scenario(scenario_uuid)
     if not scenario or scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")
@@ -140,7 +140,7 @@ async def delete_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a scenario in your workspace."""
+    """Soft-delete a scenario."""
     existing_scenario = get_scenario(scenario_uuid)
     if not existing_scenario or existing_scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")

--- a/src/routers/scenarios.py
+++ b/src/routers/scenarios.py
@@ -86,7 +86,7 @@ async def list_scenarios(ctx: OrgContext = Depends(get_current_org)):
 @router.get("/{scenario_uuid}", response_model=ScenarioResponse, summary="Get scenario")
 async def get_scenario_endpoint(
     scenario_uuid: str = Path(
-        description="The scenario to retrieve. Must be in your workspace.",
+        description="The scenario to retrieve.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -102,7 +102,7 @@ async def get_scenario_endpoint(
 async def update_scenario_endpoint(
     scenario: ScenarioUpdate,
     scenario_uuid: str = Path(
-        description="The scenario to update. Must be in your workspace.",
+        description="The scenario to update.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -135,7 +135,7 @@ async def update_scenario_endpoint(
 @router.delete("/{scenario_uuid}", summary="Delete scenario")
 async def delete_scenario_endpoint(
     scenario_uuid: str = Path(
-        description="The scenario to delete. Must be in your workspace.",
+        description="The scenario to delete.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/scenarios.py
+++ b/src/routers/scenarios.py
@@ -107,7 +107,7 @@ async def update_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a scenario's fields. Only the provided fields change; omitted fields are left as-is."""
+    """Update a scenario's fields. Only the provided fields change. Omitted fields are left as-is."""
     existing_scenario = get_scenario(scenario_uuid)
     if not existing_scenario or existing_scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")

--- a/src/routers/scenarios.py
+++ b/src/routers/scenarios.py
@@ -63,7 +63,7 @@ class ScenarioCreateResponse(BaseModel):
 async def create_scenario_endpoint(
     scenario: ScenarioCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a new scenario."""
+    """Create a new scenario"""
     with ensure_name_unique("scenarios", scenario.name, ctx.org_uuid, entity="Scenario"):
         scenario_uuid = create_scenario(
             name=scenario.name,
@@ -78,7 +78,7 @@ async def create_scenario_endpoint(
 
 @router.get("", response_model=List[ScenarioResponse], summary="List scenarios")
 async def list_scenarios(ctx: OrgContext = Depends(get_current_org)):
-    """List your scenarios, each with its config."""
+    """List your scenarios"""
     scenarios = get_all_scenarios(org_uuid=ctx.org_uuid)
     return scenarios
 
@@ -91,7 +91,7 @@ async def get_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one scenario by ID, including its config."""
+    """Get one scenario by ID"""
     scenario = get_scenario(scenario_uuid)
     if not scenario or scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")
@@ -107,7 +107,7 @@ async def update_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a scenario, the situation and goal a simulation plays out."""
+    """Update a scenario, the situation and goal a simulation plays out"""
     existing_scenario = get_scenario(scenario_uuid)
     if not existing_scenario or existing_scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")
@@ -140,7 +140,7 @@ async def delete_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a scenario."""
+    """Soft-delete a scenario"""
     existing_scenario = get_scenario(scenario_uuid)
     if not existing_scenario or existing_scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")

--- a/src/routers/scenarios.py
+++ b/src/routers/scenarios.py
@@ -78,7 +78,7 @@ async def create_scenario_endpoint(
 
 @router.get("", response_model=List[ScenarioResponse], summary="List scenarios")
 async def list_scenarios(ctx: OrgContext = Depends(get_current_org)):
-    """List all scenarios."""
+    """List your scenarios, each with its config."""
     scenarios = get_all_scenarios(org_uuid=ctx.org_uuid)
     return scenarios
 
@@ -91,7 +91,7 @@ async def get_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get a scenario."""
+    """Get one scenario by ID, including its config."""
     scenario = get_scenario(scenario_uuid)
     if not scenario or scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")
@@ -107,7 +107,7 @@ async def update_scenario_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a scenario."""
+    """Update a scenario, the situation and goal a simulation plays out."""
     existing_scenario = get_scenario(scenario_uuid)
     if not existing_scenario or existing_scenario.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Scenario not found")

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -304,7 +304,7 @@ class SimulationCreate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    name: str = Field(description="Human-readable simulation name, unique within the workspace")
+    name: str = Field(description="Simulation name, unique within the workspace")
     agent_uuid: Optional[str] = Field(
         None,
         min_length=36,
@@ -507,7 +507,7 @@ class SimulationCreateResponse(BaseModel):
         description="ID of the newly created simulation",
         examples=[_EXAMPLE_ID],
     )
-    message: str = Field(description="Human-readable confirmation message")
+    message: str = Field(description="Confirmation message")
 
 
 class RunSimulationRequest(BaseModel):

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -300,7 +300,7 @@ class EvaluatorRef(BaseModel):
 
 
 class SimulationCreate(BaseModel):
-    """Create body must use `evaluators` with evaluator IDs — not legacy metric IDs or aliases."""
+    """Create body must use `evaluators` with evaluator IDs, not legacy metric IDs or aliases."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -324,7 +324,7 @@ class SimulationCreate(BaseModel):
 
 
 class SimulationUpdate(BaseModel):
-    """Update body must use `evaluators` with evaluator IDs — not legacy metric IDs or aliases."""
+    """Update body must use `evaluators` with evaluator IDs, not legacy metric IDs or aliases."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -2607,7 +2607,7 @@ async def delete_simulation_job_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Delete a simulation run."""
+    """Delete a simulation run and its results."""
     simulation_job = get_simulation_job(job_uuid)
     if not simulation_job:
         raise HTTPException(status_code=404, detail="Job not found")

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -464,7 +464,7 @@ class AgentSummaryResponse(BaseModel):
     )
     name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` applies managed defaults; `connection` stores the config you supply as-is"
+        description="`agent` applies managed defaults. `connection` stores the config you supply as-is"
     )
     config: Optional[Dict[str, Any]] = Field(None, description="Agent config, or null")
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")
@@ -525,7 +525,7 @@ class EvaluationCriterionResult(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="Source evaluator ID, echoed from the run; null if unresolved",
+        description="Source evaluator ID, echoed from the run. Null if unresolved",
         examples=[_EXAMPLE_ID],
     )
     description: Optional[str] = Field(None, description="Evaluator's current description, or null")
@@ -555,7 +555,7 @@ class SimulationCaseResult(BaseModel):
         None, description="Full scenario object (name/label and description), or null"
     )
     evaluation_results: Optional[List[EvaluationCriterionResult]] = Field(
-        None, description="Per-evaluator judge results; null while the case is still in progress"
+        None, description="Per-evaluator judge results. Null while the case is still in progress"
     )
     transcript: Optional[List[Dict[str, Any]]] = Field(None, description="Ordered conversation turns, or null")
     audio_urls: Optional[List[str]] = Field(
@@ -579,21 +579,21 @@ class SimulationRunStatusResponse(BaseModel):
     type: SimulationRunType = Field(description="Run mode")
     updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
     total_simulations: Optional[int] = Field(
-        None, description="Expected number of persona x scenario cases; null before it's known"
+        None, description="Expected number of persona x scenario cases. Null before it's known"
     )
     completed_simulations: Optional[int] = Field(
-        None, description="Number of cases finished so far; null when not tracked"
+        None, description="Number of cases finished so far. Null when not tracked"
     )
-    metrics: Optional[Dict[str, Any]] = Field(None, description="Aggregated metrics; null until the run completes")
+    metrics: Optional[Dict[str, Any]] = Field(None, description="Aggregated metrics. Null until the run completes")
     simulation_results: Optional[List[SimulationCaseResult]] = Field(
         None, description="Per-case results, or null if none yet"
     )
     evaluators: Optional[List[SimulationEvaluatorRef]] = Field(
-        None, description="Evaluators used for this run, in link order; null if none"
+        None, description="Evaluators used for this run, in link order. Null if none"
     )
-    error: Optional[str] = Field(None, description="Failure message; null unless the run failed")
+    error: Optional[str] = Field(None, description="Failure message. Null unless the run failed")
     is_public: bool = Field(False, description="Whether the run is shared via a public link")
-    share_token: Optional[str] = Field(None, description="Share token for the public view; null when private")
+    share_token: Optional[str] = Field(None, description="Share token for the public view. Null when private")
 
 
 class SimulationRunListItem(BaseModel):
@@ -766,12 +766,12 @@ async def list_simulations(ctx: OrgContext = Depends(get_current_org)):
 
 
 class VisibilityRequest(BaseModel):
-    is_public: bool = Field(description="`true` to publish the run via a share link; `false` to make it private")
+    is_public: bool = Field(description="`true` to publish the run via a share link. `false` to make it private")
 
 
 class VisibilityResponse(BaseModel):
     is_public: bool = Field(description="Resulting public/private state of the run")
-    share_token: str | None = Field(None, description="Share token when public; null when private")
+    share_token: str | None = Field(None, description="Share token when public. Null when private")
 
 
 @router.patch("/run/{task_id}/visibility", response_model=VisibilityResponse, summary="Update simulation run visibility")

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -464,7 +464,7 @@ class AgentSummaryResponse(BaseModel):
     )
     name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` applies managed defaults. `connection` stores the config you supply as-is"
+        description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
     )
     config: Optional[Dict[str, Any]] = Field(None, description="Agent config, or null")
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -674,7 +674,7 @@ def apply_simulation_job_evaluator_enrichment(
 async def create_simulation_endpoint(
     simulation: SimulationCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a simulation in your workspace, optionally linking an agent, personas, scenarios, and `conversation` evaluators."""
+    """Create a simulation, optionally linking an agent, personas, scenarios, and `conversation` evaluators."""
     if simulation.agent_uuid:
         agent = get_agent(simulation.agent_uuid)
         if not agent or agent.get("org_uuid") != ctx.org_uuid:
@@ -738,7 +738,7 @@ async def create_simulation_endpoint(
 
 @router.get("", response_model=List[SimulationListResponse], summary="List simulations")
 async def list_simulations(ctx: OrgContext = Depends(get_current_org)):
-    """List all simulations for your workspace, each with its linked agent summary."""
+    """List all simulations, each with its linked agent summary."""
     simulations = get_all_simulations(org_uuid=ctx.org_uuid)
     result = []
     for sim in simulations:

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -310,14 +310,14 @@ class SimulationCreate(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="Agent under test. Must be in your workspace. Omit to create without an agent",
+        description="Agent under test. Omit to create without an agent",
         examples=[_EXAMPLE_ID],
     )
     persona_uuids: Optional[List[str]] = Field(
-        None, description="Personas to link. Must be in your workspace. Omit to link none"
+        None, description="Personas to link. Omit to link none"
     )
     scenario_uuids: Optional[List[str]] = Field(
-        None, description="Scenarios to link. Must be in your workspace. Omit to link none"
+        None, description="Scenarios to link. Omit to link none"
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None, description="`conversation` evaluators to link. Omit to link none"
@@ -331,7 +331,7 @@ class SimulationUpdate(BaseModel):
 
     name: Optional[str] = Field(None, description="New name. Omit to leave unchanged")
     agent_uuid: Optional[str] = Field(
-        None, description="Agent to link. Must be in your workspace. Empty string (`\"\"`) clears the agent. Omit to leave unchanged"
+        None, description="Agent to link. Empty string (`\"\"`) clears the agent. Omit to leave unchanged"
     )
     persona_uuids: Optional[List[str]] = Field(
         None, description="Replacement persona set (replaces existing). Omit to leave unchanged"
@@ -779,7 +779,7 @@ class VisibilityResponse(BaseModel):
 async def update_simulation_run_visibility(
     body: VisibilityRequest,
     task_id: str = PathParam(
-        description="The simulation run to update. Must be in your workspace.",
+        description="The simulation run to update.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -810,7 +810,7 @@ async def update_simulation_run_visibility(
 @router.get("/run/{task_id}", response_model=SimulationRunStatusResponse, summary="Get simulation run status")
 async def get_simulation_run_status(
     task_id: str = PathParam(
-        description="The simulation run to poll. Must be in your workspace.",
+        description="The simulation run to poll.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -934,7 +934,7 @@ async def get_simulation_run_status(
 @router.get("/{simulation_uuid}/runs", response_model=SimulationRunsResponse, summary="List simulation runs")
 async def get_simulation_runs(
     simulation_uuid: str = PathParam(
-        description="The simulation whose runs to list. Must be in your workspace.",
+        description="The simulation whose runs to list.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -977,7 +977,7 @@ async def get_simulation_runs(
 @router.get("/{simulation_uuid}", response_model=SimulationDetailResponse, summary="Get simulation")
 async def get_simulation_endpoint(
     simulation_uuid: str = PathParam(
-        description="The simulation to retrieve. Must be in your workspace.",
+        description="The simulation to retrieve.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -1022,7 +1022,7 @@ async def get_simulation_endpoint(
 async def update_simulation_endpoint(
     simulation: SimulationUpdate,
     simulation_uuid: str = PathParam(
-        description="The simulation to update. Must be in your workspace.",
+        description="The simulation to update.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -1154,7 +1154,7 @@ async def update_simulation_endpoint(
 @router.delete("/{simulation_uuid}", summary="Delete simulation")
 async def delete_simulation_endpoint(
     simulation_uuid: str = PathParam(
-        description="The simulation to delete. Must be in your workspace.",
+        description="The simulation to delete.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -2417,7 +2417,7 @@ def run_simulation_task(
 async def run_simulation_endpoint(
     request: RunSimulationRequest,
     simulation_uuid: str = PathParam(
-        description="The simulation to run. Must be in your workspace.",
+        description="The simulation to run.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -2513,7 +2513,7 @@ async def run_simulation_endpoint(
 @router.post("/run/{job_uuid}/abort", response_model=SimulationRunStatusResponse, summary="Abort simulation run")
 async def abort_simulation_run(
     job_uuid: str = PathParam(
-        description="The in-progress simulation run to abort. Must be in your workspace.",
+        description="The in-progress simulation run to abort.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -2602,7 +2602,7 @@ async def abort_simulation_run(
 @router.delete("/run/{job_uuid}", summary="Delete simulation run")
 async def delete_simulation_job_endpoint(
     job_uuid: str = PathParam(
-        description="The simulation run to delete. Must be in your workspace.",
+        description="The simulation run to delete.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -674,7 +674,7 @@ def apply_simulation_job_evaluator_enrichment(
 async def create_simulation_endpoint(
     simulation: SimulationCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a simulation, optionally linking an agent, personas, scenarios, and `conversation` evaluators."""
+    """Create a simulation, optionally linking an agent, personas, scenarios, and `conversation` evaluators"""
     if simulation.agent_uuid:
         agent = get_agent(simulation.agent_uuid)
         if not agent or agent.get("org_uuid") != ctx.org_uuid:
@@ -738,7 +738,7 @@ async def create_simulation_endpoint(
 
 @router.get("", response_model=List[SimulationListResponse], summary="List simulations")
 async def list_simulations(ctx: OrgContext = Depends(get_current_org)):
-    """List all simulations, each with its linked agent summary."""
+    """List all simulations"""
     simulations = get_all_simulations(org_uuid=ctx.org_uuid)
     result = []
     for sim in simulations:
@@ -784,7 +784,7 @@ async def update_simulation_run_visibility(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update public sharing for a simulation run."""
+    """Update public sharing for a simulation run"""
     job = get_simulation_job(task_id)
     if not job:
         raise HTTPException(status_code=404, detail="Task not found")
@@ -815,7 +815,7 @@ async def get_simulation_run_status(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get the status and results of a simulation run."""
+    """Get the status and results of a simulation run"""
     job = get_simulation_job(task_id)
     if not job:
         raise HTTPException(status_code=404, detail="Task not found")
@@ -939,7 +939,7 @@ async def get_simulation_runs(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """List runs for a simulation, most recently updated first."""
+    """List runs for a simulation, most recently updated first"""
     simulation = get_simulation(simulation_uuid)
     if not simulation or simulation.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Simulation not found")
@@ -982,7 +982,7 @@ async def get_simulation_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get a simulation with its linked agent, personas, scenarios, and evaluators."""
+    """Get a simulation with its linked agent, personas, scenarios, and evaluators"""
     simulation = get_simulation(simulation_uuid)
     if not simulation or simulation.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Simulation not found")
@@ -1027,7 +1027,7 @@ async def update_simulation_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a simulation's name, agent, and linked personas, scenarios, and evaluators."""
+    """Update a simulation's name, agent, and linked personas, scenarios, and evaluators"""
     existing_simulation = get_simulation(simulation_uuid)
     if (
         not existing_simulation
@@ -1159,7 +1159,7 @@ async def delete_simulation_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Delete a simulation from your workspace."""
+    """Delete a simulation from your workspace"""
     existing_simulation = get_simulation(simulation_uuid)
     if (
         not existing_simulation
@@ -2422,7 +2422,7 @@ async def run_simulation_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Run a simulation as a background job."""
+    """Run a simulation as a background job"""
     simulation = get_simulation(simulation_uuid)
     if not simulation or simulation.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Simulation not found")
@@ -2518,7 +2518,7 @@ async def abort_simulation_run(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Abort an in-progress simulation run, keeping partial results collected so far."""
+    """Abort an in-progress simulation run, keeping partial results collected so far"""
     simulation_job = get_simulation_job(job_uuid)
     if not simulation_job:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -2607,7 +2607,7 @@ async def delete_simulation_job_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Delete a simulation run and its results."""
+    """Delete a simulation run and its results"""
     simulation_job = get_simulation_job(job_uuid)
     if not simulation_job:
         raise HTTPException(status_code=404, detail="Job not found")

--- a/src/routers/simulations.py
+++ b/src/routers/simulations.py
@@ -44,6 +44,7 @@ from db import (
 )
 from llm_judge import build_evaluator_cli_payload
 from utils import (
+    AGENT_TYPE_DESCRIPTION,
     TaskStatus,
     TaskCreateResponse,
     SimulationRunType,
@@ -464,7 +465,7 @@ class AgentSummaryResponse(BaseModel):
     )
     name: str = Field(description="Agent name")
     type: Literal["agent", "connection"] = Field(
-        description="`agent` (built inside Calibrate) or `connection` (your existing agent connected to Calibrate)"
+        description=AGENT_TYPE_DESCRIPTION
     )
     config: Optional[Dict[str, Any]] = Field(None, description="Agent config, or null")
     created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -246,15 +246,15 @@ class STTEvaluationRequest(BaseModel):
     )
     audio_paths: Optional[List[str]] = Field(
         None,
-        description="Audio files to transcribe, one `s3://bucket/key` URI per item. **Required when `dataset_id` is omitted**; must align 1:1 with `texts`",
+        description="Audio files to transcribe, one `s3://bucket/key` URI per item. **Required when `dataset_id` is omitted**. Must align 1:1 with `texts`",
     )
     texts: Optional[List[str]] = Field(
         None,
-        description="Ground-truth transcripts to score against, one per audio file. **Required when `dataset_id` is omitted**; must align 1:1 with `audio_paths`",
+        description="Ground-truth transcripts to score against, one per audio file. **Required when `dataset_id` is omitted**. Must align 1:1 with `audio_paths`",
     )
     dataset_name: Optional[str] = Field(
         None,
-        description="Name for a new dataset saved from inline inputs. Ignored when `dataset_id` is set; omit to skip saving",
+        description="Name for a new dataset saved from inline inputs. Ignored when `dataset_id` is set. Omit to skip saving",
     )
     providers: List[str] = Field(
         description='STT providers to compare, e.g. `["deepgram", "openai", "sarvam"]`. At least one required'
@@ -262,7 +262,7 @@ class STTEvaluationRequest(BaseModel):
     language: str = Field(description='Spoken language for the audio, e.g. `"english"` or `"hindi"`')
     evaluator_uuids: Optional[List[str]] = Field(
         None,
-        description="Evaluators to score transcriptions; each must be an `stt` evaluator in your workspace. Omit to use the default STT evaluator",
+        description="Evaluators to score transcriptions. Each must be an `stt` evaluator in your workspace. Omit to use the default STT evaluator",
     )
 
 
@@ -746,7 +746,7 @@ async def evaluate_stt(
 
 class VisibilityRequest(BaseModel):
     is_public: bool = Field(
-        description="`true` to make the job publicly shareable; `false` to make it private"
+        description="`true` to make the job publicly shareable. `false` to make it private"
     )
 
 
@@ -754,7 +754,7 @@ class VisibilityResponse(BaseModel):
     is_public: bool = Field(description="Whether the job is now publicly shareable")
     share_token: str | None = Field(
         None,
-        description="Opaque token for the public share URL when `is_public` is true; null when private",
+        description="Opaque token for the public share URL when `is_public` is true. Null when private",
     )
 
 

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -241,7 +241,7 @@ class STTEvaluationRequest(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="Existing STT dataset to evaluate. Must be in your workspace. **Provide this OR inline `audio_paths` + `texts`, not both**",
+        description="Existing STT dataset to evaluate. **Provide this OR inline `audio_paths` + `texts`, not both**",
         examples=[_EXAMPLE_ID],
     )
     audio_paths: Optional[List[str]] = Field(
@@ -766,7 +766,7 @@ class VisibilityResponse(BaseModel):
 async def update_stt_visibility(
     body: VisibilityRequest,
     task_id: str = PathParam(
-        description="The STT evaluation to update. Must be in your workspace.",
+        description="The STT evaluation to update.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -792,7 +792,7 @@ async def update_stt_visibility(
 )
 async def get_evaluation_status(
     task_id: str = PathParam(
-        description="The STT evaluation to poll. Must be in your workspace.",
+        description="The STT evaluation to poll.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/stt.py
+++ b/src/routers/stt.py
@@ -664,7 +664,7 @@ def run_evaluation_task(
 async def evaluate_stt(
     request: STTEvaluationRequest, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Benchmark STT providers against a dataset as a background job."""
+    """Benchmark STT providers against a dataset as a background job"""
     if not request.providers:
         raise HTTPException(
             status_code=400,
@@ -771,7 +771,7 @@ async def update_stt_visibility(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update public sharing for an STT evaluation."""
+    """Update public sharing for an STT evaluation"""
     job = get_job(task_id, org_uuid=ctx.org_uuid)
     if not job or job.get("type") != "stt-eval":
         raise HTTPException(status_code=404, detail="Task not found")
@@ -797,7 +797,7 @@ async def get_evaluation_status(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get the status and results of an STT evaluation."""
+    """Get the status and results of an STT evaluation"""
     job = get_job(task_id, org_uuid=ctx.org_uuid)
     if not job:
         raise HTTPException(status_code=404, detail="Task not found")

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -55,7 +55,7 @@ class EvaluatorRef(BaseModel):
     )
     variable_values: Optional[Dict[str, Any]] = Field(
         None,
-        description="Values for the evaluator's `{{placeholder}}` variables, pinned per-test on the pivot. Omit to inherit the evaluator version's defaults",
+        description="Values for the evaluator's `{{placeholder}}` variables, pinned per test. Omit to inherit the evaluator version's defaults",
     )
 
 

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -62,7 +62,12 @@ class EvaluatorRef(BaseModel):
 class TestCreate(BaseModel):
     name: str = Field(description="Human-readable test name, unique within the workspace")
     type: TestType = Field(
-        description="Test kind (immutable after creation): `response` judges the generated reply, `tool_call` diffs generated tool calls, `conversation` judges the full conversation"
+        description=(
+            "What the test judges:\n\n"
+            "- `response` — judges the generated reply\n"
+            "- `tool_call` — diffs the generated tool calls\n"
+            "- `conversation` — judges the full conversation"
+        )
     )
     config: Optional[Dict[str, Any]] = Field(
         None,

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -71,7 +71,7 @@ class TestCreate(BaseModel):
     )
     config: Optional[Dict[str, Any]] = Field(
         None,
-        description="Calibrate test config (`history`, `evaluation`, optional `settings`). Omit to create an empty shell to fill in later",
+        description="Calibrate test config (`history`, `evaluation`, optional `settings`). Omit to create the test with no config and set it later via update",
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -42,6 +42,11 @@ _TEST_TYPE_DESCRIPTION = (
     "- `conversation`: judges the full conversation"
 )
 
+# Test name uniqueness is workspace-scoped on single create; bulk create adds
+# batch-level uniqueness on top (both are enforced). Share the base so the two
+# never drift.
+_TEST_NAME_DESCRIPTION = "Name of the test, unique within the workspace"
+
 # Each test type pins the evaluator_type it accepts. `conversation` tests judge whole
 # simulated conversations, so only `conversation` evaluators apply; `response`/`tool_call`
 # tests judge a single LLM reply, so only `llm` evaluators apply.
@@ -69,7 +74,7 @@ class EvaluatorRef(BaseModel):
 
 
 class TestCreate(BaseModel):
-    name: str = Field(description="Name of the test, unique within the workspace")
+    name: str = Field(description=_TEST_NAME_DESCRIPTION)
     type: TestType = Field(description=_TEST_TYPE_DESCRIPTION)
     config: Optional[Dict[str, Any]] = Field(
         None,
@@ -156,7 +161,7 @@ class ExpectedToolCall(BaseModel):
 
 
 class BulkTestItem(BaseModel):
-    name: str = Field(description="Test name, unique within the batch")
+    name: str = Field(description=_TEST_NAME_DESCRIPTION + " and within the batch")
     conversation_history: List[ChatMessage] = Field(
         description="Ordered messages ending at the user turn the agent should answer (must be non-empty)"
     )

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -94,11 +94,11 @@ class TestUpdate(BaseModel):
         + "\n\nImmutable. Omit, or send the existing value. A different value is rejected (400).",
     )
     config: Optional[Dict[str, Any]] = Field(
-        None, description="Replacement calibrate config. Omit to leave unchanged"
+        None, description="New config for the test. Omit to leave unchanged"
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,
-        description="Replacement evaluator links (replaces the existing set). Omit to leave links unchanged. An empty list clears them",
+        description="New evaluator links for the test. Omit to leave unchanged. An empty list clears them",
     )
 
 
@@ -135,8 +135,8 @@ class TestCreateResponse(BaseModel):
 # --- Bulk upload models ---
 
 class ChatMessage(BaseModel):
-    role: Literal["system", "user", "assistant", "tool"] = Field(
-        description="Message author role in the conversation history"
+    role: Literal["user", "assistant", "tool"] = Field(
+        description="Message author role. The agent's system prompt lives in its config, not here"
     )
     content: Optional[str] = Field(
         None, description="Message text. Omit for assistant messages that only carry `tool_calls`"

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -64,9 +64,9 @@ class TestCreate(BaseModel):
     type: TestType = Field(
         description=(
             "What the test judges:\n\n"
-            "- `response` — judges the generated reply\n"
-            "- `tool_call` — diffs the generated tool calls\n"
-            "- `conversation` — judges the full conversation"
+            "- `response`: judges the generated reply\n"
+            "- `tool_call`: diffs the generated tool calls\n"
+            "- `conversation`: judges the full conversation"
         )
     )
     config: Optional[Dict[str, Any]] = Field(
@@ -83,7 +83,7 @@ class TestUpdate(BaseModel):
     name: Optional[str] = Field(None, description="New test name. Omit to leave unchanged")
     type: Optional[TestType] = Field(
         None,
-        description="Test type. Immutable — may only echo the existing value. A different value is rejected (400). Omit to leave unchanged",
+        description="Test type. Immutable, may only echo the existing value. A different value is rejected (400). Omit to leave unchanged",
     )
     config: Optional[Dict[str, Any]] = Field(
         None, description="Replacement calibrate config. Omit to leave unchanged"

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -399,7 +399,7 @@ async def bulk_upload_tests(
 async def create_test_endpoint(
     test: TestCreate, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create a test."""
+    """Create a test that runs your agent against a conversation and grades its reply, tool calls, or the full conversation."""
     # Conversation tests have no evaluator fallback (unlike `response`, which can
     # synthesize the default LLM judge from legacy string criteria) — without a
     # linked simulation evaluator a run produces an empty calibrate config with
@@ -435,7 +435,7 @@ async def create_test_endpoint(
     summary="List tests",
 )
 async def list_tests(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
-    """List all tests, each with its linked evaluators."""
+    """List your tests, each with its linked evaluators."""
     tests = get_all_tests(org_uuid=ctx.org_uuid)
     return [_with_evaluators(t) for t in tests]
 
@@ -474,7 +474,7 @@ async def update_test_endpoint(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Update a test."""
+    """Update a test's config or the evaluators it is graded by."""
     existing_test = get_test(test_uuid)
     if not existing_test or existing_test.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Test not found")

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -83,14 +83,14 @@ class TestUpdate(BaseModel):
     name: Optional[str] = Field(None, description="New test name. Omit to leave unchanged")
     type: Optional[TestType] = Field(
         None,
-        description="Test type. Immutable — may only echo the existing value; a different value is rejected (400). Omit to leave unchanged",
+        description="Test type. Immutable — may only echo the existing value. A different value is rejected (400). Omit to leave unchanged",
     )
     config: Optional[Dict[str, Any]] = Field(
         None, description="Replacement calibrate config. Omit to leave unchanged"
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,
-        description="Replacement evaluator links (replaces the existing set). Omit to leave links unchanged; an empty list clears them (**rejected for `conversation` tests**)",
+        description="Replacement evaluator links (replaces the existing set). Omit to leave links unchanged. An empty list clears them (**rejected for `conversation` tests**)",
     )
 
 

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -380,7 +380,7 @@ def _with_evaluators(test_dict: Dict[str, Any]) -> Dict[str, Any]:
 async def bulk_delete_tests_endpoint(
     payload: BulkTestDelete, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Soft-delete multiple tests by ID."""
+    """Soft-delete multiple tests by ID"""
     if not payload.test_uuids:
         raise HTTPException(status_code=400, detail="test_uuids must not be empty")
 
@@ -403,7 +403,7 @@ async def bulk_delete_tests_endpoint(
 async def bulk_upload_tests(
     payload: BulkTestUpload, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create many test cases at once and link them to your agents."""
+    """Create many test cases at once and link them to your agents"""
     if payload.agent_uuids:
         for agent_uuid in payload.agent_uuids:
             agent = get_agent(agent_uuid)
@@ -493,7 +493,7 @@ async def bulk_upload_tests(
 async def create_test_endpoint(
     test: TestCreate, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create a test that runs your agent against a conversation and evaluates its answer quality or the tools it calls."""
+    """Create a test that runs your agent against a conversation and evaluates its answer quality or the tools it calls"""
     # Conversation tests have no evaluator fallback (unlike `response`, which can
     # synthesize the default LLM judge from legacy string criteria) — without a
     # linked simulation evaluator a run produces an empty calibrate config with
@@ -529,7 +529,7 @@ async def create_test_endpoint(
     summary="List tests",
 )
 async def list_tests(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
-    """List all the test cases for your agents."""
+    """List all the test cases for your agents"""
     tests = get_all_tests(org_uuid=ctx.org_uuid)
     return [_with_evaluators(t) for t in tests]
 
@@ -547,7 +547,7 @@ async def get_test_endpoint(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Get an agent test case by its ID."""
+    """Get an agent test case by its ID"""
     test = get_test(test_uuid)
     if not test or test.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Test not found")
@@ -634,7 +634,7 @@ async def delete_test_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a test."""
+    """Soft-delete a test"""
     existing_test = get_test(test_uuid)
     if not existing_test or existing_test.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Test not found")

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -154,7 +154,7 @@ class TestUpdate(BaseModel):
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,
-        description="New evaluator links for the test. Omit to leave unchanged. An empty list clears them",
+        description="New evaluator links for the test. Omit to leave unchanged. An empty list clears them, except on `conversation` tests, which must keep at least one",
     )
 
 

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -474,7 +474,7 @@ async def update_test_endpoint(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Update a test's name, config, and/or evaluator links."""
+    """Update a test."""
     existing_test = get_test(test_uuid)
     if not existing_test or existing_test.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Test not found")

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -60,7 +60,7 @@ class EvaluatorRef(BaseModel):
 
 
 class TestCreate(BaseModel):
-    name: str = Field(description="Human-readable test name, unique within the workspace")
+    name: str = Field(description="Test name, unique within the workspace")
     type: TestType = Field(
         description=(
             "What the test judges:\n\n"
@@ -101,7 +101,7 @@ class TestResponse(BaseModel):
         description="Test ID",
         examples=[_EXAMPLE_TEST_UUID],
     )
-    name: str = Field(description="Human-readable test name")
+    name: str = Field(description="Test name")
     type: TestType = Field(description="Test kind")
     config: Optional[Dict[str, Any]] = Field(
         None, description="Calibrate test config (`history`, `evaluation`, optional `settings`)"
@@ -121,7 +121,7 @@ class TestCreateResponse(BaseModel):
         description="ID of the newly created test",
         examples=[_EXAMPLE_TEST_UUID],
     )
-    message: str = Field(description="Human-readable confirmation message")
+    message: str = Field(description="Confirmation message")
 
 
 # --- Bulk upload models ---
@@ -221,7 +221,7 @@ class BulkTestUploadResponse(BaseModel):
         examples=[[_EXAMPLE_TEST_UUID]],
     )
     count: int = Field(description="Number of tests created")
-    message: str = Field(description="Human-readable confirmation message")
+    message: str = Field(description="Confirmation message")
     warnings: Optional[List[str]] = Field(
         None, description="Non-fatal issues (e.g. agents some tests couldn't link to). Null when there were none"
     )
@@ -236,7 +236,7 @@ class BulkTestDelete(BaseModel):
 
 class BulkTestDeleteResponse(BaseModel):
     deleted_count: int = Field(description="Number of tests actually deleted (excludes IDs not in your workspace)")
-    message: str = Field(description="Human-readable confirmation message")
+    message: str = Field(description="Confirmation message")
 
 
 def _validate_evaluators(

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -136,7 +136,7 @@ class TestCreateResponse(BaseModel):
 
 class ChatMessage(BaseModel):
     role: Literal["user", "assistant", "tool"] = Field(
-        description="Message author role. The agent's system prompt lives in its config, not here"
+        description="Message author role in the conversation history"
     )
     content: Optional[str] = Field(
         None, description="Message text. Omit for assistant messages that only carry `tool_calls`"

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -399,7 +399,7 @@ async def bulk_upload_tests(
 async def create_test_endpoint(
     test: TestCreate, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create a test in your workspace."""
+    """Create a test."""
     # Conversation tests have no evaluator fallback (unlike `response`, which can
     # synthesize the default LLM judge from legacy string criteria) — without a
     # linked simulation evaluator a run produces an empty calibrate config with
@@ -435,7 +435,7 @@ async def create_test_endpoint(
     summary="List tests",
 )
 async def list_tests(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
-    """List all tests for your workspace, each with its linked evaluators."""
+    """List all tests, each with its linked evaluators."""
     tests = get_all_tests(org_uuid=ctx.org_uuid)
     return [_with_evaluators(t) for t in tests]
 

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -33,6 +33,15 @@ _EXAMPLE_AGENT_UUID = "a3b2c1d0-e5f4-3210-abcd-ef1234567890"
 
 TestType = Literal["response", "tool_call", "conversation"]
 
+# Shared across every `type` field (create/update/response/bulk) so the gloss
+# stays identical everywhere it renders.
+_TEST_TYPE_DESCRIPTION = (
+    "What the test judges:\n\n"
+    "- `response`: judges the generated reply\n"
+    "- `tool_call`: diffs the generated tool calls\n"
+    "- `conversation`: judges the full conversation"
+)
+
 # Each test type pins the evaluator_type it accepts. `conversation` tests judge whole
 # simulated conversations, so only `conversation` evaluators apply; `response`/`tool_call`
 # tests judge a single LLM reply, so only `llm` evaluators apply.
@@ -60,18 +69,11 @@ class EvaluatorRef(BaseModel):
 
 
 class TestCreate(BaseModel):
-    name: str = Field(description="Test name, unique within the workspace")
-    type: TestType = Field(
-        description=(
-            "What the test judges:\n\n"
-            "- `response`: judges the generated reply\n"
-            "- `tool_call`: diffs the generated tool calls\n"
-            "- `conversation`: judges the full conversation"
-        )
-    )
+    name: str = Field(description="Name of the test, unique within the workspace")
+    type: TestType = Field(description=_TEST_TYPE_DESCRIPTION)
     config: Optional[Dict[str, Any]] = Field(
         None,
-        description="Calibrate test config (`history`, `evaluation`, optional `settings`). Omit to create the test with no config and set it later via update",
+        description="Config for the test (`history`, `evaluation`, optional `settings`). Omit to create the test with no config and set it later via update",
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,
@@ -83,7 +85,8 @@ class TestUpdate(BaseModel):
     name: Optional[str] = Field(None, description="New test name. Omit to leave unchanged")
     type: Optional[TestType] = Field(
         None,
-        description="Test type. Immutable, may only echo the existing value. A different value is rejected (400). Omit to leave unchanged",
+        description=_TEST_TYPE_DESCRIPTION
+        + "\n\nImmutable. Omit, or send the existing value. A different value is rejected (400).",
     )
     config: Optional[Dict[str, Any]] = Field(
         None, description="Replacement calibrate config. Omit to leave unchanged"
@@ -98,16 +101,16 @@ class TestResponse(BaseModel):
     uuid: str = Field(
         min_length=36,
         max_length=36,
-        description="Test ID",
+        description="Unique ID for the test",
         examples=[_EXAMPLE_TEST_UUID],
     )
-    name: str = Field(description="Test name")
-    type: TestType = Field(description="Test kind")
+    name: str = Field(description="Name of the test")
+    type: TestType = Field(description=_TEST_TYPE_DESCRIPTION)
     config: Optional[Dict[str, Any]] = Field(
-        None, description="Calibrate test config (`history`, `evaluation`, optional `settings`)"
+        None, description="Config for the test (`history`, `evaluation`, optional `settings`)"
     )
-    created_at: str = Field(description="Creation timestamp (ISO 8601 UTC)")
-    updated_at: str = Field(description="Last-update timestamp (ISO 8601 UTC)")
+    created_at: str = Field(description="Timestamp when the test was created (ISO 8601 UTC)")
+    updated_at: str = Field(description="Timestamp when the test was last updated (ISO 8601 UTC)")
     evaluators: List[Dict[str, Any]] = Field(
         default=[],
         description="Linked evaluators, resolved to their current live version at read time",
@@ -166,7 +169,9 @@ class BulkTestItem(BaseModel):
 
 
 class BulkTestUpload(BaseModel):
-    type: TestType = Field(description="Test kind applied to every item in the batch")
+    type: TestType = Field(
+        description=_TEST_TYPE_DESCRIPTION + "\n\nApplied to every test in the batch."
+    )
     tests: List[BulkTestItem] = Field(
         description=f"Test items to create (non-empty, max {500} per request, names unique within the batch)"
     )

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -47,6 +47,57 @@ _TEST_TYPE_DESCRIPTION = (
 # never drift.
 _TEST_NAME_DESCRIPTION = "Name of the test, unique within the workspace"
 
+# Full test-config schema, shared by create + update so it renders identically.
+# Free-form on purpose (see the type-decision note): `evaluation` is a
+# discriminated union by test type and the whole config is a calibrate
+# passthrough, so it's documented, not enforced.
+_TEST_CONFIG_DESCRIPTION = """The calibrate test config. Three top-level keys.
+
+- `history` (array, required): the conversation up to the agent's turn. Each item is `{role, content}` with `role` one of `user`, `assistant`, `tool`. A `tool` message also carries `tool_call_id` and `name`.
+- `evaluation` (object, required): `{type, ...}`, where `type` matches the test's `type` (below).
+- `settings` (object, optional): e.g. `{"language": "en"}`.
+
+`evaluation` by test type:
+- `response`: judge the agent's reply, graded by the linked evaluators. `{"type": "response"}`
+- `conversation`: append the reply and judge the whole conversation. `{"type": "conversation"}`
+- `tool_call`: diff the agent's tool calls against expected ones. Add `tool_calls`, a list of `{tool, arguments, accept_any_arguments?}`.
+
+For `tool_call`, each expected argument value is one of:
+- `{"match_type": "exact", "value": <any>}`: must equal `value`
+- `{"match_type": "llm_judge", "criteria": "..."}`: judged against the criteria
+- `{"match_type": "any"}`: any value, only checks the argument was passed
+
+`response` / `conversation` example:
+```json
+{
+  "history": [{"role": "user", "content": "What is your return policy?"}],
+  "evaluation": {"type": "response"},
+  "settings": {"language": "en"}
+}
+```
+
+`tool_call` example:
+```json
+{
+  "history": [{"role": "user", "content": "Book room 101 for tomorrow"}],
+  "evaluation": {
+    "type": "tool_call",
+    "tool_calls": [
+      {
+        "tool": "book_room",
+        "arguments": {
+          "room": {"match_type": "exact", "value": "101"},
+          "date": {"match_type": "llm_judge", "criteria": "tomorrow's date"}
+        },
+        "accept_any_arguments": false
+      }
+    ]
+  }
+}
+```
+
+Evaluators are linked via the separate `evaluators` field, not inside `config`."""
+
 # Each test type pins the evaluator_type it accepts. `conversation` tests judge whole
 # simulated conversations, so only `conversation` evaluators apply; `response`/`tool_call`
 # tests judge a single LLM reply, so only `llm` evaluators apply.
@@ -78,7 +129,8 @@ class TestCreate(BaseModel):
     type: TestType = Field(description=_TEST_TYPE_DESCRIPTION)
     config: Optional[Dict[str, Any]] = Field(
         None,
-        description="Config for the test (`history`, `evaluation`, optional `settings`). Omit to create the test with no config and set it later via update",
+        description=_TEST_CONFIG_DESCRIPTION
+        + "\n\nOmit to create the test with no config and fill it in later via update.",
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,
@@ -94,7 +146,9 @@ class TestUpdate(BaseModel):
         + "\n\nImmutable. Omit, or send the existing value. A different value is rejected (400).",
     )
     config: Optional[Dict[str, Any]] = Field(
-        None, description="New config for the test. Omit to leave unchanged"
+        None,
+        description=_TEST_CONFIG_DESCRIPTION
+        + "\n\nReplaces the stored config. Omit to leave unchanged.",
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -77,7 +77,7 @@ class TestCreate(BaseModel):
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,
-        description="Evaluators to link. **Required (>=1) for `type=conversation`** (no fallback judge). Omit for `response`/`tool_call` to link none",
+        description="Evaluators to link. Used by `response` and `conversation` tests",
     )
 
 
@@ -93,7 +93,7 @@ class TestUpdate(BaseModel):
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
         None,
-        description="Replacement evaluator links (replaces the existing set). Omit to leave links unchanged. An empty list clears them (**rejected for `conversation` tests**)",
+        description="Replacement evaluator links (replaces the existing set). Omit to leave links unchanged. An empty list clears them",
     )
 
 
@@ -161,7 +161,7 @@ class BulkTestItem(BaseModel):
         description="Ordered messages ending at the user turn the agent should answer (must be non-empty)"
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
-        None, description="Evaluators to link. **Required for `response`/`conversation` batches**"
+        None, description="Evaluators to link. Used by `response` and `conversation` tests"
     )
     tool_calls: Optional[List[ExpectedToolCall]] = Field(
         None, description="Expected tool calls. **Required for `tool_call` batches**"

--- a/src/routers/tests.py
+++ b/src/routers/tests.py
@@ -139,7 +139,9 @@ class TestCreate(BaseModel):
 
 
 class TestUpdate(BaseModel):
-    name: Optional[str] = Field(None, description="New test name. Omit to leave unchanged")
+    name: Optional[str] = Field(
+        None, description="New test name. Omit to leave unchanged"
+    )
     type: Optional[TestType] = Field(
         None,
         description=_TEST_TYPE_DESCRIPTION
@@ -166,10 +168,15 @@ class TestResponse(BaseModel):
     name: str = Field(description="Name of the test")
     type: TestType = Field(description=_TEST_TYPE_DESCRIPTION)
     config: Optional[Dict[str, Any]] = Field(
-        None, description="Config for the test (`history`, `evaluation`, optional `settings`)"
+        None,
+        description="Config for the test (`history`, `evaluation`, optional `settings`)",
     )
-    created_at: str = Field(description="Timestamp when the test was created (ISO 8601 UTC)")
-    updated_at: str = Field(description="Timestamp when the test was last updated (ISO 8601 UTC)")
+    created_at: str = Field(
+        description="Timestamp when the test was created (ISO 8601 UTC)"
+    )
+    updated_at: str = Field(
+        description="Timestamp when the test was last updated (ISO 8601 UTC)"
+    )
     evaluators: List[Dict[str, Any]] = Field(
         default=[],
         description="Linked evaluators, resolved to their current live version at read time",
@@ -188,29 +195,37 @@ class TestCreateResponse(BaseModel):
 
 # --- Bulk upload models ---
 
+
 class ChatMessage(BaseModel):
     role: Literal["user", "assistant", "tool"] = Field(
         description="Message author role in the conversation history"
     )
     content: Optional[str] = Field(
-        None, description="Message text. Omit for assistant messages that only carry `tool_calls`"
+        None,
+        description="Message text. Omit for assistant messages that only carry `tool_calls`",
     )
     tool_calls: Optional[List[Dict[str, Any]]] = Field(
-        None, description="Tool calls issued by the assistant. Omit for plain text turns"
+        None,
+        description="Tool calls issued by the assistant. Omit for plain text turns",
     )
     tool_call_id: Optional[str] = Field(
-        None, description="ID of the tool call this message responds to. **Required for `role=tool`**"
+        None,
+        description="ID of the tool call this message responds to. **Required for `role=tool`**",
     )
-    name: Optional[str] = Field(None, description="Tool name for `role=tool` messages. Omit otherwise")
+    name: Optional[str] = Field(
+        None, description="Tool name for `role=tool` messages. Omit otherwise"
+    )
 
 
 class ExpectedToolCall(BaseModel):
     tool: str = Field(description="Name of the tool the agent is expected to call")
     arguments: Optional[Dict[str, Any]] = Field(
-        None, description="Expected argument values, diffed against the generated call. Omit to expect no arguments"
+        None,
+        description="Expected argument values, diffed against the generated call. Omit to expect no arguments",
     )
     accept_any_arguments: bool = Field(
-        False, description="When `true`, only the tool name must match and `arguments` is ignored"
+        False,
+        description="When `true`, only the tool name must match and `arguments` is ignored",
     )
 
 
@@ -220,7 +235,8 @@ class BulkTestItem(BaseModel):
         description="Ordered messages ending at the user turn the agent should answer (must be non-empty)"
     )
     evaluators: Optional[List[EvaluatorRef]] = Field(
-        None, description="Evaluators to link. Used by `response` and `conversation` tests"
+        None,
+        description="Evaluators to link. Used by `response` and `conversation` tests",
     )
     tool_calls: Optional[List[ExpectedToolCall]] = Field(
         None, description="Expected tool calls. **Required for `tool_call` batches**"
@@ -240,7 +256,8 @@ class BulkTestUpload(BaseModel):
         examples=[[_EXAMPLE_AGENT_UUID]],
     )
     language: Optional[str] = Field(
-        None, description="Language written to each test's `config.settings.language`. Omit to leave unset"
+        None,
+        description="Language written to each test's `config.settings.language`. Omit to leave unset",
     )
 
     MAX_BATCH_SIZE: ClassVar[int] = 500
@@ -251,7 +268,9 @@ class BulkTestUpload(BaseModel):
             raise ValueError("tests list must not be empty")
 
         if len(self.tests) > self.MAX_BATCH_SIZE:
-            raise ValueError(f"Batch size {len(self.tests)} exceeds maximum of {self.MAX_BATCH_SIZE}")
+            raise ValueError(
+                f"Batch size {len(self.tests)} exceeds maximum of {self.MAX_BATCH_SIZE}"
+            )
 
         names = [t.name for t in self.tests]
         if len(names) != len(set(names)):
@@ -261,7 +280,9 @@ class BulkTestUpload(BaseModel):
 
         for t in self.tests:
             if not t.conversation_history:
-                raise ValueError(f"Test '{t.name}' must have at least one message in conversation_history")
+                raise ValueError(
+                    f"Test '{t.name}' must have at least one message in conversation_history"
+                )
             if self.type == "response":
                 if not t.evaluators:
                     raise ValueError(
@@ -269,7 +290,9 @@ class BulkTestUpload(BaseModel):
                     )
             elif self.type == "tool_call":
                 if not t.tool_calls:
-                    raise ValueError(f"Test '{t.name}' must have 'tool_calls' for tool_call type")
+                    raise ValueError(
+                        f"Test '{t.name}' must have 'tool_calls' for tool_call type"
+                    )
             elif self.type == "conversation":
                 if not t.evaluators:
                     raise ValueError(
@@ -287,7 +310,8 @@ class BulkTestUploadResponse(BaseModel):
     count: int = Field(description="Number of tests created")
     message: str = Field(description="Confirmation message")
     warnings: Optional[List[str]] = Field(
-        None, description="Non-fatal issues (e.g. agents some tests couldn't link to). Null when there were none"
+        None,
+        description="Non-fatal issues (e.g. agents some tests couldn't link to). Null when there were none",
     )
 
 
@@ -299,7 +323,9 @@ class BulkTestDelete(BaseModel):
 
 
 class BulkTestDeleteResponse(BaseModel):
-    deleted_count: int = Field(description="Number of tests actually deleted (excludes IDs not in your workspace)")
+    deleted_count: int = Field(
+        description="Number of tests actually deleted (excludes IDs not in your workspace)"
+    )
     message: str = Field(description="Confirmation message")
 
 
@@ -311,16 +337,18 @@ def _validate_evaluators(
     `conversation` ⇒ `simulation`). Returns db-ready refs."""
     required_evaluator_type = REQUIRED_EVALUATOR_TYPE_BY_TEST_TYPE.get(test_type)
     if required_evaluator_type is None:
-        raise HTTPException(
-            status_code=400, detail=f"Unknown test type '{test_type}'"
-        )
+        raise HTTPException(status_code=400, detail=f"Unknown test type '{test_type}'")
     out: List[Dict[str, Any]] = []
     for ref in refs:
         evaluator = get_evaluator(ref.evaluator_uuid)
         if not evaluator:
-            raise HTTPException(status_code=404, detail=f"Evaluator {ref.evaluator_uuid} not found")
+            raise HTTPException(
+                status_code=404, detail=f"Evaluator {ref.evaluator_uuid} not found"
+            )
         if evaluator.get("org_uuid") is not None and evaluator["org_uuid"] != org_uuid:
-            raise HTTPException(status_code=404, detail=f"Evaluator {ref.evaluator_uuid} not found")
+            raise HTTPException(
+                status_code=404, detail=f"Evaluator {ref.evaluator_uuid} not found"
+            )
         if evaluator.get("evaluator_type") != required_evaluator_type:
             raise HTTPException(
                 status_code=400,
@@ -346,7 +374,9 @@ def _with_evaluators(test_dict: Dict[str, Any]) -> Dict[str, Any]:
     return {**test_dict, "evaluators": evaluators}
 
 
-@router.post("/bulk-delete", response_model=BulkTestDeleteResponse, summary="Bulk delete tests")
+@router.post(
+    "/bulk-delete", response_model=BulkTestDeleteResponse, summary="Bulk delete tests"
+)
 async def bulk_delete_tests_endpoint(
     payload: BulkTestDelete, ctx: OrgContext = Depends(get_current_org)
 ):
@@ -354,7 +384,9 @@ async def bulk_delete_tests_endpoint(
     if not payload.test_uuids:
         raise HTTPException(status_code=400, detail="test_uuids must not be empty")
 
-    deleted_count = bulk_delete_tests(test_uuids=payload.test_uuids, org_uuid=ctx.org_uuid)
+    deleted_count = bulk_delete_tests(
+        test_uuids=payload.test_uuids, org_uuid=ctx.org_uuid
+    )
 
     return BulkTestDeleteResponse(
         deleted_count=deleted_count,
@@ -371,12 +403,14 @@ async def bulk_delete_tests_endpoint(
 async def bulk_upload_tests(
     payload: BulkTestUpload, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create many tests of one type in a single call, optionally linking them to agents."""
+    """Create many test cases at once and link them to your agents."""
     if payload.agent_uuids:
         for agent_uuid in payload.agent_uuids:
             agent = get_agent(agent_uuid)
             if not agent or agent.get("org_uuid") != ctx.org_uuid:
-                raise HTTPException(status_code=404, detail=f"Agent {agent_uuid} not found")
+                raise HTTPException(
+                    status_code=404, detail=f"Agent {agent_uuid} not found"
+                )
 
     resolved_evaluator_refs: List[Optional[List[Dict[str, Any]]]] = []
     for t in payload.tests:
@@ -394,17 +428,21 @@ async def bulk_upload_tests(
             evaluation["tool_calls"] = [tc.model_dump() for tc in t.tool_calls]
 
         config: Dict[str, Any] = {
-            "history": [msg.model_dump(exclude_none=True) for msg in t.conversation_history],
+            "history": [
+                msg.model_dump(exclude_none=True) for msg in t.conversation_history
+            ],
             "evaluation": evaluation,
         }
         if payload.language:
             config["settings"] = {"language": payload.language}
 
-        db_tests.append({
-            "name": t.name,
-            "type": payload.type,
-            "config": config,
-        })
+        db_tests.append(
+            {
+                "name": t.name,
+                "type": payload.type,
+                "config": config,
+            }
+        )
 
     try:
         uuids = bulk_create_tests(
@@ -428,7 +466,9 @@ async def bulk_upload_tests(
                     linked_agents.add(agent_uuid)
                 except Exception as e:
                     agent_failed = True
-                    logger.warning(f"Failed to link test {test_uuid} to agent {agent_uuid}: {e}")
+                    logger.warning(
+                        f"Failed to link test {test_uuid} to agent {agent_uuid}: {e}"
+                    )
             if agent_failed:
                 warnings.append(f"Some tests could not be linked to agent {agent_uuid}")
 
@@ -453,7 +493,7 @@ async def bulk_upload_tests(
 async def create_test_endpoint(
     test: TestCreate, ctx: OrgContext = Depends(get_org_jwt_or_api_key)
 ):
-    """Create a test that runs your agent against a conversation and grades its reply, tool calls, or the full conversation."""
+    """Create a test that runs your agent against a conversation and evaluates its answer quality or the tools it calls."""
     # Conversation tests have no evaluator fallback (unlike `response`, which can
     # synthesize the default LLM judge from legacy string criteria) — without a
     # linked simulation evaluator a run produces an empty calibrate config with
@@ -489,7 +529,7 @@ async def create_test_endpoint(
     summary="List tests",
 )
 async def list_tests(ctx: OrgContext = Depends(get_org_jwt_or_api_key)):
-    """List your tests, each with its linked evaluators."""
+    """List all the test cases for your agents."""
     tests = get_all_tests(org_uuid=ctx.org_uuid)
     return [_with_evaluators(t) for t in tests]
 
@@ -507,7 +547,7 @@ async def get_test_endpoint(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Get a test by ID, including its linked evaluators."""
+    """Get an agent test case by its ID."""
     test = get_test(test_uuid)
     if not test or test.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Test not found")
@@ -528,7 +568,7 @@ async def update_test_endpoint(
     ),
     ctx: OrgContext = Depends(get_org_jwt_or_api_key),
 ):
-    """Update a test's config or the evaluators it is graded by."""
+    """Update an agent test case"""
     existing_test = get_test(test_uuid)
     if not existing_test or existing_test.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Test not found")
@@ -566,9 +606,7 @@ async def update_test_endpoint(
         else None
     )
 
-    has_core_updates = any(
-        v is not None for v in (test.name, test.type, test.config)
-    )
+    has_core_updates = any(v is not None for v in (test.name, test.type, test.config))
     if has_core_updates:
         with ensure_name_unique(
             "tests", test.name, ctx.org_uuid, entity="Test", exclude_uuid=test_uuid

--- a/src/routers/tools.py
+++ b/src/routers/tools.py
@@ -61,7 +61,7 @@ class ToolCreateResponse(BaseModel):
 async def create_tool_endpoint(
     tool: ToolCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a new tool in your workspace."""
+    """Create a new tool."""
     with ensure_name_unique("tools", tool.name, ctx.org_uuid, entity="Tool"):
         tool_uuid = create_tool(
             name=tool.name,
@@ -75,7 +75,7 @@ async def create_tool_endpoint(
 
 @router.get("", response_model=List[ToolResponse], summary="List tools")
 async def list_tools(ctx: OrgContext = Depends(get_current_org)):
-    """List all tools in your workspace."""
+    """List all tools."""
     tools = get_all_tools(org_uuid=ctx.org_uuid)
     return tools
 
@@ -88,7 +88,7 @@ async def get_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get a tool in your workspace."""
+    """Get a tool."""
     tool = get_tool(tool_uuid)
     if not tool or tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")
@@ -134,7 +134,7 @@ async def delete_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a tool in your workspace."""
+    """Soft-delete a tool."""
     existing_tool = get_tool(tool_uuid)
     if not existing_tool or existing_tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")

--- a/src/routers/tools.py
+++ b/src/routers/tools.py
@@ -12,7 +12,7 @@ _EXAMPLE_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 
 
 class ToolCreate(BaseModel):
-    name: str = Field(description="Human-readable tool name, unique within the workspace")
+    name: str = Field(description="Tool name, unique within the workspace")
     description: str = Field(description="What the tool does. Surfaced to agents and the UI")
     config: Optional[Dict[str, Any]] = Field(
         None, description="Tool config (e.g. JSON schema, parameters). Omit to leave unset"
@@ -38,7 +38,7 @@ class ToolResponse(BaseModel):
         description="ID of the tool",
         examples=[_EXAMPLE_ID],
     )
-    name: str = Field(description="Human-readable tool name")
+    name: str = Field(description="Tool name")
     description: str = Field(description="What the tool does")
     config: Optional[Dict[str, Any]] = Field(
         None, description="Tool config, or null if unset"
@@ -54,7 +54,7 @@ class ToolCreateResponse(BaseModel):
         description="ID of the newly created tool",
         examples=[_EXAMPLE_ID],
     )
-    message: str = Field(description="Human-readable success message")
+    message: str = Field(description="Success message")
 
 
 @router.post("", response_model=ToolCreateResponse, summary="Create tool")

--- a/src/routers/tools.py
+++ b/src/routers/tools.py
@@ -75,7 +75,7 @@ async def create_tool_endpoint(
 
 @router.get("", response_model=List[ToolResponse], summary="List tools")
 async def list_tools(ctx: OrgContext = Depends(get_current_org)):
-    """List all tools."""
+    """List your tools, each with its config."""
     tools = get_all_tools(org_uuid=ctx.org_uuid)
     return tools
 
@@ -88,7 +88,7 @@ async def get_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get a tool."""
+    """Get one tool by ID, including its config."""
     tool = get_tool(tool_uuid)
     if not tool or tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")
@@ -104,7 +104,7 @@ async def update_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a tool."""
+    """Update a tool, a function your agent can call."""
     existing_tool = get_tool(tool_uuid)
     if not existing_tool or existing_tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")

--- a/src/routers/tools.py
+++ b/src/routers/tools.py
@@ -61,7 +61,7 @@ class ToolCreateResponse(BaseModel):
 async def create_tool_endpoint(
     tool: ToolCreate, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Create a new tool."""
+    """Create a new tool"""
     with ensure_name_unique("tools", tool.name, ctx.org_uuid, entity="Tool"):
         tool_uuid = create_tool(
             name=tool.name,
@@ -75,7 +75,7 @@ async def create_tool_endpoint(
 
 @router.get("", response_model=List[ToolResponse], summary="List tools")
 async def list_tools(ctx: OrgContext = Depends(get_current_org)):
-    """List your tools, each with its config."""
+    """List your tools"""
     tools = get_all_tools(org_uuid=ctx.org_uuid)
     return tools
 
@@ -88,7 +88,7 @@ async def get_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get one tool by ID, including its config."""
+    """Get one tool by ID"""
     tool = get_tool(tool_uuid)
     if not tool or tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")
@@ -104,7 +104,7 @@ async def update_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a tool, a function your agent can call."""
+    """Update a tool, a function your agent can call"""
     existing_tool = get_tool(tool_uuid)
     if not existing_tool or existing_tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")
@@ -134,7 +134,7 @@ async def delete_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Soft-delete a tool."""
+    """Soft-delete a tool"""
     existing_tool = get_tool(tool_uuid)
     if not existing_tool or existing_tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")

--- a/src/routers/tools.py
+++ b/src/routers/tools.py
@@ -13,7 +13,7 @@ _EXAMPLE_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 
 class ToolCreate(BaseModel):
     name: str = Field(description="Human-readable tool name, unique within the workspace")
-    description: str = Field(description="What the tool does; surfaced to agents and the UI")
+    description: str = Field(description="What the tool does. Surfaced to agents and the UI")
     config: Optional[Dict[str, Any]] = Field(
         None, description="Tool config (e.g. JSON schema, parameters). Omit to leave unset"
     )
@@ -104,7 +104,7 @@ async def update_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a tool's fields. Only the provided fields change; omitted fields are left as-is."""
+    """Update a tool's fields. Only the provided fields change. Omitted fields are left as-is."""
     existing_tool = get_tool(tool_uuid)
     if not existing_tool or existing_tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")

--- a/src/routers/tools.py
+++ b/src/routers/tools.py
@@ -104,7 +104,7 @@ async def update_tool_endpoint(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update a tool's fields. Only the provided fields change. Omitted fields are left as-is."""
+    """Update a tool."""
     existing_tool = get_tool(tool_uuid)
     if not existing_tool or existing_tool.get("org_uuid") != ctx.org_uuid:
         raise HTTPException(status_code=404, detail="Tool not found")

--- a/src/routers/tools.py
+++ b/src/routers/tools.py
@@ -83,7 +83,7 @@ async def list_tools(ctx: OrgContext = Depends(get_current_org)):
 @router.get("/{tool_uuid}", response_model=ToolResponse, summary="Get tool")
 async def get_tool_endpoint(
     tool_uuid: str = Path(
-        description="The tool to retrieve. Must be in your workspace.",
+        description="The tool to retrieve.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -99,7 +99,7 @@ async def get_tool_endpoint(
 async def update_tool_endpoint(
     tool: ToolUpdate,
     tool_uuid: str = Path(
-        description="The tool to update. Must be in your workspace.",
+        description="The tool to update.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -129,7 +129,7 @@ async def update_tool_endpoint(
 @router.delete("/{tool_uuid}", summary="Delete tool")
 async def delete_tool_endpoint(
     tool_uuid: str = Path(
-        description="The tool to delete. Must be in your workspace.",
+        description="The tool to delete.",
         examples=[_EXAMPLE_ID],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/tts.py
+++ b/src/routers/tts.py
@@ -181,7 +181,7 @@ class TTSEvaluationRequest(BaseModel):
         None,
         min_length=36,
         max_length=36,
-        description="Existing TTS dataset to evaluate. Must be in your workspace. **Provide this OR inline `texts`, not both**",
+        description="Existing TTS dataset to evaluate. **Provide this OR inline `texts`, not both**",
         examples=[_EXAMPLE_ID],
     )
     texts: Optional[List[str]] = Field(
@@ -782,7 +782,7 @@ class VisibilityResponse(BaseModel):
 async def update_tts_visibility(
     body: VisibilityRequest,
     task_id: str = PathParam(
-        description="The TTS evaluation to update. Must be in your workspace.",
+        description="The TTS evaluation to update.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),
@@ -808,7 +808,7 @@ async def update_tts_visibility(
 )
 async def get_tts_evaluation_status(
     task_id: str = PathParam(
-        description="The TTS evaluation to poll. Must be in your workspace.",
+        description="The TTS evaluation to poll.",
         examples=["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
     ),
     ctx: OrgContext = Depends(get_current_org),

--- a/src/routers/tts.py
+++ b/src/routers/tts.py
@@ -684,7 +684,7 @@ def run_tts_evaluation_task(
 async def evaluate_tts(
     request: TTSEvaluationRequest, ctx: OrgContext = Depends(get_current_org)
 ):
-    """Benchmark TTS providers against text inputs as a background job."""
+    """Benchmark TTS providers against text inputs as a background job"""
     if not request.providers:
         raise HTTPException(
             status_code=400,
@@ -787,7 +787,7 @@ async def update_tts_visibility(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Update public sharing for a TTS evaluation."""
+    """Update public sharing for a TTS evaluation"""
     job = get_job(task_id, org_uuid=ctx.org_uuid)
     if not job or job.get("type") != "tts-eval":
         raise HTTPException(status_code=404, detail="Task not found")
@@ -813,7 +813,7 @@ async def get_tts_evaluation_status(
     ),
     ctx: OrgContext = Depends(get_current_org),
 ):
-    """Get the status and results of a TTS evaluation."""
+    """Get the status and results of a TTS evaluation"""
     job = get_job(task_id, org_uuid=ctx.org_uuid)
     if not job:
         raise HTTPException(status_code=404, detail="Task not found")

--- a/src/routers/tts.py
+++ b/src/routers/tts.py
@@ -190,7 +190,7 @@ class TTSEvaluationRequest(BaseModel):
     )
     dataset_name: Optional[str] = Field(
         None,
-        description="Name for a new dataset saved from inline inputs. Ignored when `dataset_id` is set; omit to skip saving",
+        description="Name for a new dataset saved from inline inputs. Ignored when `dataset_id` is set. Omit to skip saving",
     )
     providers: List[str] = Field(
         description='TTS providers to compare, e.g. `["smallest", "cartesia", "openai"]`. At least one required'
@@ -198,7 +198,7 @@ class TTSEvaluationRequest(BaseModel):
     language: str = Field(description='Language to synthesize in, e.g. `"english"` or `"hindi"`')
     evaluator_uuids: Optional[List[str]] = Field(
         None,
-        description="Evaluators to score synthesized audio; each must be a `tts` evaluator in your workspace. Omit to use the default TTS evaluator",
+        description="Evaluators to score synthesized audio. Each must be a `tts` evaluator in your workspace. Omit to use the default TTS evaluator",
     )
 
 
@@ -762,7 +762,7 @@ async def evaluate_tts(
 
 class VisibilityRequest(BaseModel):
     is_public: bool = Field(
-        description="`true` to make the job publicly shareable; `false` to make it private"
+        description="`true` to make the job publicly shareable. `false` to make it private"
     )
 
 
@@ -770,7 +770,7 @@ class VisibilityResponse(BaseModel):
     is_public: bool = Field(description="Whether the job is now publicly shareable")
     share_token: str | None = Field(
         None,
-        description="Opaque token for the public share URL when `is_public` is true; null when private",
+        description="Opaque token for the public share URL when `is_public` is true. Null when private",
     )
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -193,7 +193,7 @@ class EvaluatorRunEntry(BaseModel):
         description="Pinned evaluator version ID at job-submit time",
     )
     output_type: Optional[OutputTypeLiteral] = Field(
-        None, description="Output type; drives per-row typing"
+        None, description="Output type. Drives per-row typing"
     )
 
 
@@ -509,7 +509,7 @@ def upload_top_level_files_to_s3(
 ) -> None:
     """Upload only regular files directly under ``local_dir`` (e.g. run-level ``logs``, ``leaderboard.csv``).
 
-    Subdirectories are ignored; use :func:`upload_directory_tree_to_s3` for a full tree.
+    Subdirectories are ignored. Use :func:`upload_directory_tree_to_s3` for a full tree.
     """
     if not local_dir or not local_dir.is_dir():
         return
@@ -1158,7 +1158,7 @@ _NUMERIC_ROW_KEYS = frozenset(
 
 
 def _coerce_numeric(value: Any) -> Any:
-    """Return float(value) when the string parses as numeric; otherwise unchanged."""
+    """Return float(value) when the string parses as numeric. Otherwise unchanged."""
     if value is None or isinstance(value, (int, float, bool)):
         return value
     if isinstance(value, str):
@@ -1259,7 +1259,7 @@ def post_process_provider_results(
        the only string we *know* identifies an evaluator output column.
        Falls back to the snapshot's display name when the map is missing
        (in-progress jobs whose config.json hasn't landed, or pre-migration
-       legacy data); the fallback path is vulnerable to collisions with
+       legacy data). The fallback path is vulnerable to collisions with
        built-in row columns (``id``, ``gt``, ``pred``, ``wer``, ...) and
        with duplicate evaluator names, so it's a back-compat path only.
     4. Values are typed: binary → ``bool``, rating → numeric. Known numeric
@@ -1445,7 +1445,7 @@ def compute_share_token_toggle(
       the FE never displays a share URL while the link is dead.
 
     ``token_factory`` defaults to ``str(uuid.uuid4())`` for parity with
-    the historical STT/TTS/annotation-eval shapes; pass
+    the historical STT/TTS/annotation-eval shapes. Pass
     ``secrets.token_urlsafe(24)`` for the labelling-job ``view_token``.
     """
     if token_factory is None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -160,6 +160,14 @@ EvalJobType = Literal["stt-eval", "tts-eval", "annotation-eval"]
 AnnotationTaskTypeLiteral = Literal["stt", "tts", "llm", "llm-general", "conversation"]
 TestTypeLiteral = Literal["response", "tool_call", "conversation"]
 MemberRoleLiteral = Literal["owner", "admin"]  # mirrors DB CHECK(role IN ('owner','admin'))
+
+# Bulleted gloss of the agent `type` enum, shared across every model that
+# exposes it (agents, agent-tools, agent-tests, simulations) so the two values
+# read identically everywhere.
+AGENT_TYPE_DESCRIPTION = (
+    "- `agent`: built inside Calibrate\n"
+    "- `connection`: your existing agent connected to Calibrate"
+)
 # Status a job can carry at *creation* time: it either starts immediately
 # (`in_progress`) or waits for a concurrency slot (`queued`). Narrower than
 # TaskStatus so create-response docs advertise only the reachable values.

--- a/tests/test_api_docs_style.py
+++ b/tests/test_api_docs_style.py
@@ -135,6 +135,27 @@ def test_checker_flags_unit_suffix_repeat(tmp_path):
     assert "ok_ms" not in joined
 
 
+def test_checker_resolves_composed_descriptions(tmp_path):
+    """A description built from a module-level constant (`_SHARED + "..."`) is
+    still scanned — bans must reach it, not just plain string literals."""
+    (tmp_path / "composed.py").write_text(
+        "from fastapi import APIRouter\n"
+        "from pydantic import BaseModel, Field\n"
+        "router = APIRouter()\n"
+        "_SHARED = 'Base shape.'\n"
+        "class Thing(BaseModel):\n"
+        "    a: str = Field(description=_SHARED + ' Uses deep-merge on update')\n"
+        "    b: str = Field(description=_SHARED + ' clause; another clause')\n"
+        "@router.get('/things', summary='List things')\n"
+        "async def list_things():\n"
+        "    '''List things.'''\n"
+        "    return []\n"
+    )
+    joined = "\n".join(checker.find_violations(tmp_path))
+    assert "deep-merge" in joined  # jargon ban reached the composed description
+    assert "clause-splitting semicolons" in joined  # mechanics ban reached it too
+
+
 def test_checker_accepts_a_good_module(tmp_path):
     (tmp_path / "good.py").write_text(
         "from fastapi import APIRouter, Path\n"

--- a/tests/test_api_docs_style.py
+++ b/tests/test_api_docs_style.py
@@ -72,7 +72,7 @@ def test_checker_allows_code_identifiers_in_doc_text(tmp_path):
         "router = APIRouter()\n"
         "@router.get('/x', summary='Get x')\n"
         "async def get_x():\n"
-        "    '''Resolved via `get_current_org` (the `X-Org-UUID` header); see `/org-limits`.'''\n"
+        "    '''Resolved via `get_current_org` (the `X-Org-UUID` header). See `/org-limits`.'''\n"
         "    return {}\n"
     )
     assert checker.find_violations(tmp_path) == []
@@ -94,6 +94,45 @@ def test_checker_flags_uuid_and_caller_in_doc_text(tmp_path):
     joined = "\n".join(checker.find_violations(tmp_path))
     assert "not 'UUID'" in joined
     assert "your workspace" in joined
+
+
+def test_checker_flags_em_dash_and_semicolon(tmp_path):
+    """Rendered doc text must not contain em-dashes or clause-splitting semicolons."""
+    (tmp_path / "mech.py").write_text(
+        "from fastapi import APIRouter\n"
+        "from pydantic import BaseModel, Field\n"
+        "router = APIRouter()\n"
+        "class Thing(BaseModel):\n"
+        "    a: str = Field(description='A value — explained')\n"
+        "    b: str = Field(description='A value; explained further')\n"
+        "@router.get('/things', summary='List things')\n"
+        "async def list_things():\n"
+        "    '''List things.'''\n"
+        "    return []\n"
+    )
+    joined = "\n".join(checker.find_violations(tmp_path))
+    assert "no em-dashes" in joined
+    assert "no clause-splitting semicolons" in joined
+
+
+def test_checker_flags_unit_suffix_repeat(tmp_path):
+    """A `*_ms` field must not repeat the bare 'ms' abbreviation in its description."""
+    (tmp_path / "unit.py").write_text(
+        "from fastapi import APIRouter\n"
+        "from pydantic import BaseModel, Field\n"
+        "router = APIRouter()\n"
+        "class Thing(BaseModel):\n"
+        "    latency_ms: float = Field(description='Response latency in ms')\n"
+        "    ok_ms: float = Field(description='Response latency in milliseconds')\n"
+        "@router.get('/things', summary='List things')\n"
+        "async def list_things():\n"
+        "    '''List things.'''\n"
+        "    return []\n"
+    )
+    joined = "\n".join(checker.find_violations(tmp_path))
+    assert "latency_ms" in joined and "milliseconds" in joined
+    # The spelled-out unit is fine — no violation for ok_ms.
+    assert "ok_ms" not in joined
 
 
 def test_checker_accepts_a_good_module(tmp_path):

--- a/tests/test_main_and_routers.py
+++ b/tests/test_main_and_routers.py
@@ -153,6 +153,15 @@ def test_public_api_docs_are_unauthenticated_and_filtered(client, monkeypatch):
     # public override must not have leaked back into the shared cached schema.
     assert "HTTPBearer" in full["components"]["securitySchemes"]
 
+    # JWT-only request fields (verification flags API-key writes have stripped)
+    # are hidden from the public AgentUpdate schema, but stay on the internal one.
+    pub_agent_update = pub_top["components"]["schemas"]["AgentUpdate"]["properties"]
+    assert "connection_verified" not in pub_agent_update
+    assert "benchmark_models_verified" not in pub_agent_update
+    assert {"name", "config"} <= set(pub_agent_update)
+    full_agent_update = full["components"]["schemas"]["AgentUpdate"]["properties"]
+    assert "connection_verified" in full_agent_update  # still there internally
+
     # Components are trimmed to ONLY the schemas the public paths reference
     # (transitively) — internal/JWT-only model shapes must not leak.
     import json

--- a/tests/test_main_and_routers.py
+++ b/tests/test_main_and_routers.py
@@ -178,6 +178,29 @@ def test_public_api_docs_are_unauthenticated_and_filtered(client, monkeypatch):
     }
     assert refs.issubset(set(pub_schemas))
 
+    # Free-form `Dict[str, Any]` fields (e.g. agent `config`) must NOT carry
+    # Pydantic's auto-title, which Mintlify would render as a fake `Config` type
+    # chip. The property drops its title but keeps its type + description...
+    config_prop = pub_schemas["AgentUpdate"]["properties"]["config"]
+    assert "title" not in config_prop
+    assert config_prop["description"]  # description survives
+    assert {b.get("type") for b in config_prop["anyOf"]} == {"object", "null"}
+    # ...while real model titles (used as the expandable reference name) stay.
+    assert pub_schemas["AgentUpdate"]["title"] == "AgentUpdate"
+    # No surviving title anywhere sits on a free-form object schema.
+    for schema in pub_schemas.values():
+        for prop in schema.get("properties", {}).values():
+            branches = prop.get("anyOf", [])
+            freeform = prop if not branches else next(
+                (b for b in branches if b.get("type") == "object"), None
+            )
+            if (
+                freeform
+                and freeform.get("additionalProperties")
+                and not freeform.get("properties")
+            ):
+                assert "title" not in prop, f"stale title on free-form field: {prop}"
+
 
 # ---------------------------------------------------------------------------
 # Presigned URL endpoint

--- a/tests/test_main_and_routers.py
+++ b/tests/test_main_and_routers.py
@@ -187,19 +187,35 @@ def test_public_api_docs_are_unauthenticated_and_filtered(client, monkeypatch):
     assert {b.get("type") for b in config_prop["anyOf"]} == {"object", "null"}
     # ...while real model titles (used as the expandable reference name) stay.
     assert pub_schemas["AgentUpdate"]["title"] == "AgentUpdate"
-    # No surviving title anywhere sits on a free-form object schema.
-    for schema in pub_schemas.values():
-        for prop in schema.get("properties", {}).values():
-            branches = prop.get("anyOf", [])
-            freeform = prop if not branches else next(
-                (b for b in branches if b.get("type") == "object"), None
-            )
-            if (
-                freeform
-                and freeform.get("additionalProperties")
-                and not freeform.get("properties")
-            ):
-                assert "title" not in prop, f"stale title on free-form field: {prop}"
+    # No surviving title anywhere sits on a free-form field — neither a
+    # `Dict[str, Any]` (object) NOR a `List[Dict[str, Any]]` (array of objects,
+    # e.g. `tool_calls`). Both render as a shapeless chip; a lingering auto-title
+    # ("Tool Calls · object[]") reads as a fake type. This guards the whole spec
+    # so no new free-form field regresses.
+    def _is_ff_obj(n):
+        return (
+            isinstance(n, dict)
+            and n.get("type") == "object"
+            and n.get("additionalProperties")
+            and not n.get("properties")
+        )
+
+    def _is_freeform(n):
+        return _is_ff_obj(n) or (
+            isinstance(n, dict)
+            and n.get("type") == "array"
+            and _is_ff_obj(n.get("items", {}))
+        )
+
+    for sname, schema in pub_schemas.items():
+        for fname, prop in schema.get("properties", {}).items():
+            branches = [
+                b for b in prop.get("anyOf", []) if b.get("type") != "null"
+            ] or [prop]
+            if any(_is_freeform(b) for b in branches):
+                assert "title" not in prop, (
+                    f"stale auto-title on free-form field {sname}.{fname}: {prop}"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routers_agent_tests.py
+++ b/tests/test_routers_agent_tests.py
@@ -369,6 +369,9 @@ def test_run_agent_test_queued_path(client, monkeypatch):
     assert client.get(f"/agent-tests/run/{task_id}").status_code == 403
     got = client.get(f"/agent-tests/run/{task_id}", headers=h)
     assert got.status_code == 200
+    # results_s3_prefix is an internal storage key — never exposed in the API
+    # response (the frontend doesn't read it either).
+    assert "results_s3_prefix" not in got.json()
 
     # Another org's user cannot poll this run → 404
     other_poll = _signup(client)

--- a/tests/test_routers_tests.py
+++ b/tests/test_routers_tests.py
@@ -126,6 +126,30 @@ def test_bulk_create_tests_with_api_key(client):
     assert r.json()["count"] == 2
 
 
+def test_bulk_create_rejects_system_role(client):
+    """`system` is not a valid conversation_history role — the agent's system
+    prompt lives in its config, not the history. Only user/assistant/tool."""
+    jwt = _signup(client)
+    r = client.post(
+        "/tests/bulk",
+        json={
+            "type": "response",
+            "tests": [
+                {
+                    "name": f"bulk-{uuid.uuid4().hex[:6]}",
+                    "conversation_history": [
+                        {"role": "system", "content": "you are helpful"},
+                        {"role": "user", "content": "hi"},
+                    ],
+                    "evaluators": [],
+                }
+            ],
+        },
+        headers=jwt,
+    )
+    assert r.status_code == 422, r.text
+
+
 def test_create_test_invalid_api_key(client):
     """POST /tests with a bogus key must 401."""
     r = client.post(

--- a/tests/test_routers_tests.py
+++ b/tests/test_routers_tests.py
@@ -155,14 +155,28 @@ def test_update_conversation_test_rejects_clearing_evaluators(client):
     `evaluators` list is 400, so the description's 'clears them' promise
     correctly excludes conversation tests."""
     jwt = _signup(client)
-    evaluators = client.get("/evaluators", headers=jwt).json()
-    conv_ev = next(e for e in evaluators if e.get("evaluator_type") == "conversation")
+    # Create a conversation evaluator (its first version is set live on create),
+    # so the link doesn't depend on seeded-evaluator ordering/state.
+    ev = client.post(
+        "/evaluators",
+        json={
+            "name": f"conv-ev-{uuid.uuid4().hex[:6]}",
+            "evaluator_type": "conversation",
+            "version": {
+                "judge_model": "openai/gpt-4o-mini",
+                "system_prompt": "Judge the conversation.",
+            },
+        },
+        headers=jwt,
+    )
+    assert ev.status_code == 200, ev.text
+    conv_ev_uuid = ev.json()["uuid"]
     created = client.post(
         "/tests",
         json={
             "name": f"conv-{uuid.uuid4().hex[:6]}",
             "type": "conversation",
-            "evaluators": [{"evaluator_uuid": conv_ev["uuid"]}],
+            "evaluators": [{"evaluator_uuid": conv_ev_uuid}],
         },
         headers=jwt,
     )

--- a/tests/test_routers_tests.py
+++ b/tests/test_routers_tests.py
@@ -150,6 +150,30 @@ def test_bulk_create_rejects_system_role(client):
     assert r.status_code == 422, r.text
 
 
+def test_update_conversation_test_rejects_clearing_evaluators(client):
+    """A conversation test must keep >=1 evaluator: PUT with an empty
+    `evaluators` list is 400, so the description's 'clears them' promise
+    correctly excludes conversation tests."""
+    jwt = _signup(client)
+    evaluators = client.get("/evaluators", headers=jwt).json()
+    conv_ev = next(e for e in evaluators if e.get("evaluator_type") == "conversation")
+    created = client.post(
+        "/tests",
+        json={
+            "name": f"conv-{uuid.uuid4().hex[:6]}",
+            "type": "conversation",
+            "evaluators": [{"evaluator_uuid": conv_ev["uuid"]}],
+        },
+        headers=jwt,
+    )
+    assert created.status_code == 200, created.text
+    t_uuid = created.json()["uuid"]
+
+    cleared = client.put(f"/tests/{t_uuid}", json={"evaluators": []}, headers=jwt)
+    assert cleared.status_code == 400, cleared.text
+    assert "at least one evaluator" in cleared.text
+
+
 def test_create_test_invalid_api_key(client):
     """POST /tests with a bogus key must 401."""
     r = client.post(


### PR DESCRIPTION
## What
- Rewrite endpoint descriptions, field docs, and enum glosses across all routers to be plain, consistent, and free of filler/jargon (workspace-scope, deep-merge, "Human-readable", em-dashes, semicolons, null caveats the type chip implies, bare-restatement docstrings).
- Add rich, example-driven `config` schemas to agent + test create/update so a client can construct a valid config from the docs; keep the fields free-form `Dict` by design.
- Model the run-result `evaluators` block as `TestRunEvaluator` and strip auto-titles from free-form `Dict`/`List[Dict]` fields so the public spec renders real shapes instead of fake `Config`/`Tool Calls` type chips.

## Notes
- Behavior changes (not docs-only): `ChatMessage.role` no longer accepts `system` (422); `results_s3_prefix` removed from the public run-status response (verified the frontend never reads it); `RunEvaluator` renamed to `TestRunEvaluator`.
- The api-docs-style checker now bans em-dashes/semicolons/unit-echo/deep-merge/"Human-readable" and resolves descriptions composed from module-level constants; a spec test guards against fake auto-titles. The `api-writing-style` skill was expanded with every rule surfaced here.
- SDK/CLI naming overlays unchanged (no public routes added/removed/renamed).