### PR TITLE
Reject non-semver client versions in publish-sdk workflow

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -74,6 +74,10 @@ jobs:
             echo "::error::No version resolved (workflow_call and workflow_dispatch require a version)." >&2
             exit 1
           fi
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version '$VERSION'. Must be numeric MAJOR.MINOR.PATCH (e.g. 0.1.0) with no leading 'v' or other letters." >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing calibrate-sdk (Fern) + Calibrate CLI + MCP (Speakeasy) version $VERSION"
 


### PR DESCRIPTION
## What
- Validate the resolved client version in `publish-sdk.yml` against `MAJOR.MINOR.PATCH` and fail the `prepare` job when it doesn't match.
- Rejects a leading `v`, letters, pre-release suffixes, or wrong part counts before any client publishes (Fern / Speakeasy / tag steps).

## Notes
- Applies to both `workflow_dispatch` (manual) and `workflow_call` inputs.