### PR TITLE
Scope public-spec field hiding to evaluator schemas only

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -246,17 +246,27 @@ _PUBLIC_SPEC_HIDDEN_FIELDS: Dict[str, tuple] = {
     "AgentToolsCreateResponse": ("ids",),
 }
 
-# Distinctive internal field names stripped from EVERY public component schema
-# (no public response should expose them, and the concrete schema name is
-# sometimes module-namespaced, e.g. `routers__evaluators__EvaluatorResponse`, so
-# matching by field name is more robust than by schema name). `owner_user_id` is
-# a raw tenant user ID; `live_version_index` is a UI-only array position (the
-# live version is already identified by the `live_version_id` UUID).
-_PUBLIC_SPEC_HIDDEN_FIELD_NAMES: frozenset = frozenset(
-    # `kind` (single vs side_by_side) is a niche scoring mode not exposed on the
-    # public evaluator surface.
+# Distinctive internal field names stripped from every *evaluator* public
+# component schema. These names only appear on evaluator-shaped models today, but
+# matching them globally by name would silently drop any unrelated future field
+# that happened to reuse one (e.g. a `kind` on some other resource). So the strip
+# is scoped to evaluator schemas via `_is_evaluator_schema` — the concrete schema
+# name is sometimes module-namespaced (e.g. `routers__evaluators__EvaluatorResponse`),
+# which is why we match by schema name rather than pinning an exact list.
+# `owner_user_id` is a raw tenant user ID; `live_version_index` is a UI-only array
+# position (the live version is already identified by the `live_version_id` UUID);
+# `kind` (single vs side_by_side) is a niche scoring mode not on the public surface.
+_PUBLIC_SPEC_EVALUATOR_HIDDEN_FIELD_NAMES: frozenset = frozenset(
     {"owner_user_id", "live_version_index", "kind"}
 )
+
+
+def _is_evaluator_schema(name: str) -> bool:
+    """True for evaluator-shaped component schemas, incl. module-namespaced ones
+    (`routers__evaluators__EvaluatorResponse`) and the evaluator default-prompt
+    response (`DefaultPromptResponse`)."""
+    lowered = name.lower()
+    return "evaluator" in lowered or lowered == "defaultpromptresponse"
 
 
 def _drop_fields(schema: Dict[str, Any], fields) -> None:
@@ -275,10 +285,10 @@ def _strip_hidden_public_fields(schemas: Dict[str, Any]) -> None:
         schema = schemas.get(model)
         if schema:
             _drop_fields(schema, fields)
-    if _PUBLIC_SPEC_HIDDEN_FIELD_NAMES:
-        for schema in schemas.values():
-            if isinstance(schema, dict):
-                _drop_fields(schema, _PUBLIC_SPEC_HIDDEN_FIELD_NAMES)
+    if _PUBLIC_SPEC_EVALUATOR_HIDDEN_FIELD_NAMES:
+        for name, schema in schemas.items():
+            if isinstance(schema, dict) and _is_evaluator_schema(name):
+                _drop_fields(schema, _PUBLIC_SPEC_EVALUATOR_HIDDEN_FIELD_NAMES)
 
 
 def _build_public_openapi() -> Dict[str, Any]:

--- a/tests/test_main_and_routers.py
+++ b/tests/test_main_and_routers.py
@@ -241,6 +241,27 @@ def test_public_api_docs_are_unauthenticated_and_filtered(client, monkeypatch):
     # still present internally (the frontend uses owner_user_id for default-vs-custom)
     assert "owner_user_id" in _json.dumps(full["components"]["schemas"])
 
+    # The by-name strip is scoped to evaluator schemas only — a non-evaluator
+    # schema that happened to carry one of these field names would keep it.
+    import main as _main
+
+    strip = _main._PUBLIC_SPEC_EVALUATOR_HIDDEN_FIELD_NAMES
+    schemas = {
+        "routers__evaluators__EvaluatorResponse": {"properties": dict.fromkeys(strip)},
+        "DefaultPromptResponse": {"properties": {"kind": {}}},
+        "SomeOtherThing": {
+            "properties": {"kind": {}, "keep": {}},
+            "required": ["kind"],
+        },
+    }
+    _main._strip_hidden_public_fields(schemas)
+    # evaluator schemas lose the internal names...
+    assert schemas["routers__evaluators__EvaluatorResponse"]["properties"] == {}
+    assert "kind" not in schemas["DefaultPromptResponse"]["properties"]
+    # ...but an unrelated schema's identically-named field survives.
+    assert "kind" in schemas["SomeOtherThing"]["properties"]
+    assert schemas["SomeOtherThing"]["required"] == ["kind"]
+
     # Components are trimmed to ONLY the schemas the public paths reference
     # (transitively) — internal/JWT-only model shapes must not leak.
     import json


### PR DESCRIPTION
## What
- `_strip_hidden_public_fields` dropped `owner_user_id`, `live_version_index`, and `kind` from *every* public component schema by name; scope the strip to evaluator schemas via `_is_evaluator_schema` so an unrelated future field reusing one of those names can't silently vanish from the public docs/SDKs.
- Add a test pinning that an evaluator schema loses the names while a non-evaluator schema keeps an identically-named field.

## Notes
- No public-surface change today — those names only appear on evaluator models. Full suite green (554 passed).