### PR TITLE
Fix MCP gen config: display_name key in mcpbManifestOverlay

### DIFF
--- a/.speakeasy/out/mcp/.speakeasy/gen.yaml
+++ b/.speakeasy/out/mcp/.speakeasy/gen.yaml
@@ -53,9 +53,7 @@ mcp-typescript:
   responseFormat: flat
   validateResponse: false
   mcpbManifestOverlay:
-    # mcpb manifest key is snake_case display_name; the camelCase displayName
-    # is rejected by @anthropic-ai/mcpb >=1.2.0 ("Unrecognized key displayName"),
-    # which fails the .mcpb pack. This overlay merges verbatim into manifest.json.
+    # snake_case: camelCase displayName fails the mcpb>=1.2.0 pack.
     display_name: Calibrate
     description: >-
       Run and monitor Calibrate agent tests from AI assistants. List agents,

--- a/.speakeasy/out/mcp/.speakeasy/gen.yaml
+++ b/.speakeasy/out/mcp/.speakeasy/gen.yaml
@@ -53,7 +53,10 @@ mcp-typescript:
   responseFormat: flat
   validateResponse: false
   mcpbManifestOverlay:
-    displayName: Calibrate
+    # mcpb manifest key is snake_case display_name; the camelCase displayName
+    # is rejected by @anthropic-ai/mcpb >=1.2.0 ("Unrecognized key displayName"),
+    # which fails the .mcpb pack. This overlay merges verbatim into manifest.json.
+    display_name: Calibrate
     description: >-
       Run and monitor Calibrate agent tests from AI assistants. List agents,
       resolve names to UUIDs, launch test runs, and poll results via the


### PR DESCRIPTION
## What
`.speakeasy/out/mcp/.speakeasy/gen.yaml`: rename the `mcpbManifestOverlay` key from camelCase `displayName` to snake_case `display_name`.

This overlay merges verbatim into the generated MCP's `manifest.json`. The camelCase key is invalid, so `@anthropic-ai/mcpb` ≥1.2.0 rejected the `.mcpb` pack during publish. `display_name` is the valid key (and sets the Claude Desktop name to "Calibrate").

## Notes
- Verified locally against the real manifest + mcpb 1.2.0: `displayName` fails validation, `display_name` passes and packs.